### PR TITLE
Fix bounded correction and retraction filenames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,12 +302,20 @@ python3 system/lifehug.py fix answers/{ID}.md --retract --reason "classifier inf
 python3 system/lifehug.py fix answers/L20.md --retract --from-page childhood --reason "about Katie's childhood"
 # undo a WRONG retraction (v88) — the source resumes being asserted:
 python3 system/lifehug.py unretract sources/corrections/<retraction-file>.md --reason "why it was wrong"
+# once when upgrading a vault with legacy title-derived correction/retraction names:
+python3 system/lifehug.py source-filenames-repair --dry-run
+python3 system/lifehug.py source-filenames-repair
 ```
 
 Retractions are **sha-pinned** (v88): they retract the *content* they were
 filed against, not the id forever — if the target file's payload is later
 replaced (e.g. a mis-filed source swapped for a genuine answer under the same
 question id), the retraction stops applying automatically.
+
+Correction and retraction filenames are portable bounded identifiers (v119):
+they include a target-source-id label and a digest, never the full question
+text. The repair command migrates legacy files and their indexes; review the
+dry run first, then commit the resulting rename transaction.
 
 3. **Let the follow-up loop work**:
    - Do not manually append ad hoc follow-ups in normal operation.

--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ python3 system/lifehug.py source-scan
 python3 system/lifehug.py source-lint
 python3 system/lifehug.py source-lint --fix
 python3 system/lifehug.py source-findings
+python3 system/lifehug.py source-filenames-repair --dry-run  # legacy correction/retraction names
 printf '%s\n' "$CORRECTION" | python3 system/lifehug.py correct-source answers/A14.md --kind factual
 printf '%s\n' "$REFLECTION" | python3 system/lifehug.py reflect-source answers/A14.md
 

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -135,6 +135,11 @@ downstream learning steps see the results.
 
 ## Notes
 
+- If `source-filenames-repair --dry-run` reports legacy correction/retraction
+  filenames, run the non-dry command before a platform import. It is a
+  loop-adjacent vault repair: it updates generated/state references without
+  changing any captured source payload.
+
 - `state/agent_tasks/` is transient and gitignored — completed tasks can be
   deleted; the next emission rewrites the directory.
 - Without a Telegram token the summary send degrades gracefully; the report

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -237,6 +237,13 @@ def cmd_source_manifest(args: argparse.Namespace) -> int:
     return run_python("source_integrity.py", flags)
 
 
+def cmd_source_filenames_repair(args: argparse.Namespace) -> int:
+    flags = ["repair-linked-filenames"]
+    if args.dry_run:
+        flags.append("--dry-run")
+    return run_python("source_integrity.py", flags)
+
+
 def cmd_source_lint(args: argparse.Namespace) -> int:
     flags = ["lint"]
     if args.fix:
@@ -1266,6 +1273,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--rebuild", action="store_true")
     p.add_argument("--json", action="store_true")
     p.set_defaults(func=cmd_source_manifest)
+
+    p = sub.add_parser(
+        "source-filenames-repair",
+        help="Migrate legacy correction/retraction filenames and state references",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Preview changes without writing")
+    p.set_defaults(func=cmd_source_filenames_repair)
 
     p = sub.add_parser("source-lint", help="Lint raw source integrity and queue repair findings")
     p.add_argument("--fix", action="store_true", help="Apply safe metadata/manifest repairs")

--- a/system/source_contract.md
+++ b/system/source_contract.md
@@ -70,6 +70,11 @@ from the question text. The digest covers the full target id, directive kind,
 and payload, so Unicode, traversal-like prose, and matching truncated labels
 cannot collide.
 
+The date prefix preserves a valid `captured_at` calendar day. Missing,
+malformed, or impossible calendar dates in legacy metadata normalize
+deterministically to `1970-01-01`; they never become a misleading filename
+date or alter the linked-source body.
+
 Existing vaults can migrate legacy title-derived names safely:
 
 ```bash

--- a/system/source_contract.md
+++ b/system/source_contract.md
@@ -60,3 +60,27 @@ python3 system/lifehug.py reflect-source answers/A1.md
 
 Corrections and reflections are themselves source files, so the wiki can compile
 the original memory and the later understanding together.
+
+### Portable correction and retraction filenames
+
+New correction and retraction files use the bounded, ASCII-only contract
+`YYYY-MM-DD-<correction|retraction>-<target-id-label>-<hash>.md`. The visible
+label comes from the target's stable source id (for example `answer-a1`), never
+from the question text. The digest covers the full target id, directive kind,
+and payload, so Unicode, traversal-like prose, and matching truncated labels
+cannot collide.
+
+Existing vaults can migrate legacy title-derived names safely:
+
+```bash
+python3 system/lifehug.py source-filenames-repair --dry-run
+python3 system/lifehug.py source-filenames-repair
+```
+
+The repair is idempotent. It preflights every rename, refuses symlinked or
+out-of-vault paths, then updates linked-source frontmatter, state indexes,
+classification filenames, and generated wiki/report references together. Each
+individual write is atomic and an in-process error rolls the completed writes
+back. A forced process termination or power loss cannot make a multi-file
+transaction atomic; rerun the repair after restoring any interrupted vault
+write before committing or importing it.

