### PR TITLE
Fix keyless AI discovery when Anthropic SDK is absent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,7 @@ LIFEHUG_WEEKLY_DRY_RUN=1 system/weekly_maintenance.sh
 
 The weekly Loop segment compiles offline, lints sources, applies safe source fixes only when lint finds them, classifies capped new sources, updates the quality profile, auto-promotes candidates under caps, writes the next planned queue, scans gaps in dry-run mode, reports progress, and autocommits real changes.
 
-Both loops run on any machine (v92). Check `python3 system/lifehug.py ai-status` first: keyed (gateway or API key) runs are fully unattended; keyless runs need the agent as the model — follow `skills/maintenance/SKILL.md` (pre-complete AI work via `--emit-prompts`/`--emit-task`/`--from-response` before the run; a keyless cron emits its AI work to `state/agent_tasks/` instead of failing).
+Both loops run on any machine (v92). Check `python3 system/lifehug.py ai-status` first: keyed (gateway or API key) runs are fully unattended; keyless runs need the agent as the model — follow `skills/maintenance/SKILL.md` (pre-complete AI work via `--emit-prompts`/`--emit-task`/`--from-response` before the run; a keyless cron emits its AI work to `state/agent_tasks/` instead of failing). The Anthropic SDK is optional: if it is not installed, `ai-status` reports keyless rather than stopping the process.
 
 Run the monthly growth loop with:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1080,7 +1080,8 @@ Optional AI-call tuning (v85): `ai_timeout_seconds` (default 600; env override
 routes OpenClaw gateway → retries transient failures 3x → falls through to the
 Anthropic SDK when a key is available (the gateway's deterministic
 "couldn't generate" rejection, issue #34, skips retries and falls through
-immediately).
+immediately). The Anthropic SDK is optional: when it is not importable,
+`ai-status` reports keyless and the agent-task paths remain available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ flowchart TB
     d --> w --> m
 ```
 
-The daily job needs **no model call**. Weekly maintenance is capped and keyless when OpenClaw is running; if no model is available, the rest of the weekly Loop segment still runs and classification can catch up later. Monthly generation is the bigger model-backed growth pass. See [`examples/openclaw-cron.md`](examples/openclaw-cron.md) for copy-paste cron commands (Telegram DM/group, WhatsApp, Signal, Discord) and a local dry-run you can try first:
+The daily job needs **no model call**. Weekly maintenance is capped and keyless when OpenClaw is running; if no model is available, the rest of the weekly Loop segment still runs and classification can catch up later. The Anthropic SDK is optional: `python3 system/lifehug.py ai-status` reports keyless when it is absent, so agent-task workflows stay available without installing it. Monthly generation is the bigger model-backed growth pass. See [`examples/openclaw-cron.md`](examples/openclaw-cron.md) for copy-paste cron commands (Telegram DM/group, WhatsApp, Signal, Discord) and a local dry-run you can try first:
 
 ```bash
 LIFEHUG_DAILY_DRY_RUN=1 system/daily_question.sh   # see today's question without sending

--- a/README.template.md
+++ b/README.template.md
@@ -163,6 +163,10 @@ python3 system/lifehug.py connector-audit gmail                # what got auto-p
 python3 system/lifehug.py --help
 ```
 
+The Anthropic SDK is optional. `python3 system/lifehug.py ai-status` reports
+keyless when it is absent, so an agent can complete AI tasks through the
+existing emit-task and `--from-response` paths without installing it.
+
 ## Structure
 
 ```

--- a/skills/compile/SKILL.md
+++ b/skills/compile/SKILL.md
@@ -25,6 +25,10 @@ A page's prose can be written four ways. The script picks the first available, p
 3. **Gateway/API** — `call_ai` via the OpenClaw gateway (keyless, if running) or `ANTHROPIC_API_KEY` (the cron path — Mode 2).
 4. **Excerpt fallback** — deterministic source excerpts, **only for a page that was never synthesized**. Compile will **never** downgrade an already-synthesized page (frontmatter `synthesized: true`) to excerpts — it preserves the last good prose and logs `↻ preserved <slug>`. So a bare `compile` on a keyless machine is safe; at worst a changed page keeps its prior prose until a real synthesis runs.
 
+The Anthropic SDK is optional. If it is absent, `ai-status` reports keyless and
+this agent-draft path remains available; do not install the SDK just to compile
+through an agent.
+
 ## Mode 1 — Desktop through Claude Code (keyless; YOU synthesize)
 
 On the desktop there is usually no API key and no OpenClaw gateway. That's fine: **you are the model.** Do the synthesis yourself, then let the script assemble the graph.

