### PR TITLE
docs: cross-medium parity rule + v118

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,20 @@ Then decide:
 2. **Setup done but no cron?** → If `config.yaml` exists but no daily question delivery is configured, help the user set up their cron job.
 3. **Normal session?** → Check if there's a pending question or incoming answer to process. Prefer `python3 system/lifehug.py process-answer` for answer saves.
 
+## Cross-Medium Parity (owner-set, 2026-08-05)
+
+Lifehug is one product in multiple mediums: this local companion, the hosted
+platform (lifehug/lifehug-platform), future mobile apps. Mediums differ in
+HOW, never in WHAT — user-facing capabilities stay feature-equivalent,
+adapted to each medium. The rule is bidirectional: **any session building a
+user-facing feature here files the twin issue on lifehug-platform in the
+same pass (and vice versa), or records in the PR why the feature doesn't
+translate to the other medium.** Hosted infrastructure (sessions, invite
+gates, durable stores) is not a feature and needs no twin. Design/theming
+parity is deliberately deferred until the platform's design settles
+(lifehug-platform#236 tracks the future shared design library).
+First backfill wave from the platform's UI build: issues #51–#54 here.
+
 ## Git Conflict Resolution — State File Safety
 
 **This section is the UPGRADE case**: pulling framework changes from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1229,3 +1229,11 @@ Lifehug tracks its version in `system/version.json`. Framework files (listed the
 - `README.md`, `profile.yaml` (committed identity/prefs), `config.yaml` (gitignored secrets/overrides), `system/question-bank.md`, `system/rotation.json`, `system/coverage.json`, `system/schedule.json`
 - `answers/`, `outputs/`, `sources/`
 - `state/question_candidates.json`, `state/question_queue.json`, `state/planner_state.json`, `state/source_manifest.json`, `state/source_lint_findings.json`, `state/timeline_placements.json`
+
+## Cross-Medium Parity
+
+Feature equivalence across mediums (local / hosted platform / future mobile)
+is bidirectional and owner-set (2026-08-05): build a user-facing feature →
+file the twin issue on the other repo in the same pass, or record why it
+doesn't translate. Full rule: AGENTS.md §Cross-Medium Parity. Backfill wave:
+issues #51–#54.

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 117,
-  "released": "2026-08-04",
-  "changelog": "v117: one vault, many machines — multi-writer git discipline (lifehug-platform ADR 0011, issue #174). Your vault can now be driven safely from several places at once: this machine, a second machine, a hosted Lifehug environment. Two flows learned to read fresh before they act — daily_question.sh pulls before it picks the question, and file_answer_bg.sh pulls before it files — so a question answered on your phone this morning is not re-asked by your laptop this evening. Both pulls are non-fatal: if git is unreachable you still get your question and your answer still files, exactly as before. process-answer's --push path no longer crashes when someone else pushed first; it rebases and retries, and if the push still cannot land it says so plainly and tells you your commit is safe and unpushed instead of dying on a traceback. CLAUDE.md gains 'Shared Vault: One Vault, Many Machines': the four disciplines, why you should answer with an explicit question id across machines, and a step-by-step recovery for a rotation.json rebase conflict. Drive-by fix: AGENTS.md's rebase snippet had --ours and --theirs backwards (during a rebase your commits replay onto the remote, so the labels invert) and would have taken the opposite side of every state-file conflict it described.",
+  "version": 118,
+  "released": "2026-08-05",
+  "changelog": "v118: cross-medium parity rule documented (AGENTS.md/CLAUDE.md) — feature equivalence between this local companion and hosted Lifehug is now a stated, bidirectional build rule; the first platform→local backfill wave is filed as issues #51–#54 (local answer capture, local warm acknowledgment, mobile-usable local UI, viewable source bodies). Docs only; no behavior change.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",


### PR DESCRIPTION
The owner-set parity principle, written into this repo's operating docs: mediums differ in how, never in what — any session building a user-facing feature here files the twin on lifehug-platform in the same pass, or records why it doesn't translate. Backfill wave from tonight's platform UI build: #51–#54. Version bumped per the every-PR rule (docs-only one-liner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)