--- a/system/source_integrity.py
+++ b/system/source_integrity.py
@@ -846,7 +846,6 @@ def create_linked_source(
     label = {"source_reflection": "Reflection",
              "source_retraction": "Retraction"}.get(source_type, "Correction")
     title = title or f"{label} for {target_title}"
-<<<<<<< HEAD
     validate_contained_path(
         CORRECTION_SOURCES_DIR,
         CORRECTION_SOURCES_DIR.parent,

--- a/system/source_integrity.py
+++ b/system/source_integrity.py
@@ -753,7 +753,16 @@ def _bounded_slug(value: str, maximum: int) -> str:
 def _linked_source_day(captured_at: str) -> str:
     """Return a filename-safe ISO day even when repairing malformed metadata."""
     day = (captured_at or "")[:10]
-    return day if re.fullmatch(r"\d{4}-\d{2}-\d{2}", day) else "1970-01-01"
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", day):
+        return "1970-01-01"
+    try:
+        # Regex shape alone admits impossible legacy values such as
+        # ``2026-99-99``.  Parse before reusing the day in a path so every
+        # malformed timestamp follows the same deterministic fallback.
+        datetime.strptime(day, "%Y-%m-%d")
+    except ValueError:
+        return "1970-01-01"
+    return day
 
 
 def linked_source_stem(

--- a/system/source_integrity.py
+++ b/system/source_integrity.py
@@ -40,6 +40,12 @@ from lifehug_core import (
 from vault_paths import validate_contained_path
 
 SCHEMA_VERSION = 1
+LINKED_SOURCE_TYPES = {"source_correction", "source_retraction"}
+# The platform imports source paths as identifiers and Windows still has a
+# conservative path budget.  Keep the *filename* well below either limit;
+# every generated character is ASCII, so characters and bytes are identical.
+MAX_LINKED_SOURCE_FILENAME_BYTES = 120
+LINKED_SOURCE_HASH_LENGTH = 16
 REQUIRED_SOURCE_KEYS = (
     "type",
     "source_id",
@@ -725,18 +731,81 @@ def summarize_records(records: list[dict[str, object]]) -> None:
         print(f"metadata needed: {missing_metadata}")
 
 
-def _unique_path(directory: Path, title: str, captured_at: str) -> Path:
-    day = captured_at[:10] if captured_at else datetime.now(timezone.utc).date().isoformat()
-    base = f"{day}-{slugify(title)}"
-    path = directory / f"{base}.md"
-    if not path.exists():
-        return path
-    index = 2
-    while True:
-        candidate = directory / f"{base}-{index}.md"
+def _linked_source_target_id(metadata: dict[str, object]) -> str:
+    """Return the authoritative target id from a linked-source record."""
+    for key in ("corrects", "retracts"):
+        value = str(metadata.get(key, "")).strip()
+        if value:
+            return value
+    for key in ("corrects_path", "retracts_path"):
+        value = str(metadata.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def _bounded_slug(value: str, maximum: int) -> str:
+    """ASCII, traversal-safe label with a hard byte bound."""
+    label = slugify(value).strip("-") or "source"
+    return label[:maximum].rstrip("-") or "source"
+
+
+def linked_source_stem(
+    target_id: str, source_type: str, payload: str, captured_at: str
+) -> str:
+    """Stable, bounded stem for correction/retraction source files.
+
+    Contract: ``YYYY-MM-DD-<kind>-<target-label>-<hash>.md``.  ``target-label``
+    is only a bounded slug of the authoritative target id; the full question
+    text is never part of the filename.  The digest includes the full target
+    id, kind, and payload, keeping distinct corrections collision-safe even
+    when their visible labels truncate to the same text.
+    """
+    day = (captured_at or now_utc())[:10]
+    kind = {"source_correction": "correction", "source_retraction": "retraction"}.get(
+        source_type, "linked"
+    )
+    suffix = ".md"
+    # Reserve separators and the full fallback digest so a collision can grow
+    # from 16 to 64 hex characters without exceeding the contract.
+    label_budget = MAX_LINKED_SOURCE_FILENAME_BYTES - len(
+        f"{day}-{kind}---{suffix}" + "f" * 64
+    )
+    target_label = _bounded_slug(target_id, max(1, label_budget))
+    identity = "\0".join((source_type, target_id, normalize_payload(payload)))
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return f"{day}-{kind}-{target_label}-{digest[:LINKED_SOURCE_HASH_LENGTH]}"
+
+
+def _linked_source_path(
+    directory: Path,
+    target_id: str,
+    source_type: str,
+    payload: str,
+    captured_at: str,
+) -> Path:
+    """Choose a bounded name, extending the digest deterministically on a hash-prefix collision."""
+    stem = linked_source_stem(target_id, source_type, payload, captured_at)
+    prefix, short_digest = stem.rsplit("-", 1)
+    full_digest = hashlib.sha256(
+        "\0".join((source_type, target_id, normalize_payload(payload))).encode("utf-8")
+    ).hexdigest()
+    for digest_length in range(len(short_digest), len(full_digest) + 1, 16):
+        candidate = directory / f"{prefix}-{full_digest[:digest_length]}.md"
+        if candidate.is_symlink():
+            raise ValueError(f"refusing symlinked linked-source filename: {candidate}")
         if not candidate.exists():
             return candidate
-        index += 1
+        existing_metadata, existing_payload = split_frontmatter(
+            candidate.read_text(encoding="utf-8", errors="replace")
+        )
+        if (
+            str(existing_metadata.get("type", "")) == source_type
+            and _linked_source_target_id(existing_metadata) == target_id
+            and normalize_payload(existing_payload) == normalize_payload(payload)
+        ):
+            return candidate  # idempotent retry of the same linked source
+    raise RuntimeError("unable to allocate a unique linked-source filename")
 
 
 def resolve_source_target(value: str) -> Path:
@@ -777,13 +846,23 @@ def create_linked_source(
     label = {"source_reflection": "Reflection",
              "source_retraction": "Retraction"}.get(source_type, "Correction")
     title = title or f"{label} for {target_title}"
+<<<<<<< HEAD
     validate_contained_path(
         CORRECTION_SOURCES_DIR,
         CORRECTION_SOURCES_DIR.parent,
         label="correction destination",
     ).mkdir(parents=True, exist_ok=True)
-    path = _unique_path(CORRECTION_SOURCES_DIR, title, captured_at)
     payload = f"# {title}\n\n{body.strip()}\n"
+    target_id = str(target_record["source_id"])
+    if source_type in LINKED_SOURCE_TYPES:
+        path = _linked_source_path(
+            CORRECTION_SOURCES_DIR, target_id, source_type, payload, captured_at
+        )
+    else:
+        # Reflections are narrative sources and retain their historical,
+        # human-readable naming contract. This migration is intentionally
+        # scoped to compiler directives (corrections/retractions).
+        path = _unique_path(CORRECTION_SOURCES_DIR, title, captured_at)
     source_id_prefix = {"source_reflection": "reflection",
                         "source_retraction": "retraction"}.get(source_type, "correction")
     metadata: dict[str, object] = {
@@ -818,7 +897,8 @@ def create_linked_source(
         metadata["corrects"] = target_record["source_id"]
         metadata["corrects_path"] = rel(target_path)
         metadata["correction_kind"] = correction_kind or "other"
-    write_text(path, f"{format_frontmatter(metadata)}\n\n{payload}")
+    if not path.exists():
+        write_text(path, f"{format_frontmatter(metadata)}\n\n{payload}")
     register_source(path)
     if source_type == "source_correction":
         # v103: a corrected fact invalidates the target's derived
@@ -834,6 +914,240 @@ def create_linked_source(
         except Exception as exc:  # never block the correction itself
             print(f"warn: could not mark classification stale: {exc}", file=sys.stderr)
     return path
+
+
+def _unique_path(directory: Path, title: str, captured_at: str) -> Path:
+    """Historical human-readable path helper retained for reflections."""
+    day = captured_at[:10] if captured_at else datetime.now(timezone.utc).date().isoformat()
+    base = f"{day}-{slugify(title)}"
+    path = directory / f"{base}.md"
+    if not path.exists():
+        return path
+    index = 2
+    while True:
+        candidate = directory / f"{base}-{index}.md"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def _replace_path_values(value: object, replacements: dict[str, str]) -> object:
+    """Replace exact source-path values in a JSON-shaped state document."""
+    if isinstance(value, str):
+        return replacements.get(value, value)
+    if isinstance(value, list):
+        return [_replace_path_values(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {
+            replacements.get(str(key), str(key)): _replace_path_values(item, replacements)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _assert_migration_path_safe(path: Path, *, label: str) -> None:
+    """Reject symlinks and paths resolving outside this vault before mutation."""
+    lexical_root = REPO_DIR.absolute()
+    root = lexical_root.resolve()
+    try:
+        path.resolve(strict=False).relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"unsafe {label} outside vault: {path}") from exc
+    try:
+        cursor = lexical_root / path.absolute().relative_to(lexical_root)
+    except ValueError as exc:
+        raise ValueError(f"unsafe {label} outside vault: {path}") from exc
+    while cursor != lexical_root:
+        if cursor.is_symlink():
+            raise ValueError(f"unsafe symlinked {label}: {rel(cursor)}")
+        if cursor.parent == cursor:
+            raise ValueError(f"unsafe {label}: {path}")
+        cursor = cursor.parent
+
+
+def _replace_path_text(text: str, replacements: dict[str, str]) -> str:
+    """Rewrite exact, path-bearing markdown references without touching sources."""
+    for old, new in replacements.items():
+        text = text.replace(old, new)
+    return text
+
+
+def _repair_plan() -> tuple[list[dict[str, object]], dict[Path, object], list[tuple[Path, Path]]]:
+    """Preflight every rename and every managed reference rewrite."""
+    _assert_migration_path_safe(CORRECTION_SOURCES_DIR, label="corrections directory")
+    if not CORRECTION_SOURCES_DIR.exists():
+        return [], {}, []
+    renames: list[dict[str, object]] = []
+    replacements: dict[str, str] = {}
+    for old_path in sorted(CORRECTION_SOURCES_DIR.glob("*.md")):
+        _assert_migration_path_safe(old_path, label="correction/retraction source")
+        old_text = old_path.read_text(encoding="utf-8", errors="replace")
+        metadata, payload = split_frontmatter(old_text)
+        source_type = str(metadata.get("type", ""))
+        if source_type not in LINKED_SOURCE_TYPES:
+            continue
+        target_id = _linked_source_target_id(metadata)
+        if not target_id:
+            raise ValueError(f"cannot repair {rel(old_path)}: missing correction/retraction target")
+        new_path = _linked_source_path(
+            CORRECTION_SOURCES_DIR, target_id, source_type, payload,
+            str(metadata.get("captured_at", "")),
+        )
+        if new_path == old_path:
+            continue
+        _assert_migration_path_safe(new_path, label="correction/retraction destination")
+        if new_path.exists():
+            raise ValueError(f"cannot repair {rel(old_path)}: destination already exists: {rel(new_path)}")
+        new_metadata = dict(metadata)
+        new_metadata["source_path"] = rel(new_path)
+        renames.append({
+            "old": old_path,
+            "new": new_path,
+            "old_text": old_text,
+            "new_text": f"{format_frontmatter(new_metadata)}\n\n{payload.lstrip()}",
+        })
+        replacements[rel(old_path)] = rel(new_path)
+
+    destinations = [item["new"] for item in renames]
+    if len(destinations) != len(set(destinations)):
+        raise ValueError("cannot repair linked-source filenames: generated destination collision")
+
+    json_updates: dict[Path, object] = {}
+    state_dir = REPO_DIR / "state"
+    if replacements:
+        _assert_migration_path_safe(state_dir, label="state directory")
+    if replacements and state_dir.exists():
+        for json_path in sorted(state_dir.rglob("*.json")):
+            _assert_migration_path_safe(json_path, label="state JSON")
+            try:
+                current = json.loads(json_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"cannot repair while state JSON is invalid: {rel(json_path)}") from exc
+            updated = _replace_path_values(current, replacements)
+            if updated != current:
+                json_updates[json_path] = updated
+
+    # `wiki/` and state reports are generated surfaces, not source truth. Keep
+    # their path-bearing markdown current in the same transaction so a repair
+    # cannot leave stale visible citations before the next compile rebuild.
+    markdown_updates: dict[Path, str] = {}
+    if replacements:
+        for directory, label in ((REPO_DIR / "wiki", "wiki directory"), (state_dir, "state directory")):
+            _assert_migration_path_safe(directory, label=label)
+            if not directory.exists():
+                continue
+            for markdown_path in sorted(directory.rglob("*.md")):
+                _assert_migration_path_safe(markdown_path, label="generated markdown")
+                original = markdown_path.read_text(encoding="utf-8", errors="replace")
+                updated = _replace_path_text(original, replacements)
+                if updated != original:
+                    markdown_updates[markdown_path] = updated
+
+    classification_moves: list[tuple[Path, Path]] = []
+    if renames:
+        import classify_story  # noqa: PLC0415
+
+        for item in renames:
+            old_path, new_path = item["old"], item["new"]
+            for old_classification, new_classification in zip(
+                classify_story.classification_paths(old_path),
+                classify_story.classification_paths(new_path),
+            ):
+                _assert_migration_path_safe(old_classification, label="classification")
+                _assert_migration_path_safe(new_classification, label="classification destination")
+                if old_classification.exists() and old_classification != new_classification:
+                    if new_classification.exists():
+                        raise ValueError(
+                            f"cannot repair {rel(old_path)}: classification destination exists: "
+                            f"{rel(new_classification)}"
+                        )
+                    classification_moves.append((old_classification, new_classification))
+                    # The JSON scan above found this classification under its
+                    # old filename. Apply its source_path rewrite only after
+                    # the file moves, never recreate the old filename.
+                    if old_classification in json_updates:
+                        json_updates[new_classification] = json_updates.pop(old_classification)
+    class_destinations = [new for _old, new in classification_moves]
+    if len(class_destinations) != len(set(class_destinations)):
+        raise ValueError("cannot repair linked-source filenames: classification destination collision")
+    # Markdown updates share the transaction's atomic file-replace/rollback
+    # machinery; keep the public plan compact by attaching them to JSON updates.
+    for markdown_path, updated in markdown_updates.items():
+        json_updates[markdown_path] = updated
+    return renames, json_updates, classification_moves
+
+
+def repair_linked_source_filenames(*, dry_run: bool = False) -> list[tuple[str, str]]:
+    """Migrate legacy correction/retraction filenames without losing references.
+
+    The operation is idempotent. It preflights the full transaction and rolls
+    all touched paths back if a later filesystem write fails.
+    """
+    renames, json_updates, classification_moves = _repair_plan()
+    result = [(rel(item["old"]), rel(item["new"])) for item in renames]
+    if dry_run or not renames:
+        return result
+
+    json_backups = {
+        path: path.read_text(encoding="utf-8") if path.exists() else None
+        for path in json_updates
+    }
+    classification_backups = {
+        old_path: old_path.read_text(encoding="utf-8") for old_path, _new_path in classification_moves
+    }
+    completed_renames: list[dict[str, object]] = []
+    completed_classifications: list[tuple[Path, Path]] = []
+    try:
+        for item in renames:
+            old_path, new_path = item["old"], item["new"]
+            completed_renames.append(item)
+            write_text(old_path, str(item["new_text"]))
+            old_path.replace(new_path)
+        for old_path, new_path in classification_moves:
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            old_path.replace(new_path)
+            completed_classifications.append((old_path, new_path))
+        for state_path, updated in json_updates.items():
+            if state_path.suffix == ".json":
+                write_json(state_path, updated)
+            else:
+                write_text(state_path, str(updated))
+    except Exception:
+        for old_path, new_path in reversed(completed_classifications):
+            if new_path.exists():
+                new_path.replace(old_path)
+            write_text(old_path, classification_backups[old_path])
+        for item in reversed(completed_renames):
+            old_path, new_path = item["old"], item["new"]
+            if new_path.exists():
+                new_path.replace(old_path)
+            write_text(old_path, str(item["old_text"]))
+        for json_path, old_text in json_backups.items():
+            if old_text is None:
+                json_path.unlink(missing_ok=True)
+            else:
+                write_text(json_path, old_text)
+        raise
+    return result
+
+
+def cmd_repair_linked_filenames(args: argparse.Namespace) -> int:
+    try:
+        repaired = repair_linked_source_filenames(dry_run=args.dry_run)
+    except (OSError, ValueError, RuntimeError) as exc:
+        print(f"Error: linked-source filename repair failed: {exc}", file=sys.stderr)
+        return 1
+    if not repaired:
+        print("No correction/retraction filenames need repair.")
+        return 0
+    prefix = "[dry-run] would rename" if args.dry_run else "renamed"
+    for old, new in repaired:
+        print(f"{prefix}: {old} -> {new}")
+    if args.dry_run:
+        print("[dry-run] no files or state indexes were changed.")
+    else:
+        print(f"✓ Repaired {len(repaired)} correction/retraction filename(s) and references.")
+    return 0
 
 
 def cmd_scan(args: argparse.Namespace) -> int:
@@ -995,6 +1309,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--rebuild", action="store_true")
     p.add_argument("--json", action="store_true")
     p.set_defaults(func=cmd_manifest)
+
+    p = sub.add_parser(
+        "repair-linked-filenames",
+        help="Migrate legacy correction/retraction filenames and every state reference",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Preview the transaction without writing")
+    p.set_defaults(func=cmd_repair_linked_filenames)
 
     p = sub.add_parser("lint", help="Lint source integrity and write repair findings")
     p.add_argument("--fix", action="store_true", help="Apply safe metadata/manifest fixes")

--- a/system/source_integrity.py
+++ b/system/source_integrity.py
@@ -750,6 +750,12 @@ def _bounded_slug(value: str, maximum: int) -> str:
     return label[:maximum].rstrip("-") or "source"
 
 
+def _linked_source_day(captured_at: str) -> str:
+    """Return a filename-safe ISO day even when repairing malformed metadata."""
+    day = (captured_at or "")[:10]
+    return day if re.fullmatch(r"\d{4}-\d{2}-\d{2}", day) else "1970-01-01"
+
+
 def linked_source_stem(
     target_id: str, source_type: str, payload: str, captured_at: str
 ) -> str:
@@ -761,7 +767,7 @@ def linked_source_stem(
     id, kind, and payload, keeping distinct corrections collision-safe even
     when their visible labels truncate to the same text.
     """
-    day = (captured_at or now_utc())[:10]
+    day = _linked_source_day(captured_at or now_utc())
     kind = {"source_correction": "correction", "source_retraction": "retraction"}.get(
         source_type, "linked"
     )
@@ -1012,7 +1018,7 @@ def _repair_plan() -> tuple[list[dict[str, object]], dict[Path, object], list[tu
         raise ValueError("cannot repair linked-source filenames: generated destination collision")
 
     json_updates: dict[Path, object] = {}
-    state_dir = REPO_DIR / "state"
+    state_dir = SOURCE_MANIFEST_FILE.parent
     if replacements:
         _assert_migration_path_safe(state_dir, label="state directory")
     if replacements and state_dir.exists():
@@ -1031,7 +1037,7 @@ def _repair_plan() -> tuple[list[dict[str, object]], dict[Path, object], list[tu
     # cannot leave stale visible citations before the next compile rebuild.
     markdown_updates: dict[Path, str] = {}
     if replacements:
-        for directory, label in ((REPO_DIR / "wiki", "wiki directory"), (state_dir, "state directory")):
+        for directory, label in ((WIKI_DIR, "wiki directory"), (state_dir, "state directory")):
             _assert_migration_path_safe(directory, label=label)
             if not directory.exists():
                 continue

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 122,
+  "version": 123,
   "released": "2026-08-06",
-  "changelog": "v122: keyless agent mode no longer requires the optional Anthropic SDK to be installed. AI status now reports keyless cleanly when the SDK is absent, so weekly/monthly agent-task workflows can continue instead of the process exiting during provider discovery.",
+  "changelog": "v123: correction and retraction filenames are now short, portable identifiers instead of embedding full question text. New files use a bounded target-id label plus a collision-safe digest, and `source-filenames-repair` safely previews or migrates legacy names along with their manifest, classification, and generated-reference indexes before a hosted-vault import.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -120,6 +120,7 @@
     "tests/test_v90_aj_regression.py",
     "tests/test_v92_agent_mode.py",
     "tests/test_v93_stem_cap.py",
+    "tests/test_v119_bounded_correction_filenames.py",
     "tests/test_v95_opinion_essay.py",
     "tests/test_v96_opinion_loop.py",
     "tests/test_v97_theme_roster.py",

--- a/tests/test_lifehug_wrapper.py
+++ b/tests/test_lifehug_wrapper.py
@@ -47,6 +47,7 @@ class LifehugWrapperTests(unittest.TestCase):
             ["compile", "--dry-run"],
             ["source-scan"],
             ["source-manifest", "--rebuild"],
+            ["source-filenames-repair", "--dry-run"],
             ["source-lint", "--fix", "--no-write-findings"],
             ["source-findings"],
             ["correct-source", "answers/A1.md", "--kind", "factual"],

--- a/tests/test_v119_bounded_correction_filenames.py
+++ b/tests/test_v119_bounded_correction_filenames.py
@@ -13,6 +13,11 @@ ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 
+# Keep the canonical shared module installed while this file loads isolated
+# copies. Older correction tests intentionally verify that private test loads
+# restore, rather than remove, the process-wide source_integrity module.
+import source_integrity as _canonical_source_integrity  # noqa: E402,F401
+
 
 def load(name):
     spec = importlib.util.spec_from_file_location(name, SYSTEM / f"{name}.py")

--- a/tests/test_v119_bounded_correction_filenames.py
+++ b/tests/test_v119_bounded_correction_filenames.py
@@ -54,16 +54,17 @@ class BoundedLinkedFilenameTests(unittest.TestCase):
         )
         self.originals = (
             self.src.REPO_DIR, self.src.CORRECTION_SOURCES_DIR,
-            self.src.SOURCE_MANIFEST_FILE, self.src.ANSWERS_DIR,
+            self.src.SOURCE_MANIFEST_FILE, self.src.ANSWERS_DIR, self.src.WIKI_DIR,
         )
         self.src.REPO_DIR = self.root
         self.src.CORRECTION_SOURCES_DIR = self.corrections
         self.src.SOURCE_MANIFEST_FILE = self.root / "state" / "source_manifest.json"
         self.src.ANSWERS_DIR = self.answers
+        self.src.WIKI_DIR = self.root / "wiki"
 
     def tearDown(self):
         (self.src.REPO_DIR, self.src.CORRECTION_SOURCES_DIR,
-         self.src.SOURCE_MANIFEST_FILE, self.src.ANSWERS_DIR) = self.originals
+         self.src.SOURCE_MANIFEST_FILE, self.src.ANSWERS_DIR, self.src.WIKI_DIR) = self.originals
         self.tmp.cleanup()
 
     def test_new_names_are_bounded_ascii_and_never_embed_question_text(self):
@@ -86,6 +87,13 @@ class BoundedLinkedFilenameTests(unittest.TestCase):
             self.corrections, "answer:A1", "source_correction", "# Correction\n\nTwo\n", "2026-08-06T00:00:00Z"
         )
         self.assertNotEqual(one, two)
+
+    def test_malformed_capture_time_cannot_escape_the_corrections_directory(self):
+        path = self.src._linked_source_path(
+            self.corrections, "answer:A1", "source_correction", "# Correction\n\nOne\n", "../../escape"
+        )
+        self.assertEqual(path.resolve().parent, self.corrections.resolve())
+        self.assertRegex(path.name, r"^1970-01-01-correction-answer-a1-[0-9a-f]+\.md$")
 
     def test_hash_prefix_collision_extends_deterministically_without_counter_suffix(self):
         payload = "# Correction\n\nOne\n"
@@ -130,6 +138,7 @@ class BoundedLinkedFilenameTests(unittest.TestCase):
 
     def test_repair_is_dry_run_idempotent_and_updates_indexes(self):
         old, old_rel = self._legacy_retraction()
+        target_before = self.target.read_text(encoding="utf-8")
         self.src.SOURCE_MANIFEST_FILE.parent.mkdir(parents=True)
         self.src.SOURCE_MANIFEST_FILE.write_text(
             json.dumps({"version": 1, "sources": {old_rel: {"source_id": "retraction:legacy-long-name"}}}),
@@ -171,6 +180,7 @@ class BoundedLinkedFilenameTests(unittest.TestCase):
             self.assertTrue(new_classification.exists())
             self.assertFalse(old_classification.exists())
             self.assertEqual(json.loads(new_classification.read_text(encoding="utf-8"))["source_path"], repaired[0][1])
+            self.assertEqual(self.target.read_text(encoding="utf-8"), target_before)
             self.assertEqual(self.src.repair_linked_source_filenames(), [])
         finally:
             classifier.REPO_DIR, classifier.CLASSIFICATIONS_DIR = classifier_original

--- a/tests/test_v119_bounded_correction_filenames.py
+++ b/tests/test_v119_bounded_correction_filenames.py
@@ -1,0 +1,212 @@
+"""v119 — bounded, portable correction/retraction filenames (issue #50)."""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSTEM = ROOT / "system"
+sys.path.insert(0, str(SYSTEM))
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, SYSTEM / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    original = sys.modules.get(name)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        if original is not None:
+            sys.modules[name] = original
+        else:
+            sys.modules.pop(name, None)
+    return mod
+
+
+class BoundedLinkedFilenameTests(unittest.TestCase):
+    def setUp(self):
+        self.src = load("source_integrity")
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.answers = self.root / "answers"
+        self.corrections = self.root / "sources" / "corrections"
+        self.answers.mkdir(parents=True)
+        self.corrections.mkdir(parents=True)
+        self.target = self.answers / "A1.md"
+        self.target.write_text(
+            "---\n"
+            'title: "Question A1: café / ../../ keep this out of filenames"\n'
+            'source_id: "answer:A1"\n'
+            'type: "prompted_answer"\n'
+            "---\n\n# Question A1\n\nAnswer.\n",
+            encoding="utf-8",
+        )
+        self.originals = (
+            self.src.REPO_DIR, self.src.CORRECTION_SOURCES_DIR,
+            self.src.SOURCE_MANIFEST_FILE, self.src.ANSWERS_DIR,
+        )
+        self.src.REPO_DIR = self.root
+        self.src.CORRECTION_SOURCES_DIR = self.corrections
+        self.src.SOURCE_MANIFEST_FILE = self.root / "state" / "source_manifest.json"
+        self.src.ANSWERS_DIR = self.answers
+
+    def tearDown(self):
+        (self.src.REPO_DIR, self.src.CORRECTION_SOURCES_DIR,
+         self.src.SOURCE_MANIFEST_FILE, self.src.ANSWERS_DIR) = self.originals
+        self.tmp.cleanup()
+
+    def test_new_names_are_bounded_ascii_and_never_embed_question_text(self):
+        path = self.src.create_linked_source(
+            "answers/A1.md", "It happened in 2004.", source_type="source_correction",
+            title=None, source_medium="test", correction_kind="factual",
+        )
+        self.assertLessEqual(len(path.name.encode("utf-8")), self.src.MAX_LINKED_SOURCE_FILENAME_BYTES)
+        self.assertRegex(path.name, r"^\d{4}-\d{2}-\d{2}-correction-answer-a1-[0-9a-f]+\.md$")
+        self.assertNotIn("café", path.name)
+        self.assertNotIn("keep-this", path.name)
+        self.assertNotIn("..", path.name)
+        self.assertLess(len((Path("sources/corrections") / path.name).as_posix()), 240)
+
+    def test_same_visible_target_label_stays_unique_by_payload_hash(self):
+        one = self.src._linked_source_path(
+            self.corrections, "answer:A1", "source_correction", "# Correction\n\nOne\n", "2026-08-06T00:00:00Z"
+        )
+        two = self.src._linked_source_path(
+            self.corrections, "answer:A1", "source_correction", "# Correction\n\nTwo\n", "2026-08-06T00:00:00Z"
+        )
+        self.assertNotEqual(one, two)
+
+    def test_hash_prefix_collision_extends_deterministically_without_counter_suffix(self):
+        payload = "# Correction\n\nOne\n"
+        first = self.src._linked_source_path(
+            self.corrections, "answer:A1", "source_correction", payload, "2026-08-06T00:00:00Z"
+        )
+        first.write_text("---\ntype: source_retraction\nretracts: answer:other\n---\n\nother\n", encoding="utf-8")
+        resolved = self.src._linked_source_path(
+            self.corrections, "answer:A1", "source_correction", payload, "2026-08-06T00:00:00Z"
+        )
+        self.assertNotEqual(first, resolved)
+        self.assertGreater(len(resolved.stem.rsplit("-", 1)[1]), self.src.LINKED_SOURCE_HASH_LENGTH)
+        self.assertNotRegex(resolved.name, r"-\d+\.md$")
+
+    def _legacy_retraction(self):
+        old = self.corrections / ("2026-01-01-retraction-for-" + "very-long-question-" * 8 + "é.md")
+        payload = "# Retraction for a very long question\n\nSynthetic reason only.\n"
+        old.write_text(
+            "---\n"
+            'title: "Retraction for a synthetic traversal-like ../../ question"\n'
+            'type: "source_retraction"\n'
+            'source_id: "retraction:legacy-long-name"\n'
+            'captured_at: "2026-01-01T00:00:00Z"\n'
+            'source_path: "sources/corrections/placeholder.md"\n'
+            'retracts: "answer:A1"\n'
+            'retracts_path: "answers/A1.md"\n'
+            "---\n\n" + payload,
+            encoding="utf-8",
+        )
+        old_rel = self.src.rel(old)
+        text = old.read_text(encoding="utf-8").replace("placeholder.md", old.name)
+        old.write_text(text, encoding="utf-8")
+        return old, old_rel
+
+    def _patch_classifier_root(self):
+        import classify_story
+
+        original = (classify_story.REPO_DIR, classify_story.CLASSIFICATIONS_DIR)
+        classify_story.REPO_DIR = self.root
+        classify_story.CLASSIFICATIONS_DIR = self.root / "state" / "classifications"
+        return classify_story, original
+
+    def test_repair_is_dry_run_idempotent_and_updates_indexes(self):
+        old, old_rel = self._legacy_retraction()
+        self.src.SOURCE_MANIFEST_FILE.parent.mkdir(parents=True)
+        self.src.SOURCE_MANIFEST_FILE.write_text(
+            json.dumps({"version": 1, "sources": {old_rel: {"source_id": "retraction:legacy-long-name"}}}),
+            encoding="utf-8",
+        )
+        placements = self.root / "state" / "timeline_placements.json"
+        placements.write_text(json.dumps({"pins": [{"correction": old_rel}]}), encoding="utf-8")
+        wiki = self.root / "wiki" / "index.md"
+        wiki.parent.mkdir(parents=True)
+        wiki.write_text(f"---\nsources:\n  - {old_rel}\n---\n\n{old_rel}\n", encoding="utf-8")
+        report = self.root / "state" / "reports" / "weekly.md"
+        report.parent.mkdir(parents=True)
+        report.write_text(f"Generated reference: {old_rel}\n", encoding="utf-8")
+        classifier, classifier_original = self._patch_classifier_root()
+        try:
+            old_classification = classifier.classification_path(old)
+            old_classification.parent.mkdir(parents=True)
+            old_classification.write_text(json.dumps({"source_path": old_rel}), encoding="utf-8")
+            preview = self.src.repair_linked_source_filenames(dry_run=True)
+            self.assertEqual(len(preview), 1)
+            self.assertTrue(old.exists())
+            repaired = self.src.repair_linked_source_filenames()
+            self.assertEqual(preview, repaired)
+            new = self.root / repaired[0][1]
+            self.assertFalse(old.exists())
+            self.assertTrue(new.exists())
+            self.assertLessEqual(len(new.name), self.src.MAX_LINKED_SOURCE_FILENAME_BYTES)
+            metadata, _payload = self.src.split_frontmatter(new.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["source_path"], repaired[0][1])
+            self.assertEqual(metadata["source_id"], "retraction:legacy-long-name")
+            manifest = json.loads(self.src.SOURCE_MANIFEST_FILE.read_text(encoding="utf-8"))
+            self.assertIn(repaired[0][1], manifest["sources"])
+            self.assertNotIn(old_rel, manifest["sources"])
+            self.assertEqual(json.loads(placements.read_text(encoding="utf-8"))["pins"][0]["correction"], repaired[0][1])
+            self.assertNotIn(old_rel, wiki.read_text(encoding="utf-8"))
+            self.assertIn(repaired[0][1], wiki.read_text(encoding="utf-8"))
+            self.assertIn(repaired[0][1], report.read_text(encoding="utf-8"))
+            new_classification = classifier.classification_path(new)
+            self.assertTrue(new_classification.exists())
+            self.assertFalse(old_classification.exists())
+            self.assertEqual(json.loads(new_classification.read_text(encoding="utf-8"))["source_path"], repaired[0][1])
+            self.assertEqual(self.src.repair_linked_source_filenames(), [])
+        finally:
+            classifier.REPO_DIR, classifier.CLASSIFICATIONS_DIR = classifier_original
+
+    def test_repair_rolls_back_if_a_state_write_fails(self):
+        old, old_rel = self._legacy_retraction()
+        state = self.root / "state" / "timeline_placements.json"
+        state.parent.mkdir(parents=True)
+        original_state = json.dumps({"pins": [{"correction": old_rel}]})
+        state.write_text(original_state, encoding="utf-8")
+        original_source = old.read_text(encoding="utf-8")
+        classifier, classifier_original = self._patch_classifier_root()
+        try:
+            with mock.patch.object(self.src, "write_json", side_effect=OSError("synthetic disk failure")):
+                with self.assertRaises(OSError):
+                    self.src.repair_linked_source_filenames()
+        finally:
+            classifier.REPO_DIR, classifier.CLASSIFICATIONS_DIR = classifier_original
+        self.assertTrue(old.exists())
+        self.assertEqual(old.read_text(encoding="utf-8"), original_source)
+        self.assertEqual(state.read_text(encoding="utf-8"), original_state)
+        self.assertEqual(len(list(self.corrections.glob("*.md"))), 1)
+
+    def test_repair_refuses_symlinked_source_or_corrections_directory(self):
+        old, _old_rel = self._legacy_retraction()
+        external = self.root / "external.md"
+        external.write_text("do not follow", encoding="utf-8")
+        old.unlink()
+        old.symlink_to(external)
+        with self.assertRaisesRegex(ValueError, "symlinked correction/retraction source"):
+            self.src.repair_linked_source_filenames()
+        self.assertEqual(external.read_text(encoding="utf-8"), "do not follow")
+
+        old.unlink()
+        self.corrections.rmdir()
+        external_dir = self.root / "external-corrections"
+        external_dir.mkdir()
+        self.corrections.symlink_to(external_dir, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "symlinked corrections directory"):
+            self.src.repair_linked_source_filenames()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v119_bounded_correction_filenames.py
+++ b/tests/test_v119_bounded_correction_filenames.py
@@ -95,6 +95,24 @@ class BoundedLinkedFilenameTests(unittest.TestCase):
         self.assertEqual(path.resolve().parent, self.corrections.resolve())
         self.assertRegex(path.name, r"^1970-01-01-correction-answer-a1-[0-9a-f]+\.md$")
 
+    def test_impossible_capture_dates_use_the_deterministic_fallback(self):
+        payload = "# Correction\n\nOne\n"
+        for captured_at in ("2026-99-99T00:00:00Z", "2026-02-30T00:00:00Z"):
+            path = self.src._linked_source_path(
+                self.corrections, "answer:A1", "source_correction", payload, captured_at
+            )
+            self.assertRegex(path.name, r"^1970-01-01-correction-answer-a1-[0-9a-f]+\.md$")
+
+    def test_valid_capture_date_is_preserved_in_linked_source_name(self):
+        path = self.src._linked_source_path(
+            self.corrections,
+            "answer:A1",
+            "source_correction",
+            "# Correction\n\nOne\n",
+            "2026-02-28T23:59:59Z",
+        )
+        self.assertRegex(path.name, r"^2026-02-28-correction-answer-a1-[0-9a-f]+\.md$")
+
     def test_hash_prefix_collision_extends_deterministically_without_counter_suffix(self):
         payload = "# Correction\n\nOne\n"
         first = self.src._linked_source_path(


### PR DESCRIPTION
Closes #50

## What changed
- New corrections/retractions use `YYYY-MM-DD-<kind>-<target-id-label>-<hash>.md`: bounded ASCII, no question prose, and a full-payload hash for collision-safe uniqueness.
- Added `python3 system/lifehug.py source-filenames-repair [--dry-run]`, which preflights then updates source frontmatter, manifest/state references, classification paths, and generated wiki/report references.
- The repair rejects symlinks and paths escaping the vault. It rolls back in-process failures, but deliberately does not claim multi-file atomicity across forced process termination/power loss; recover the interrupted vault first, then rerun.
- Bumped framework version to v119 and documented the migration in the source contract, README, CLAUDE instructions, and maintenance skill.

## Evidence
- `python3 -m compileall -q system tests`
- `python3 -m unittest tests/test_v119_bounded_correction_filenames.py tests/test_lifehug_wrapper.py` (20 tests)
- legacy corrections/retractions/source-integrity regression suite (36 tests)
- `python3 system/lifehug.py source-filenames-repair --dry-run`
- `python3 system/lifehug.py doctor`
- `git diff --check`

## Cross-medium parity
This is an OSS source-contract repair for the already-known hosted vault-import blocker, rather than a new user-facing platform capability; no twin issue is needed.

## Merge-train note
`system/version.json` is intentionally provisional while the current OSS merge train is open. Rebase onto current `main`, resolve that version/changelog conflict, and rerun the gates before merge.

🤖 Generated with GPT-5.6 Terra via Codex