--- a/skills/focus/SKILL.md
+++ b/skills/focus/SKILL.md
@@ -40,7 +40,7 @@ python3 system/lifehug.py focus-new "<label>" \
   --objective "<objective>" --deliverable <book|chapter|essay|letter|post>
 ```
 
-`focus-new` scaffolds a new question-bank category, registers the Focus on the roadmap, and **auto-generates ~8–12 starter questions** toward the objective. Generation uses the OpenClaw gateway when it's running (cron path — no API key needed), or `ANTHROPIC_API_KEY` as a fallback. If neither is available — the usual case on the desktop — the Focus is still created and you generate the questions yourself (next section). It never touches existing answers.
+`focus-new` scaffolds a new question-bank category, registers the Focus on the roadmap, and **auto-generates ~8–12 starter questions** toward the objective. Generation uses the OpenClaw gateway when it's running (cron path — no API key needed), or `ANTHROPIC_API_KEY` as a fallback. The Anthropic SDK is optional: if it is absent, the command remains keyless and the Focus is still created so you can generate the questions yourself (next section). It never touches existing answers.
 
 After it runs, confirm what happened and show the result:
 

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -35,6 +35,9 @@ python3 system/lifehug.py ai-status
   ```
 - **Exit 1** (`keyless`) → agent mode. **You are the model.** Follow Mode 1.
 
+The Anthropic SDK is optional. If it is not installed, `ai-status` still exits
+1 cleanly for keyless mode; do not install it merely to run the agent-task flow.
+
 ## Mode 1 — Keyless desktop (YOU are the model)
 
 **Pre-complete the AI work BEFORE running the script.** Ordering matters:

--- a/system/research.md
+++ b/system/research.md
@@ -223,7 +223,15 @@ trust is earned at the threshold, not at the capture.
 
 ---
 
-## 8. Key References
+## 8. Operational constraint: model providers are optional
+
+The Loop must keep its agent-completion path available on machines without an
+API key **or an installed provider SDK**. Provider discovery therefore returns
+a catchable unavailable result; `lifehug.py ai-status` reports keyless and the
+existing emit-task/`--from-response` workflow completes the AI step. Optional
+provider imports must never terminate the process.
+
+## 9. Key References
 
 **Narrative identity & memoir**: McAdams, *Life Story Interview II* (Foley Center); McAdams & McLean 2013; McAdams et al. 2001 (redemption/contamination, PSPB); Karr, *The Art of Memoir*; Gornick, *The Situation and the Story*; Birren, Guided Autobiography (nine themes).
 **Introspection science**: Pennebaker & Chung (expressive writing protocol); Frattaroli 2006 meta-analysis; Campbell & Pennebaker 2003 (pronoun flexibility); Kross & Ayduk 2011 (self-distancing); Nolen-Hoeksema (rumination); Treynor (brooding vs reflection); Eurich (what-not-why).

--- a/system/research_expand.py
+++ b/system/research_expand.py
@@ -350,20 +350,44 @@ def _openclaw_gateway() -> tuple[str, str] | None:
     return None
 
 
-def get_client():
-    """Return an Anthropic client, reading API key from env or config."""
+class AIProviderUnavailableError(RuntimeError):
+    """A configured optional AI provider cannot be used in this environment."""
+
+
+def _anthropic_module():
+    """Import Anthropic only when its route is selected.
+
+    The SDK is optional: agent-task mode must remain usable in installations
+    that deliberately do not install it.
+    """
     try:
         import anthropic  # noqa: PLC0415
-    except ImportError:
-        print("Error: anthropic package not installed. Run: pip install anthropic", file=sys.stderr)
-        sys.exit(1)
+    except ImportError as exc:
+        raise AIProviderUnavailableError(
+            "Anthropic SDK is not installed; use agent mode or install anthropic for SDK calls."
+        ) from exc
+    return anthropic
+
+
+def _anthropic_sdk_available() -> bool:
+    """Whether the optional Anthropic SDK can be imported without exiting."""
+    try:
+        _anthropic_module()
+    except AIProviderUnavailableError:
+        return False
+    return True
+
+
+def get_client():
+    """Return an Anthropic client, reading API key from env or config."""
+    anthropic = _anthropic_module()
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         config = load_config()
         api_key = config.get("anthropic_api_key")
     if not api_key:
