### PR TITLE
Add answer-ack-prompt: hosted-parity acknowledgment tone contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ When the user replies to a daily question (via any channel):
    - Pipe the answer through `python3 system/lifehug.py process-answer {question_id}`
    - Let `process-answer` compile the private wiki automatically unless there is a clear repair reason to pass `--no-compile-wiki`
    - Commit and push if requested or part of the configured daily workflow
-3. **Acknowledge warmly** — Thank them, share a brief reflection on their answer, mention what's coming next
+3. **Acknowledge warmly** — Thank them, share a brief reflection on their answer, mention what's coming next. `python3 system/lifehug.py answer-ack-prompt` builds the canonical prompt for this (stdin: question/answer JSON) — the same tone contract the hosted platform uses, so behavior stays consistent whichever surface answered.
 
 ## Unprompted Story Ingest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,15 @@ A code change is not done until its paper trail ships **in the same pass**:
    and `skills/*/SKILL.md`.
 2. **GitHub issues** — comment progress on the covering issue with verification
    results; close it when delivered. If work surfaced a new gap, file it.
-3. **Tests + changelog** — tests for new behavior; `system/version.json`
-   changelog entry on release.
+3. **Tests + version bump** — tests for new behavior, and **every PR bumps
+   `system/version.json`** (owner rule, 2026-08-04): increment `version`,
+   set `released`, write the changelog entry sized to user impact — a
+   feature that changes behavior for the user gets a full changelog
+   paragraph naming what they'll notice; a small fix gets a one-liner.
+   Any new file the upgrade path should distribute goes into
+   `framework_files` in the same bump (that manifest is what
+   `system/update.py` ships to existing installs — a file missing from it
+   never reaches upgraders). No PR ships without a bump.
 
 "Done" = code + tests + docs + issue state — never code alone. The owner should
 never have to ask whether the docs match the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,14 @@ You are an interviewer, editor, and writing partner. You:
 
 Lifehug is script-first. Use `python3 system/lifehug.py ...` and the underlying `system/` scripts as the canonical behavior. Do not reimplement answer saving, question picking, daily delivery, or wiki compilation manually unless you are repairing a failed script run with a clear reason.
 
+**Changing the framework itself?** `AGENTS.md` is the canonical home for
+contribution rules — the Definition of Done and the every-PR version-bump
+requirement live there, not here. Read it before any framework change,
+whatever model or tool you are. (This file teaches you to *operate* the
+system; AGENTS.md governs *changing* it. The two files reference each
+other so every model sees the same rules regardless of which one its
+harness auto-loads.)
+
 The central product concept is **the Loop**: the continuous-learning path where source capture, wiki compile, source integrity, classification, quality scoring, candidate promotion, planning, daily questioning, and artifact feedback compound over time. When auditing or designing, say whether a feature is **In the Loop**, **Loop-adjacent**, or **Out of the Loop**. A mission-critical feature is not done if it only exists in a script but is not reached by the daily, weekly, monthly, or artifact flows.
 
 You are warm but not sycophantic. You're genuinely curious about this person's life. You ask follow-ups that show you were listening. You never rush.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -73,6 +73,7 @@ python3 system/lifehug.py weekly-maintenance # weekly lint/fix, profile, queue, 
 python3 system/lifehug.py monthly-research  # monthly neighborhoods and focus recommendations
 python3 system/lifehug.py followups-status  # pass-transition state
 python3 system/lifehug.py followups-prompt  # prompt context for AI-generated depth questions