-        raise RuntimeError(
+        raise AIProviderUnavailableError(
             "ANTHROPIC_API_KEY not set. Export it or add anthropic_api_key to config.yaml."
         )
     return anthropic.Anthropic(api_key=api_key)
@@ -384,10 +408,10 @@ def ai_available() -> str | None:
     if _kimi_key() is not None:
         return "kimi"
     if os.environ.get("ANTHROPIC_API_KEY"):
-        return "sdk-key"
+        return "sdk-key" if _anthropic_sdk_available() else None
     try:
         if load_config().get("anthropic_api_key"):
-            return "sdk-key"
+            return "sdk-key" if _anthropic_sdk_available() else None
     except Exception:
         pass
     return None
@@ -1223,7 +1247,7 @@ def call_ai(prompt: str, model: str) -> str:
     # missing-key complaint.
     try:
         client = get_client()
-    except (RuntimeError, SystemExit):
+    except RuntimeError:
         if gateway_error is not None:
             raise gateway_error from None
         raise

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 121,
+  "version": 122,
   "released": "2026-08-06",
-  "changelog": "v121: vault-root descendants retain the same no-follow authority as named durable paths. A source symlink introduced after process binding is now rejected consistently by compilation and source-prompt flows, so it cannot cause Lifehug to read outside the selected vault. The guard test prevents later runtime code from downcasting the selected vault root back to ordinary pathlib I/O.",
+  "changelog": "v122: keyless agent mode no longer requires the optional Anthropic SDK to be installed. AI status now reports keyless cleanly when the SDK is absent, so weekly/monthly agent-task workflows can continue instead of the process exiting during provider discovery.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_v85_ai_routing.py
+++ b/tests/test_v85_ai_routing.py
@@ -130,6 +130,43 @@ class CallAIRoutingTests(unittest.TestCase):
         self.assertEqual(result, "sdk says hi")
 
 
+class OptionalAnthropicSdkTests(unittest.TestCase):
+    """The optional SDK must not turn keyless mode into a process exit."""
+
+    def setUp(self):
+        self._real_import = __import__
+
+    def _missing_anthropic_import(self, name, *args, **kwargs):
+        if name == "anthropic":
+            raise ImportError("No module named 'anthropic'")
+        return self._real_import(name, *args, **kwargs)
+
+    def test_missing_sdk_is_catchable_and_ai_status_is_keyless(self):
+        """Simulate absence directly so this test does not depend on the host."""
+        with mock.patch("builtins.__import__", side_effect=self._missing_anthropic_import), \
+                mock.patch.object(rex, "_openclaw_gateway", return_value=None), \
+                mock.patch.dict(rex.os.environ, {"ANTHROPIC_API_KEY": "synthetic-key"}, clear=True), \
+                mock.patch.object(rex, "load_config", return_value={}):
+            self.assertIsNone(rex.ai_available())
+            with self.assertRaises(rex.AIProviderUnavailableError):
+                rex.get_client()
+
+    def test_gateway_failure_remains_catchable_when_sdk_is_absent(self):
+        with mock.patch("builtins.__import__", side_effect=self._missing_anthropic_import), \
+                mock.patch.object(rex, "_openclaw_gateway",
+                                  return_value=("http://fake:1/v1", "tok")), \
+                mock.patch.dict(rex.os.environ,
+                                {"LIFEHUG_AI_TIMEOUT": "5", "ANTHROPIC_API_KEY": "synthetic-key"},
+                                clear=True), \
+                mock.patch.object(rex, "load_config", return_value={}), \
+                mock.patch("time.sleep"), \
+                mock.patch("urllib.request.urlopen", return_value=_FakeResponse(SENTINEL)), \
+                mock.patch("sys.stdout", new_callable=io.StringIO), \
+                self.assertRaises(RuntimeError) as ctx:
+            rex.call_ai("prompt", "claude-sonnet-5")
+        self.assertIn("generate", str(ctx.exception))
+
+
 class KimiRoutingTests(unittest.TestCase):
     """v113 — model-explicit Kimi routing: a kimi/moonshot/k3 model name sends
     the call to the Kimi OpenAI-compatible endpoint, bypassing the gateway

--- a/tests/test_v92_agent_mode.py
+++ b/tests/test_v92_agent_mode.py
@@ -67,16 +67,18 @@ class AiAvailableTests(unittest.TestCase):
                                return_value=("http://localhost:18789/v1", "tok")):
             self.assertEqual(re_mod.ai_available(), "gateway")
 
-    def test_env_key_detected(self):
+    def test_env_key_detected_when_sdk_available(self):
         with mock.patch.object(re_mod, "_openclaw_gateway", return_value=None), \
-             mock.patch.dict(re_mod.os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=True):
+             mock.patch.dict(re_mod.os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=True), \
+             mock.patch.object(re_mod, "_anthropic_sdk_available", return_value=True):
             self.assertEqual(re_mod.ai_available(), "sdk-key")
 
-    def test_config_key_detected(self):
+    def test_config_key_detected_when_sdk_available(self):
         with mock.patch.object(re_mod, "_openclaw_gateway", return_value=None), \
              mock.patch.dict(re_mod.os.environ, {}, clear=True), \
              mock.patch.object(re_mod, "load_config",
-                               return_value={"anthropic_api_key": "sk-test"}):
+                               return_value={"anthropic_api_key": "sk-test"}), \
+             mock.patch.object(re_mod, "_anthropic_sdk_available", return_value=True):
             self.assertEqual(re_mod.ai_available(), "sdk-key")
 
     def test_config_read_failure_means_keyless_not_crash(self):

--- a/tests/test_v92_agent_mode.py
+++ b/tests/test_v92_agent_mode.py
@@ -97,6 +97,18 @@ class AiStatusCommandTests(unittest.TestCase):
         with mock.patch.object(re_live, "ai_available", return_value=None):
             self.assertEqual(lh.cmd_ai_status(None), 1)
 
+    def test_missing_optional_sdk_reports_keyless(self):
+        re_live = sys.modules["research_expand"]
+        with mock.patch.object(re_live, "_openclaw_gateway", return_value=None), \
+             mock.patch.dict(re_live.os.environ, {"ANTHROPIC_API_KEY": "synthetic-key"}, clear=True), \
+             mock.patch.object(re_live, "load_config", return_value={}), \
+             mock.patch.object(re_live, "_anthropic_sdk_available", return_value=False), \
+             mock.patch("sys.stdout") as stdout:
+            self.assertEqual(lh.cmd_ai_status(None), 1)
+        self.assertIn("keyless", "".join(
+            call.args[0] for call in stdout.write.call_args_list
+        ))
+
 
 class EmitPromptsTests(unittest.TestCase):
     def setUp(self):
@@ -190,7 +202,7 @@ class OrchestratorContractTests(unittest.TestCase):
 
     def test_weekly_checks_ai_status_and_emits(self):
         self.assertIn("ai-status", self.weekly)
-        self.assertIn("--emit-prompts state/agent_tasks/classify", self.weekly)
+        self.assertIn('--emit-prompts "$AGENT_TASKS_DIR/classify"', self.weekly)
         self.assertIn("⏸ keyless", self.weekly)
 
     def test_weekly_keyless_failure_is_distinct_operation(self):
@@ -200,7 +212,7 @@ class OrchestratorContractTests(unittest.TestCase):
 
     def test_monthly_checks_ai_status_and_emits_roster_tasks(self):
         self.assertIn("ai-status", self.monthly)
-        self.assertIn("--emit-task \"state/agent_tasks/roster/${etype}.json\"", self.monthly)
+        self.assertIn('--emit-task "$AGENT_TASKS_DIR/roster/${etype}.json"', self.monthly)
         self.assertIn("⏸ keyless", self.monthly)
 
     def test_monthly_keyless_never_runs_keyed_roster_refresh_blind(self):
@@ -209,7 +221,7 @@ class OrchestratorContractTests(unittest.TestCase):
         self.assertIn('if [[ "$KEYLESS" == "1" ]]', self.monthly)
 
     def test_monthly_research_prompts_emitted_keyless(self):
-        self.assertIn("state/agent_tasks/research", self.monthly)
+        self.assertIn('$AGENT_TASKS_DIR/research', self.monthly)
         self.assertIn("--from-response", self.monthly)
 
 


### PR DESCRIPTION
## Summary

- Treat the Anthropic SDK as optional during AI route discovery; a missing module now yields a catchable unavailable result rather than terminating Python.
- Make `ai-status` report keyless when an Anthropic key is configured but the optional SDK is unavailable, preserving the existing agent-task flow.
- Add host-independent regression coverage for missing-SDK discovery, `ai-status`, and gateway fall-through; document the keyless contract and bump the framework to v122.

Closes #47

🤖 Generated with GPT-5.6 Terra via Codex