+python3 system/lifehug.py answer-ack-prompt  # warm acknowledgment prompt after an answer (stdin: question/answer JSON)
 ```
 
 Process an answer from stdin:

--- a/system/answer_ack.py
+++ b/system/answer_ack.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Lifehug — Answer Acknowledgment: warm reply prompt after an answer is saved.
+
+Builds the AI prompt for the warm acknowledgment message sent right after a
+daily answer is filed (see CLAUDE.md "Processing an Answer" / AGENTS.md's
+"Acknowledge warmly" step). This is the behavioral authority for the
+acknowledgment tone contract — the local Claude skill and the hosted Lifehug
+platform both build the message this way, so it stays consistent whichever
+surface answered.
+
+It does NOT call the AI itself — it prints a prompt; the calling model (or
+platform) completes it into the actual message.
+
+Usage:
+    echo '{"question_id": "A3", "question_text": "...", "question_category": "A",
+           "answer_text": "...", "followup_pending": true}' \
+        | python3 system/answer_ack.py
+
+Reads a single JSON object on stdin with:
+    question_id       str  — the question's ID, e.g. "A3"
+    question_text     str  — the question as asked
+    question_category str  — the category letter, e.g. "A"
+    answer_text       str  — the author's answer, verbatim
+    followup_pending  bool — whether a same-day follow-up question will follow
+
+Prints the built prompt to stdout, nothing else. On empty stdin, invalid
+JSON, or a missing/mis-typed required field, prints a one-line error to
+stderr and exits 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+REQUIRED_FIELDS = {
+    "question_id": str,
+    "question_text": str,
+    "question_category": str,
+    "answer_text": str,
+    "followup_pending": bool,
+}
+
+
+def build_prompt(payload: dict) -> str:
+    """Assemble the acknowledgment prompt from a validated payload."""
+    question_id = payload["question_id"]
+    question_text = payload["question_text"]
+    question_category = payload["question_category"]
+    answer_text = payload["answer_text"]
+    followup_pending = payload["followup_pending"]
+
+    lines = []
+    lines.append("=" * 70)
+    lines.append("LIFEHUG — ANSWER ACKNOWLEDGMENT")
+    lines.append("=" * 70)
+    lines.append("")
+    lines.append(f"Question: [{question_id}] (category {question_category})")
+    lines.append("")
+    lines.append("-" * 70)
+    lines.append("YOUR TASK")
+    lines.append("-" * 70)
+    lines.append("")
+    lines.append("The author just answered today's Lifehug question. Write the warm")
+    lines.append("acknowledgment message that goes back to them immediately, before")
+    lines.append("anything else follows.")
+    lines.append("")
+    lines.append("You are warm but not sycophantic. You're genuinely curious about")
+    lines.append("this person's life, and you show it by noticing what they actually")
+    lines.append("said — not with a generic compliment.")
+    lines.append("")
+    lines.append("Tone contract:")
+    lines.append("  1. Thank the author warmly. 2-4 sentences total.")
+    lines.append("  2. Reflect ONE concrete detail from their answer back at them —")
+    lines.append("     a name, a place, an image, a feeling they named. Show you")
+    lines.append("     actually listened. Not a generic compliment ('what a great")
+    lines.append("     story') — something that could only be said about THIS answer.")
+    lines.append("  3. No advice. No analysis. No questions back.")
+    if followup_pending:
+        lines.append("  4. End with one light sentence noting another question is")
+        lines.append("     coming while you're here, and that it's totally optional.")
+    else:
+        lines.append("  4. Do not mention a follow-up question — none is coming today.")
+    lines.append("")
+    lines.append("-" * 70)
+    lines.append("THE QUESTION")
+    lines.append("-" * 70)
+    lines.append("")
+    lines.append(question_text)
+    lines.append("")
+    lines.append("-" * 70)
+    lines.append("THE ANSWER")
+    lines.append("-" * 70)
+    lines.append("")
+    lines.append(answer_text)
+    lines.append("")
+    lines.append("=" * 70)
+    lines.append("END OF CONTEXT")
+    lines.append("=" * 70)
+    lines.append("")
+    lines.append("Output ONLY the acknowledgment message text. No explanation, no")
+    lines.append("preamble, no quotes, no markdown fences. Just the message.")
+
+    return "\n".join(lines)
+
+
+def _validate(payload) -> str | None:
+    """Return an error string if payload is invalid, else None."""
+    if not isinstance(payload, dict):
+        return "payload must be a JSON object"
+    for field, expected_type in REQUIRED_FIELDS.items():
+        if field not in payload:
+            return f"missing required field: {field}"
+        value = payload[field]
+        if expected_type is bool:
+            # bool is a subclass of int in Python — guard against ints/strings
+            # silently passing as booleans.
+            if not isinstance(value, bool):
+                return f"field {field!r} must be a boolean"
+        elif not isinstance(value, expected_type):
+            return f"field {field!r} must be a string"
+    return None
+
+
+def main() -> None:
+    argparse.ArgumentParser(
+        description="Print the warm answer-acknowledgment prompt (stdin: question/answer JSON)"
+    ).parse_args()
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("Error: empty stdin — expected a JSON payload", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"Error: invalid JSON on stdin: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    error = _validate(payload)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    print(build_prompt(payload))
+
+
+if __name__ == "__main__":
+    main()

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -455,6 +455,10 @@ def cmd_process_answer(args: argparse.Namespace) -> int:
     return run_python("process_answer.py", [*question_id, *flags])
 
 
+def cmd_answer_ack_prompt(_args: argparse.Namespace) -> int:
+    return run_python("answer_ack.py", [])
+
+
 def cmd_daily_dry_run(_args: argparse.Namespace) -> int:
     env = os.environ.copy()
     env["LIFEHUG_DAILY_DRY_RUN"] = "1"
@@ -1371,6 +1375,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--no-compile-wiki", action="store_true")
     p.add_argument("--sensitivity", default=None, choices=["private", "family", "friends", "public"])
     p.set_defaults(func=cmd_process_answer)
+
+    p = sub.add_parser("answer-ack-prompt",
+                       help="Print the warm answer-acknowledgment prompt (stdin: question/answer JSON)")
+    p.set_defaults(func=cmd_answer_ack_prompt)
 
     p = sub.add_parser("daily-dry-run", help="Validate daily delivery config without sending")
     p.set_defaults(func=cmd_daily_dry_run)

--- a/system/process_answer.py
+++ b/system/process_answer.py
@@ -28,6 +28,9 @@ from lifehug_core import (
 from source_integrity import SCHEMA_VERSION, format_frontmatter, payload_sha256, register_source
 from update_readme import update_readme
 
+FOLLOWUP_HEADER = "📖 Lifehug — since you're on a roll"
+FOLLOWUP_FOOTER = "(Totally optional — tomorrow's question comes either way)"
+
 
 def refresh_neighborhood_readiness_safely() -> None:
     """Refresh derived neighborhood lifecycle fields without blocking answer save."""
@@ -182,9 +185,9 @@ def maybe_send_followup_question(answered_question_id: str) -> None:
     if not question or question["id"] == answered_question_id:
         return
 
-    text = ("📖 Lifehug — since you're on a roll\n\n"
+    text = (f"{FOLLOWUP_HEADER}\n\n"
             f"{ask.format_question(question, categories)}\n\n"
-            "(Totally optional — tomorrow's question comes either way)")
+            f"{FOLLOWUP_FOOTER}")
     if send_telegram(text):
         ask.mark_question_sent(rotation, question["id"])
         rebuild_coverage()

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 115,
-  "released": "2026-07-21",
-  "changelog": "v115: kimi reasoning-model token headroom (issue #44). kimi-k3 spends completion budget on reasoning_tokens — the hardcoded 4096 max_tokens truncated JSON or returned empty content, failing wiki synthesis with excerpt fallback. _kimi_call now defaults to 16384 (config kimi_max_tokens) and retries once on empty completions.",
+  "version": 116,
+  "released": "2026-08-04",
+  "changelog": "v116: answer-ack-prompt — shared acknowledgment tone contract for hosted parity (lifehug-platform#175). New `answer-ack-prompt` command (system/answer_ack.py) builds the warm post-answer acknowledgment prompt from JSON on stdin (question, answer, followup_pending) so the local skill and the hosted platform share one behavioral authority for tone. Follow-up framing copy in process_answer.py hoisted to FOLLOWUP_HEADER/FOLLOWUP_FOOTER constants (byte-identical) so downstream consumers can pin it. AGENTS.md now requires a version bump on every PR, sized to user impact.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -21,6 +21,7 @@
     "sources/corrections/.gitkeep",
     "sources/manual/.gitkeep",
     "state/.gitkeep",
+    "system/answer_ack.py",
     "system/artifact.py",
     "system/ask.py",
     "system/book.py",

--- a/tests/test_answer_ack.py
+++ b/tests/test_answer_ack.py
@@ -1,0 +1,124 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSTEM = ROOT / "system"
+sys.path.insert(0, str(SYSTEM))
+
+
+def load_answer_ack():
+    spec = importlib.util.spec_from_file_location("answer_ack", SYSTEM / "answer_ack.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+PAYLOAD = {
+    "question_id": "A3",
+    "question_text": "What's a place from your childhood you still think about?",
+    "question_category": "A",
+    "answer_text": "My grandmother's kitchen in Oaxaca, the smell of cinnamon and the "
+    "tile floor that was always cool under my bare feet in summer.",
+    "followup_pending": True,
+}
+
+
+class BuildPromptTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_answer_ack()
+
+    def test_embeds_question_text_verbatim(self):
+        prompt = self.mod.build_prompt(PAYLOAD)
+        self.assertIn(PAYLOAD["question_text"], prompt)
+
+    def test_embeds_answer_text_verbatim(self):
+        prompt = self.mod.build_prompt(PAYLOAD)
+        self.assertIn(PAYLOAD["answer_text"], prompt)
+
+    def test_tone_contract_lines_present(self):
+        prompt = self.mod.build_prompt(PAYLOAD)
+        self.assertIn("2-4 sentences", prompt)
+        self.assertIn("No advice", prompt)
+        self.assertIn("No analysis", prompt)
+        self.assertIn("No questions back", prompt)
+        self.assertIn("warm but not sycophantic", prompt)
+
+
+class FollowupBranchTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_answer_ack()
+
+    def test_followup_pending_true_mentions_optional_followup(self):
+        prompt = self.mod.build_prompt({**PAYLOAD, "followup_pending": True})
+        self.assertIn("while you're here", prompt)
+        self.assertIn("totally optional", prompt)
+
+    def test_followup_pending_false_omits_followup_language(self):
+        prompt = self.mod.build_prompt({**PAYLOAD, "followup_pending": False})
+        self.assertNotIn("while you're here", prompt)
+        self.assertNotIn("totally optional", prompt)
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, stdin_text):
+        return subprocess.run(
+            [sys.executable, str(SYSTEM / "answer_ack.py")],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_valid_payload_prints_only_the_prompt(self):
+        mod = load_answer_ack()
+        result = self._run(json.dumps(PAYLOAD))
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.stdout, mod.build_prompt(PAYLOAD) + "\n")
+
+    def test_empty_stdin_exits_1_with_one_line_stderr(self):
+        result = self._run("")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(len(result.stderr.strip().splitlines()), 1)
+
+    def test_invalid_json_exits_1(self):
+        result = self._run("{not json")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+
+    def test_missing_field_exits_1(self):
+        payload = dict(PAYLOAD)
+        del payload["answer_text"]
+        result = self._run(json.dumps(payload))
+        self.assertEqual(result.returncode, 1)
+
+    def test_mistyped_field_exits_1(self):
+        payload = {**PAYLOAD, "followup_pending": "true"}
+        result = self._run(json.dumps(payload))
+        self.assertEqual(result.returncode, 1)
+
+
+class FollowupFramingConstantsTests(unittest.TestCase):
+    def test_constants_have_expected_values(self):
+        spec = importlib.util.spec_from_file_location("process_answer", SYSTEM / "process_answer.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        self.assertEqual(mod.FOLLOWUP_HEADER, "📖 Lifehug — since you're on a roll")
+        self.assertEqual(
+            mod.FOLLOWUP_FOOTER,
+            "(Totally optional — tomorrow's question comes either way)",
+        )
+
+    def test_maybe_send_followup_question_uses_constants(self):
+        script = (SYSTEM / "process_answer.py").read_text(encoding="utf-8")
+        self.assertNotIn('"📖 Lifehug — since you\'re on a roll\\n\\n"', script)
+        self.assertIn("FOLLOWUP_HEADER", script)
+        self.assertIn("FOLLOWUP_FOOTER", script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lifehug_wrapper.py
+++ b/tests/test_lifehug_wrapper.py
@@ -73,6 +73,7 @@ class LifehugWrapperTests(unittest.TestCase):
             ["serve", "--port", "8765"],
             ["rebuild"],
             ["process-answer", "A1", "--source", "text", "--summary", "Short answer"],
+            ["answer-ack-prompt"],
             ["daily-dry-run"],
             ["weekly-maintenance", "--dry-run"],
             ["monthly-research", "--dry-run", "--gap-limit", "2", "--self-topic", "Who I am becoming", "--focus-min-score", "15"],


### PR DESCRIPTION
## Summary

- Adds `system/answer_ack.py` and the `answer-ack-prompt` subcommand (`python3 system/lifehug.py answer-ack-prompt`) — a stdlib-only, stdin-driven script that builds the warm answer-acknowledgment prompt (`build_prompt(payload)`), following the same "print a prompt, don't call the AI" pattern as `gen_followups.py --prompt` / `compose.py`.
- This is the upstream-first behavioral authority for the acknowledgment tone contract: the hosted Lifehug platform (lifehug-platform#175) needs to send the same warm acknowledgment after an answer that the local Claude skill sends, so both surfaces build the message the same way rather than the platform re-deriving its own copy of the tone rules.
- Hoists the adaptive-cadence follow-up message framing in `system/process_answer.py` from an inline literal to two named, byte-identical constants — `FOLLOWUP_HEADER` and `FOLLOWUP_FOOTER` — so the platform (or anything else) can pin the exact copy instead of re-typing it. No behavior change.
- Docs: extends AGENTS.md's "Acknowledge warmly" step and `skill/SKILL.md`'s Canonical Commands list to reference the new command.
- Tests: `tests/test_answer_ack.py` covers prompt construction (verbatim question/answer embedding, tone-contract lines, the `followup_pending` true/false branch), the CLI contract (empty stdin / invalid JSON / missing or mis-typed field → exit 1 with one-line stderr; valid payload → stdout is only the prompt), and that the hoisted constants exist with the exact expected values and are actually used. `tests/test_lifehug_wrapper.py`'s canonical-commands parser test is extended with `answer-ack-prompt`.

## Test plan

- [x] `python3 -m pytest tests/ -q` — full suite green (622 passed, 69 subtests passed)
- [x] Manual check: `echo '{"question_id":"A3","question_text":"...","question_category":"A","answer_text":"...","followup_pending":true}' | python3 system/lifehug.py answer-ack-prompt` prints the prompt to stdout only

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>