### PR TITLE
feat: run installed framework against data-only vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,11 @@ schemas, a vault containing `system/`, symlinks, or other special files fail
 before mutation. `state/hosted.json` has no stand-down meaning in the open-source
 runtime.
 
+This applies equally to a durable path assembled from the selected vault root
+at runtime (for example, a user-selected source path): those descendants retain
+the same no-follow authority after process binding rather than falling back to
+ordinary `pathlib` I/O.
+
 Integrations should consume the normalized contract rather than infer paths:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The wiki is a **graph of your life**, and these are the standard terms used thro
 - [The three clocks](#the-three-clocks-scheduling)
 - [Every script, holistically](#every-script-holistically)
 - [Getting started](#getting-started)
+- [Framework and vault layouts](#framework-and-vault-layouts)
 - [Key commands](#key-commands)
 - [Repo layout](#repo-layout)
 - [Updating](#updating) · [Methodology](#methodology)
@@ -145,12 +146,12 @@ No ratings, no streaks, no friction. **The answer itself is the only feedback th
 | **Focus** | Anything you're building toward — a person, a book, a theme, your life's work. A Focus = an *objective* + a *tier* (how deep). | `state/roadmap.json` |
 | **Tier** | How much depth a Focus needs: `basic` ≈ a blog post (~8 answers), `standard` ≈ an essay / a person (~20), `extreme` ≈ a book / life's work (~50+). | — |
 | **Roadmap** | The full set of Focuses with targets and caps. *Derived* from the question bank — you never hand-edit it. | `state/roadmap.json` |
-| **Question bank** | Every question ever created, answered or not, grouped by category (A–E generic, F–J projects, K+ people). Only grows. | `system/question-bank.md` |
+| **Question bank** | Every question ever created, answered or not, grouped by category (A–E generic, F–J projects, K+ people). Only grows. | `system/question-bank.md` embedded; `question-bank.md` external |
 | **Neighborhood** | A cluster of 6–12 questions around one topic, arranged on a narrative **arc**, aimed at a deliverable. It tracks generated, promoted, and answered readiness separately; only answered material makes it draft-ready. | `state/neighborhoods.json` |
 | **Candidate** | A proposed question waiting in a review buffer. Becomes a real question only when *promoted* into the bank. | `state/question_candidates.json` |
 | **Wiki** | The cross-linked, owner-only encyclopedia of your life, synthesized from your answers. | `wiki/` |
 | **Artifact** | The product payoff: a produced letter, post, caption, tweet, chapter, speech, or other deliverable. Drafts live in `outputs/`; approved finals/context can be promoted as sources. | `outputs/`, `sources/artifacts/` |
-| **Pass** | A depth cycle over the whole story: skeleton → depth → connections → polish. Each pass deepens what the last one outlined. | `system/rotation.json` |
+| **Pass** | A depth cycle over the whole story: skeleton → depth → connections → polish. Each pass deepens what the last one outlined. | `system/rotation.json` embedded; `state/rotation.json` external |
 
 The key mental model: a **Focus** is the unit of intent. Everything — a person, a memoir, a recurring theme, a relationship, a place, a company story — is a Focus with a tier and an objective.
 
@@ -515,6 +516,40 @@ Clone, run `./setup.sh`, and open the repo with any AI that reads `CLAUDE.md` (C
 0 9 * * * cd /path/to/lifehug && system/daily_question.sh
 ```
 
+### Framework and vault layouts
+
+The normal clone remains the zero-configuration **embedded layout**: executable framework files and private vault data share one checkout. Existing commands and paths remain unchanged.
+
+```text
+lifehug/
+├── system/                 # framework code + embedded question/rotation/coverage files
+├── templates/              # framework assets
+├── answers/ sources/ wiki/ outputs/
+└── state/                  # durable vault state
+```
+
+An installed framework can instead operate on a separate **data-only vault**. The vault must not contain `system/` or framework templates. Its minimum shape is the versioned contract in [`system/vault_contract.json`](system/vault_contract.json):
+
+```text
+my-private-vault/
+├── question-bank.md
+└── state/
+    ├── rotation.json       # schema version 1
+    └── coverage.json       # schema version 1
+```
+
+Optional `answers/`, `sources/`, `wiki/`, `outputs/`, profile/config files, and additional `state/` records are created or read under that vault as their workflows require. Code, templates, mission text, and connector implementations always stay in the framework install.
+
+Select the vault for one command with the global flag (before the subcommand), or for a process/scheduler with the environment variable:
+
+```bash
+python3 /opt/lifehug/system/lifehug.py --vault-root ~/Documents/my-private-vault status
+LIFEHUG_VAULT_ROOT=~/Documents/my-private-vault \
+  python3 /opt/lifehug/system/lifehug.py compile --no-ai
+```
+
+Resolution is explicit `--vault-root`, then `LIFEHUG_VAULT_ROOT`, then the embedded framework checkout. Selection is process-scoped; start a new CLI invocation to switch vaults. Missing minimum files, unsupported state schemas, a vault containing `system/`, and symlinked vault roots or required paths fail before mutation. `state/hosted.json` has no stand-down meaning in the open-source runtime.
+
 ---
 
 ## Key commands
@@ -583,6 +618,8 @@ python3 system/lifehug.py --help
 ---
 
 ## Repo layout
+
+The tree below is the embedded layout. See [Framework and vault layouts](#framework-and-vault-layouts) for a separate data-only vault.
 
 ```
 lifehug/

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Lifehug is **script-first**: the Python scripts *are* the system, and `lifehug.p
 | **`lifehug.py`** | The CLI dispatcher (~40 subcommands). A thin router — it just shells out to the focused scripts below with the right working directory. This is the canonical interface; prefer it over calling scripts directly. |
 | **`lifehug_core.py`** | Shared library. Parses the question bank, computes coverage, defines all file paths and the question-ID format, and does atomic JSON/text writes. Every other script imports it. |
 | **`jobs.py`** + **`job_execute.py`** | Durable metadata-only queue and single-writer worker. Typed payloads stay in private sidecars and cross the child boundary through stdin, never process argv. Explicit schedule/provider identities deduplicate; ordinary repeated actions create fresh jobs. |
-| **`vault_paths.py`** | One authority for keeping installed framework assets separate from the active user vault (`--vault-root` → `LIFEHUG_VAULT_ROOT` → embedded layout), with fail-closed path containment and symlink checks. |
+| **`vault_paths.py`** | One authority for keeping installed framework assets separate from the active user vault (`--vault-root` → `LIFEHUG_VAULT_ROOT` → embedded layout), with process binding, no-follow file operations, deterministic tree preflight, and an exportable versioned contract. |
 | **`daily_question.sh`** | The cron entrypoint. Commits pending data, compiles the wiki, asks `ask.py` for today's question, sends + pins it on Telegram, then confirms it as delivered. Handles pass-completion prompts too. |
 | **`weekly_maintenance.sh`** | The weekly self-improvement entrypoint. Compiles offline, lints source integrity, applies safe metadata/manifest fixes only when needed, classifies a capped batch of unclassified sources, updates the quality profile, **auto-promotes the highest-scoring candidates into the bank** (dynamic cap based on bank fullness), builds the next queue, scans for gaps, reports progress, then commits and sends a Telegram summary. Dry-run previews the same candidate promotion gate without writing. |
 | **`monthly_research.sh`** | The monthly growth entrypoint. Compiles with AI if available, detects thin areas, opens a small capped set of new research neighborhoods, refreshes self-knowledge candidates, recommends new Focuses, refreshes entity rosters, reports progress, then commits real changes. |
@@ -540,15 +540,37 @@ my-private-vault/
 
 Optional `answers/`, `sources/`, `wiki/`, `outputs/`, profile/config files, and additional `state/` records are created or read under that vault as their workflows require. Code, templates, mission text, and connector implementations always stay in the framework install.
 
-Select the vault for one command with the global flag (before the subcommand), or for a process/scheduler with the environment variable:
+Select the vault for one command with the global flag (before or after the
+subcommand), or for a process/scheduler with the environment variable:
 
 ```bash
 python3 /opt/lifehug/system/lifehug.py --vault-root ~/Documents/my-private-vault status
+python3 /opt/lifehug/system/lifehug.py status --vault-root ~/Documents/my-private-vault
 LIFEHUG_VAULT_ROOT=~/Documents/my-private-vault \
   python3 /opt/lifehug/system/lifehug.py compile --no-ai
 ```
 
-Resolution is explicit `--vault-root`, then `LIFEHUG_VAULT_ROOT`, then the embedded framework checkout. Selection is process-scoped; start a new CLI invocation to switch vaults. Missing minimum files, unsupported state schemas, a vault containing `system/`, and symlinked vault roots or required paths fail before mutation. `state/hosted.json` has no stand-down meaning in the open-source runtime.
+Resolution is explicit `--vault-root`, then `LIFEHUG_VAULT_ROOT`, then the
+embedded framework checkout. Selection is process-scoped; start a new CLI
+invocation to switch vaults. Runtime reads and writes walk from a pinned vault
+directory without following symlinks, and reject a root, parent, or destination
+that changes during the operation. Missing minimum files, unsupported state
+schemas, a vault containing `system/`, symlinks, or other special files fail
+before mutation. `state/hosted.json` has no stand-down meaning in the open-source
+runtime.
+
+Integrations should consume the normalized contract rather than infer paths:
+
+```bash
+python3 /opt/lifehug/system/vault_paths.py contract
+python3 /opt/lifehug/system/vault_paths.py walk --vault-root ~/Documents/my-private-vault
+python3 /opt/lifehug/system/vault_paths.py classify state/rotation.json --authority vault
+```
+
+The `contract` output has a stable identity digest, explicit embedded/external
+data mappings, framework classifications, required shape, JSON validation
+policy, and special-file policy. It never includes a machine-local absolute
+path.
 
 ---
 

--- a/system/artifact.py
+++ b/system/artifact.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import compose
 from lifehug_core import (
+    AGENT_TASKS_DIR,
     ARTIFACT_SOURCES_DIR,
     OUTPUTS_DIR,
     REPO_DIR,
@@ -504,7 +505,7 @@ def cmd_revise(args: argparse.Namespace) -> int:
         # the durable browser job succeeds once it has safely emitted the
         # agent task.  The private feedback stays in gitignored task storage,
         # never in the job record or job log.
-        task_dir = REPO_DIR / "state" / "agent_tasks" / "artifact"
+        task_dir = AGENT_TASKS_DIR / "artifact"
         task_dir.mkdir(parents=True, exist_ok=True)
         task = {
             "task": "artifact-revise",

--- a/system/book.py
+++ b/system/book.py
@@ -38,10 +38,10 @@ if str(_SYSTEM_DIR) not in sys.path:
     sys.path.insert(0, str(_SYSTEM_DIR))
 
 from lifehug_core import (
+    BOOK_OFFERS_FILE,
     CLASSIFICATIONS_DIR,
     OUTPUTS_DIR,
     QUESTIONS_FILE,
-    STATE_DIR,
     WIKI_DIR,
     now_utc,
     parse_categories,
@@ -77,9 +77,6 @@ WORDS_PER_QUESTION_TARGET = 350
 
 # Persisted memory of which chapter milestones have been announced so the
 # process_answer hook can fire an offer exactly once per crossing.
-BOOK_OFFERS_FILE = STATE_DIR / "book_offers.json"
-
-
 def _verdict(saturation: float, saturated: bool = False) -> tuple[str, str]:
     if saturated:
         return "SATURATED", "well-known — maintenance"

--- a/system/classify_story.py
+++ b/system/classify_story.py
@@ -53,6 +53,7 @@ from lifehug_core import (
     read_json,
     slugify,
     write_json,
+    write_text,
 )
 
 # ── constants ─────────────────────────────────────────────────────────────────
@@ -799,7 +800,7 @@ def emit_prompts(sources: list[Path], out_dir: Path) -> int:
             continue
         stem = classify_stem(source_path)
         prompt_file = out_dir / f"{stem}.prompt.md"
-        prompt_file.write_text(build_prompt(source_path, fm, story_text), encoding="utf-8")
+        write_text(prompt_file, build_prompt(source_path, fm, story_text))
         items.append({
             "source": _relative_path(source_path),
             "prompt": prompt_file.name,

--- a/system/compile_and_commit.sh
+++ b/system/compile_and_commit.sh
@@ -11,11 +11,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="${WORKSPACE:-$(dirname "$SCRIPT_DIR")}"
+WORKSPACE="${WORKSPACE:-${LIFEHUG_VAULT_ROOT:-$(dirname "$SCRIPT_DIR")}}"
+WORKSPACE="$(python3 "$SCRIPT_DIR/vault_paths.py" root --vault-root "$WORKSPACE")" || exit 1
+export LIFEHUG_VAULT_ROOT="$WORKSPACE"
 cd "$WORKSPACE"
 export PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}"
 
-SENTINEL="state/.compile-needed"
+SENTINEL="$(python3 "$SCRIPT_DIR/vault_paths.py" data-path compile_needed --vault-root "$WORKSPACE")"
+LEARNING_FAILURES_FILE="$WORKSPACE/$(python3 "$SCRIPT_DIR/vault_paths.py" data-path learning_failures --vault-root "$WORKSPACE")"
+export LEARNING_FAILURES_FILE
 
 # Nothing to do?
 if [[ ! -f "$SENTINEL" ]]; then
@@ -34,11 +38,11 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') compile needed — worker owns vault writer l
 # Record failure for the learning loop (same pattern as daily_question.sh)
 record_learning_failure() {
   python3 - "$@" <<'PY'
-import json, sys, datetime
+import datetime, json, os, sys
 scope, action, status, detail = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4] if len(sys.argv) > 4 else ""
 entry = {"ts": datetime.datetime.now().isoformat(), "scope": scope, "action": action,
          "status": status, "detail": detail[:500]}
-with open("state/learning_failures.jsonl", "a") as f:
+with open(os.environ["LEARNING_FAILURES_FILE"], "a") as f:
     f.write(json.dumps(entry) + "\n")
 PY
 }
@@ -63,20 +67,10 @@ echo "$COMPILE_OUT"
 rm -f "$SENTINEL"
 
 # Git: add, commit, pull-rebase, push (non-fatal)
-PATHS=(
-  README.md
-  question-bank.md
-  state/rotation.json
-  state/coverage.json
-  system/question-bank.md
-  system/rotation.json
-  system/coverage.json
-  answers
-  outputs
-  sources
-  state
-  wiki
-)
+PATHS=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] && PATHS+=("$path")
+done < <(python3 "$SCRIPT_DIR/vault_paths.py" git-paths --vault-root "$WORKSPACE")
 EXISTING=()
 for path in "${PATHS[@]}"; do
   [[ -e "$path" ]] && EXISTING+=("$path")

--- a/system/compose.py
+++ b/system/compose.py
@@ -42,6 +42,7 @@ from lifehug_core import (
     TEMPLATES_DIR,
     answer_body,
     answer_id_from_filename,
+    write_text,
 )
 
 SYSTEM_DIR = Path(__file__).parent
@@ -339,7 +340,7 @@ def write_meta(path, meta):
         if v.get("feedback"):
             fb = v["feedback"].replace("'", "''")
             lines.append(f"    feedback: '{fb}'")
-    path.write_text("\n".join(lines) + "\n")
+    write_text(path, "\n".join(lines) + "\n")
 
 
 def read_meta(path):
@@ -462,7 +463,7 @@ def cmd_save(args):
     if not content.strip():
         print("Error: no content on stdin", file=sys.stderr)
         sys.exit(1)
-    out_file.write_text(content if content.endswith("\n") else content + "\n")
+    write_text(out_file, content if content.endswith("\n") else content + "\n")
 
     # Build/update meta.yaml
     meta_path = out_dir / "meta.yaml"

--- a/system/connectors/base.py
+++ b/system/connectors/base.py
@@ -29,6 +29,7 @@ from lifehug_core import (
     CONNECTORS_STATE_DIR,
     REPO_DIR,
     STATE_DIR,
+    append_text,
     now_utc,
     read_json,
     slugify,
@@ -86,10 +87,13 @@ def append_ledger(path: Path, new_entries: list[dict]) -> tuple[int, int]:
         if entry.get("message_id") and entry["message_id"] not in seen
     ]
     if added:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as handle:
-            for entry in added:
-                handle.write(json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n")
+        append_text(
+            path,
+            "".join(
+                json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n"
+                for entry in added
+            ),
+        )
     return len(added), len(existing) + len(added)
 
 

--- a/system/connectors/base.py
+++ b/system/connectors/base.py
@@ -25,7 +25,16 @@ import re
 from pathlib import Path
 
 import source_integrity
-from lifehug_core import REPO_DIR, STATE_DIR, now_utc, read_json, slugify, write_json, write_text
+from lifehug_core import (
+    CONNECTORS_STATE_DIR,
+    REPO_DIR,
+    STATE_DIR,
+    now_utc,
+    read_json,
+    slugify,
+    write_json,
+    write_text,
+)
 from connectors.scoring import (
     AXES,
     BANDS,
@@ -37,8 +46,6 @@ from connectors.scoring import (
     score_thread,
     tokens_known,
 )
-
-CONNECTORS_STATE_DIR = STATE_DIR / "connectors"
 
 # Safety valves on auto-promotion: at most this many threads per run, and
 # --dry-run reports without writing. The threshold itself is the owner's

--- a/system/connectors/gmail.py
+++ b/system/connectors/gmail.py
@@ -250,7 +250,7 @@ class GmailConnector(BaseConnector):
             flow = InstalledAppFlow.from_client_secrets_file(str(self.client_secrets_path), SCOPES)
             credentials = flow.run_local_server(port=0)
         self.token_path.parent.mkdir(parents=True, exist_ok=True)
-        self.token_path.write_text(credentials.to_json(), encoding="utf-8")
+        write_text(self.token_path, credentials.to_json())
         print(f"✓ gmail authorized (scope gmail.readonly only) — token at {self.token_path}")
         return 0
 
@@ -264,7 +264,7 @@ class GmailConnector(BaseConnector):
         credentials = Credentials.from_authorized_user_file(str(self.token_path), SCOPES)
         if credentials.expired and credentials.refresh_token:
             credentials.refresh(Request())
-            self.token_path.write_text(credentials.to_json(), encoding="utf-8")
+            write_text(self.token_path, credentials.to_json())
         service = build("gmail", "v1", credentials=credentials, cache_discovery=False)
         return GmailClient(service)
 

--- a/system/daily_question.sh
+++ b/system/daily_question.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="${WORKSPACE:-$(dirname "$SCRIPT_DIR")}"
+WORKSPACE="${WORKSPACE:-${LIFEHUG_VAULT_ROOT:-$(dirname "$SCRIPT_DIR")}}"
+WORKSPACE="$(python3 "$SCRIPT_DIR/vault_paths.py" root --vault-root "$WORKSPACE")" || exit 1
+export LIFEHUG_VAULT_ROOT="$WORKSPACE"
 cd "$WORKSPACE"
 DRY_RUN="${LIFEHUG_DAILY_DRY_RUN:-0}"
 export PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}"
@@ -95,20 +97,10 @@ safe_pull() {
 # rejected push must never cost the author their daily question. Pull-rebase
 # first — a second machine (dev box) writes to the same repo.
 safe_autocommit() {
-  local paths=(
-    README.md
-    question-bank.md
-    state/rotation.json
-    state/coverage.json
-    system/question-bank.md
-    system/rotation.json
-    system/coverage.json
-    answers
-    outputs
-    sources
-    state
-    wiki
-  )
+  local paths=()
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && paths+=("$path")
+  done < <(python3 "$SCRIPT_DIR/vault_paths.py" git-paths --vault-root "$WORKSPACE")
   local existing=()
   for path in "${paths[@]}"; do
     [[ -e "$path" ]] && existing+=("$path")

--- a/system/entity_roster.py
+++ b/system/entity_roster.py
@@ -47,6 +47,7 @@ from lifehug_core import (
     read_json,
     slugify,
     write_json,
+    write_text,
 )
 from recommend_focuses import STOPWORDS, OLD_FOCUS_TERM, load_recommendation_state
 
@@ -678,7 +679,7 @@ def main() -> int:
     previous_roster = load_roster(t)
 
     if args.emit_task:
-        Path(args.emit_task).write_text(json.dumps({
+        write_text(Path(args.emit_task), json.dumps({
             "type": t,
             "prompt": build_prompt(t, candidates, focus_map, excerpts, previous_roster),
             "candidates": candidates,
@@ -690,7 +691,7 @@ def main() -> int:
                                               "maps_to_focus": None},
                                              **({"chrono": 1} if t == "period" else {}),
                                              **({"keywords": ["phrase"]} if t == "theme" else {}))]},
-        }, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        }, indent=2, ensure_ascii=False) + "\n")
         n = len(excerpts or candidates)
         print(f"✓ Emitted {t} roster task ({n} items) to {args.emit_task}")
         print(f"  Write the roster JSON, then: python3 system/entity_roster.py --type {t} --from-response <file>")

--- a/system/entity_roster.py
+++ b/system/entity_roster.py
@@ -37,8 +37,8 @@ sys.path.insert(0, str(SYSTEM_DIR))
 
 from lifehug_core import (
     ANSWERS_DIR,
+    ENTITY_ROSTERS_DIR,
     QUESTIONS_FILE,
-    STATE_DIR,
     answer_body,
     answer_id_from_filename,
     load_config,
@@ -51,7 +51,7 @@ from lifehug_core import (
 from recommend_focuses import STOPWORDS, OLD_FOCUS_TERM, load_recommendation_state
 
 ENTITY_TYPES = ("person", "place", "period", "object", "theme")
-ENTITY_DIR = STATE_DIR / "entity_rosters"
+ENTITY_DIR = ENTITY_ROSTERS_DIR
 
 # (page_min_score, page_min_answers) defaults per type. Objects are symbolic-gated,
 # not score-gated, so their thresholds are 0/1.

--- a/system/file_answer_bg.sh
+++ b/system/file_answer_bg.sh
@@ -34,7 +34,9 @@ fi
 shift
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKSPACE="${WORKSPACE:-$(dirname "$SCRIPT_DIR")}"
+WORKSPACE="${WORKSPACE:-${LIFEHUG_VAULT_ROOT:-$(dirname "$SCRIPT_DIR")}}"
+WORKSPACE="$(python3 "$SCRIPT_DIR/vault_paths.py" root --vault-root "$WORKSPACE")" || exit 1
+export LIFEHUG_VAULT_ROOT="$WORKSPACE"
 export PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}"
 
 # Back-compat: v82 callers pass LIFEHUG_CHAT_ID; the framework's own
@@ -60,7 +62,7 @@ chmod 600 "$BODY"
 trap 'rm -f "$BODY"' EXIT
 cat > "$BODY"
 
-cd "$WORKSPACE"
+cd "$WORKSPACE" || exit 1
 
 # Read fresh at decision time — discipline 1 of the shared-vault contract.
 # The question id is explicit here, so this pull is not about WHICH question we
@@ -104,7 +106,8 @@ RC=$?
 
 # Signal that a compile is needed (picked up by hourly cron)
 if [[ $RC -eq 0 ]]; then
-  touch "$WORKSPACE/state/.compile-needed"
+  COMPILE_NEEDED="$(python3 "$SCRIPT_DIR/vault_paths.py" data-path compile_needed --vault-root "$WORKSPACE")" || exit 1
+  touch "$WORKSPACE/$COMPILE_NEEDED"
 fi
 
 if [[ $RC -eq 0 ]]; then

--- a/system/gen_followups.py
+++ b/system/gen_followups.py
@@ -46,7 +46,6 @@ from lifehug_core import (
 )
 
 SYSTEM_DIR = Path(__file__).parent
-REPO_DIR = SYSTEM_DIR.parent
 
 
 def load_json(path):

--- a/system/job_execute.py
+++ b/system/job_execute.py
@@ -19,7 +19,15 @@ import jobs
 
 
 def main() -> int:
-    vault = Path(os.environ.get("LIFEHUG_VAULT_ROOT", ""))
+    try:
+        vault = jobs.resolve_vault_root(
+            Path(os.environ.get("LIFEHUG_VAULT_ROOT", "")),
+            framework_system_dir=jobs.FRAMEWORK_SYSTEM_DIR,
+        )
+        jobs.configure(vault)
+    except ValueError:
+        return 77
+    os.environ["LIFEHUG_VAULT_ROOT"] = str(vault)
     token = os.environ.get("LIFEHUG_JOB_RUNNER_TOKEN")
     if not jobs.writer_token_is_live(token, vault_root=vault):
         return 77

--- a/system/job_execute.py
+++ b/system/job_execute.py
@@ -15,17 +15,22 @@ import runpy
 import sys
 from pathlib import Path
 
-import jobs
+from vault_paths import resolve_framework_system_dir, resolve_vault_root
 
 
 def main() -> int:
     try:
-        vault = jobs.resolve_vault_root(
-            Path(os.environ.get("LIFEHUG_VAULT_ROOT", "")),
-            framework_system_dir=jobs.FRAMEWORK_SYSTEM_DIR,
+        framework_system = resolve_framework_system_dir()
+        selected = os.environ.get("LIFEHUG_VAULT_ROOT")
+        vault = resolve_vault_root(
+            Path(selected) if selected else None,
+            framework_system_dir=framework_system,
+            bind_process=True,
         )
+        import jobs  # noqa: PLC0415
+
         jobs.configure(vault)
-    except ValueError:
+    except (RuntimeError, ValueError):
         return 77
     os.environ["LIFEHUG_VAULT_ROOT"] = str(vault)
     token = os.environ.get("LIFEHUG_JOB_RUNNER_TOKEN")

--- a/system/jobs.py
+++ b/system/jobs.py
@@ -50,6 +50,7 @@ from vault_paths import (
     read_vault_text,
     resolve_framework_system_dir,
     resolve_vault_root,
+    unlink_vault_file,
     validate_contained_path,
     vault_data_path,
 )
@@ -857,8 +858,8 @@ class _WriterLease:
             self.thread.join(timeout=2)
         owner = _read_json(WRITER_OWNER_FILE)
         if owner and owner.get("owner_id") == self.owner_id:
-            with contextlib.suppress(FileNotFoundError):
-                WRITER_OWNER_FILE.unlink()
+            with contextlib.suppress(FileNotFoundError, ValueError):
+                unlink_vault_file(WRITER_OWNER_FILE, vault_root=VAULT_ROOT)
         if self.lock is not None:
             self.lock.__exit__(_exc_type, _exc, _tb)
             self.lock = None
@@ -977,8 +978,8 @@ def _finalize_from_receipt(record: dict, receipt: dict) -> dict:
     exit_code = receipt["exit_code"]
     payload_path = _payload_path(record["id"])
     if exit_code == 0:
-        with contextlib.suppress(OSError):
-            payload_path.unlink()
+        with contextlib.suppress(OSError, ValueError):
+            unlink_vault_file(payload_path, vault_root=VAULT_ROOT)
     payload_retained = payload_path.exists()
     record.update({
         "state": "succeeded" if exit_code == 0 else "failed",
@@ -1066,23 +1067,23 @@ def cleanup_sidecars(*, grace_seconds: int = ORPHAN_GRACE_SECONDS) -> dict[str, 
             continue
         record = load_job(path.stem)
         if record and record["state"] == "succeeded":
-            with contextlib.suppress(OSError):
-                path.unlink()
+            with contextlib.suppress(OSError, ValueError):
+                unlink_vault_file(path, vault_root=VAULT_ROOT)
                 removed["successful_payloads"] += 1
             if not path.exists() and record.get("payload_retained"):
                 record.update({"payload_retained": False, "updated_at": _now()})
                 _write_json(_record_path(record["id"]), record)
         elif record is None and path.stat().st_mtime <= cutoff:
-            with contextlib.suppress(OSError):
-                path.unlink()
+            with contextlib.suppress(OSError, ValueError):
+                unlink_vault_file(path, vault_root=VAULT_ROOT)
                 removed["orphan_payloads"] += 1
     for path in RECEIPTS_DIR.glob("*.json"):
         if path.is_symlink():
             continue
         job_id = path.name.split("-", 1)[0]
         if _ID_RE.fullmatch(job_id) and load_job(job_id) is None and path.stat().st_mtime <= cutoff:
-            with contextlib.suppress(OSError):
-                path.unlink()
+            with contextlib.suppress(OSError, ValueError):
+                unlink_vault_file(path, vault_root=VAULT_ROOT)
                 removed["orphan_receipts"] += 1
     return removed
 
@@ -1095,12 +1096,12 @@ def purge_job(job_id: str) -> dict:
             raise ValueError("unknown job")
         if record["state"] not in TERMINAL_STATES:
             raise ValueError("only terminal jobs can be purged")
-        with contextlib.suppress(OSError):
-            _payload_path(job_id).unlink()
+        with contextlib.suppress(OSError, ValueError):
+            unlink_vault_file(_payload_path(job_id), vault_root=VAULT_ROOT)
         for receipt in RECEIPTS_DIR.glob(f"{job_id}-*.json"):
             if not receipt.is_symlink():
-                with contextlib.suppress(OSError):
-                    receipt.unlink()
+                with contextlib.suppress(OSError, ValueError):
+                    unlink_vault_file(receipt, vault_root=VAULT_ROOT)
         record.update({
             "payload_retained": False,
             "purged_at": _now(),

--- a/system/jobs.py
+++ b/system/jobs.py
@@ -45,13 +45,18 @@ from vault_paths import (
     resolve_framework_system_dir,
     resolve_vault_root,
     validate_contained_path,
+    vault_data_path,
 )
 
 FRAMEWORK_SYSTEM_DIR = resolve_framework_system_dir()
-DEFAULT_VAULT_ROOT = resolve_vault_root(framework_system_dir=FRAMEWORK_SYSTEM_DIR)
+DEFAULT_VAULT_ROOT = Path(
+    os.environ.get("LIFEHUG_VAULT_ROOT", str(FRAMEWORK_SYSTEM_DIR.parent))
+)
 
 VAULT_ROOT = DEFAULT_VAULT_ROOT
-JOBS_DIR = VAULT_ROOT / "state" / "jobs"
+JOBS_DIR = vault_data_path(
+    "jobs", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+)
 PAYLOADS_DIR = JOBS_DIR / ".payloads"
 RECEIPTS_DIR = JOBS_DIR / ".receipts"
 WRITER_LOCK = JOBS_DIR / ".writer-v2.lock"
@@ -126,7 +131,9 @@ def configure(vault_root: Path) -> None:
         vault_root,
         framework_system_dir=FRAMEWORK_SYSTEM_DIR,
     )
-    JOBS_DIR = VAULT_ROOT / "state" / "jobs"
+    JOBS_DIR = vault_data_path(
+        "jobs", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
     PAYLOADS_DIR = JOBS_DIR / ".payloads"
     RECEIPTS_DIR = JOBS_DIR / ".receipts"
     WRITER_LOCK = JOBS_DIR / ".writer-v2.lock"
@@ -136,7 +143,9 @@ def configure(vault_root: Path) -> None:
 
 
 def _ensure_layout() -> None:
-    state_root = VAULT_ROOT / "state"
+    state_root = vault_data_path(
+        "state", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
     if state_root.is_symlink():
         raise ValueError("vault/state may not be a symlink")
     if state_root.exists() and not state_root.is_dir():
@@ -888,7 +897,9 @@ def writer_token_is_live(token: str | None, *, vault_root: Path | None = None) -
     if not isinstance(token, str) or not re.fullmatch(r"[0-9a-f]{20}", token):
         return False
     root = resolve_vault_root(vault_root, framework_system_dir=FRAMEWORK_SYSTEM_DIR)
-    jobs_dir = root / "state" / "jobs"
+    jobs_dir = vault_data_path(
+        "jobs", vault_root=root, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
     owner_file = jobs_dir / ".writer-owner.json"
     lock_file = jobs_dir / ".writer-v2.lock"
     try:
@@ -947,34 +958,34 @@ def _load_payload(job_id: str, command: str) -> dict:
 
 def _validate_execution_paths(command: str, payload: dict) -> None:
     """Re-check typed refs after queueing, closing enqueue-to-run symlink races."""
+    outputs_root = vault_data_path(
+        "outputs", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
+    sources_root = vault_data_path(
+        "sources", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
+    corrections_root = vault_data_path(
+        "correction_sources", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
+    answers_root = vault_data_path(
+        "answers", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
+    )
     if command.startswith("artifact-"):
-        validate_contained_path(
-            VAULT_ROOT / "outputs",
-            VAULT_ROOT / "outputs",
-            label="output root",
-        )
+        validate_contained_path(outputs_root, outputs_root, label="output root")
         ref = payload.get("ref")
         if isinstance(ref, str):
-            validate_contained_path(VAULT_ROOT / ref, VAULT_ROOT / "outputs", label="artifact ref")
+            validate_contained_path(VAULT_ROOT / ref, outputs_root, label="artifact ref")
         seed = payload.get("seed")
         if isinstance(seed, str):
-            validate_contained_path(VAULT_ROOT / seed, VAULT_ROOT / "sources", label="source seed")
+            validate_contained_path(VAULT_ROOT / seed, sources_root, label="source seed")
     if command in {"fix-source", "reflect-source", "timeline-place"}:
         ref = payload.get("ref") if command != "timeline-place" else payload.get("source")
         if isinstance(ref, str) and ref.startswith(("answers/", "sources/")):
-            allowed = "answers" if ref.startswith("answers/") else "sources"
-            validate_contained_path(VAULT_ROOT / ref, VAULT_ROOT / allowed, label="source ref")
-        validate_contained_path(
-            VAULT_ROOT / "sources" / "corrections",
-            VAULT_ROOT / "sources",
-            label="correction destination",
-        )
+            allowed = answers_root if ref.startswith("answers/") else sources_root
+            validate_contained_path(VAULT_ROOT / ref, allowed, label="source ref")
+        validate_contained_path(corrections_root, sources_root, label="correction destination")
     if command in {"process-answer", "file-answer"}:
-        validate_contained_path(
-            VAULT_ROOT / "answers",
-            VAULT_ROOT / "answers",
-            label="answer root",
-        )
+        validate_contained_path(answers_root, answers_root, label="answer root")
 
 
 def _receipt(record: dict) -> dict | None:

--- a/system/jobs.py
+++ b/system/jobs.py
@@ -42,6 +42,12 @@ from pathlib import Path
 from typing import Callable
 
 from vault_paths import (
+    atomic_create_vault_bytes,
+    atomic_write_vault_text,
+    ensure_vault_directory,
+    open_vault_fd,
+    read_vault_bytes,
+    read_vault_text,
     resolve_framework_system_dir,
     resolve_vault_root,
     validate_contained_path,
@@ -95,30 +101,20 @@ def _parse_time(value: str) -> datetime | None:
 
 def _write_json(path: Path, data: object, *, mode: int = 0o600) -> None:
     """Atomically write JSON without following a destination symlink."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.is_symlink():
-        raise ValueError("refusing symlinked job storage")
-    tmp = path.parent / f".{path.name}.{secrets.token_hex(8)}.tmp"
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    fd = os.open(tmp, flags, mode)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(data, handle, indent=2, ensure_ascii=False)
-            handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp, path)
-    finally:
-        with contextlib.suppress(FileNotFoundError):
-            tmp.unlink()
+    atomic_write_vault_text(
+        path,
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        vault_root=VAULT_ROOT,
+        mode=mode,
+    )
 
 
 def _read_json(path: Path) -> dict | None:
-    if path.is_symlink() or not path.is_file():
-        return None
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeError):
+        value = json.loads(read_vault_text(path, vault_root=VAULT_ROOT))
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, UnicodeError):
         return None
     return value if isinstance(value, dict) else None
 
@@ -130,6 +126,7 @@ def configure(vault_root: Path) -> None:
     VAULT_ROOT = resolve_vault_root(
         vault_root,
         framework_system_dir=FRAMEWORK_SYSTEM_DIR,
+        bind_process=True,
     )
     JOBS_DIR = vault_data_path(
         "jobs", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
@@ -146,47 +143,22 @@ def _ensure_layout() -> None:
     state_root = vault_data_path(
         "state", vault_root=VAULT_ROOT, framework_system_dir=FRAMEWORK_SYSTEM_DIR
     )
-    if state_root.is_symlink():
-        raise ValueError("vault/state may not be a symlink")
-    if state_root.exists() and not state_root.is_dir():
-        raise ValueError("vault/state must be a directory")
-    state_root.mkdir(parents=True, exist_ok=True)
-    if JOBS_DIR.exists() and (JOBS_DIR.is_symlink() or not JOBS_DIR.is_dir()):
-        raise ValueError("job directory must be a real directory under vault/state")
-    JOBS_DIR.mkdir(exist_ok=True)
-    if JOBS_DIR.resolve().parent != state_root.resolve():
-        raise ValueError("job directory escaped vault/state")
-    for directory in (PAYLOADS_DIR, RECEIPTS_DIR):
-        if directory.exists() and (directory.is_symlink() or not directory.is_dir()):
-            raise ValueError("job sidecar directories must be real directories")
-    PAYLOADS_DIR.mkdir(mode=0o700, exist_ok=True)
-    RECEIPTS_DIR.mkdir(mode=0o700, exist_ok=True)
+    for directory in (state_root, JOBS_DIR, PAYLOADS_DIR, RECEIPTS_DIR):
+        ensure_vault_directory(directory, vault_root=VAULT_ROOT)
 
 
 def _identity_key() -> bytes:
     _ensure_layout()
-    if IDENTITY_KEY_FILE.is_symlink():
-        raise ValueError("identity key may not be a symlink")
     try:
-        key = IDENTITY_KEY_FILE.read_bytes()
+        key = read_vault_bytes(IDENTITY_KEY_FILE, vault_root=VAULT_ROOT)
     except FileNotFoundError:
         key = secrets.token_bytes(32)
-        tmp = IDENTITY_KEY_FILE.parent / f".identity-key-{secrets.token_hex(8)}.tmp"
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(key)
-                handle.flush()
-                os.fsync(handle.fileno())
-            try:
-                # A hard-link publishes only a fully-written inode and fails
-                # atomically if another cold-start process won the race.
-                os.link(tmp, IDENTITY_KEY_FILE, follow_symlinks=False)
-            except FileExistsError:
-                key = IDENTITY_KEY_FILE.read_bytes()
-        finally:
-            with contextlib.suppress(FileNotFoundError):
-                tmp.unlink()
+            atomic_create_vault_bytes(
+                IDENTITY_KEY_FILE, key, vault_root=VAULT_ROOT, mode=0o600
+            )
+        except FileExistsError:
+            key = read_vault_bytes(IDENTITY_KEY_FILE, vault_root=VAULT_ROOT)
     if len(key) != 32:
         raise ValueError("invalid job identity key")
     return key
@@ -809,12 +781,12 @@ def _owned_lock_record(owner_id: str, lease_seconds: int) -> dict:
 
 def _open_lock_file(path: Path) -> int:
     _ensure_layout()
-    if path.is_symlink() or (path.exists() and not path.is_file()):
-        raise ValueError("lock path must be a regular local file")
-    flags = os.O_RDWR | os.O_CREAT
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    return os.open(path, flags, 0o600)
+    return open_vault_fd(
+        path,
+        os.O_RDWR | os.O_CREAT,
+        vault_root=VAULT_ROOT,
+        mode=0o600,
+    )
 
 
 class _KernelLock:
@@ -907,17 +879,18 @@ def writer_token_is_live(token: str | None, *, vault_root: Path | None = None) -
         validate_contained_path(lock_file, jobs_dir, label="writer lock")
     except ValueError:
         return False
-    owner = _read_json(owner_file)
+    try:
+        owner_value = json.loads(read_vault_text(owner_file, vault_root=root))
+    except (FileNotFoundError, json.JSONDecodeError, UnicodeError, ValueError):
+        return False
+    owner = owner_value if isinstance(owner_value, dict) else None
     if not owner or _owner_is_stale(owner):
         return False
     if not secrets.compare_digest(str(owner.get("owner_id", "")), token):
         return False
     try:
-        flags = os.O_RDWR
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
-        fd = os.open(lock_file, flags)
-    except OSError:
+        fd = open_vault_fd(lock_file, os.O_RDWR, vault_root=root)
+    except (OSError, ValueError):
         return False
     try:
         try:

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -15,11 +15,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-from vault_paths import bootstrap_cli_vault_root
+from vault_paths import bootstrap_cli_vault_root, normalize_cli_vault_args
 
 # Global options must select the vault before lifehug_core and the command
 # modules bind their path constants. The helper is the single precedence and
 # validation authority; argparse below only exposes the public flag.
+sys.argv[1:] = normalize_cli_vault_args(sys.argv[1:])
 bootstrap_cli_vault_root(sys.argv[1:])
 
 from lifehug_core import (

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -15,14 +15,25 @@ import subprocess
 import sys
 from pathlib import Path
 
+from vault_paths import bootstrap_cli_vault_root
+
+# Global options must select the vault before lifehug_core and the command
+# modules bind their path constants. The helper is the single precedence and
+# validation authority; argparse below only exposes the public flag.
+bootstrap_cli_vault_root(sys.argv[1:])
+
 from lifehug_core import (
     ANSWERS_DIR,
+    CLASSIFICATIONS_DIR,
     CONFIG_FILE,
     COVERAGE_FILE,
+    ENTITY_ROSTERS_DIR,
+    QUALITY_PROFILE_FILE,
+    QUESTION_CANDIDATES_FILE,
+    QUESTION_QUEUE_FILE,
     QUESTIONS_FILE,
     REPO_DIR,
     ROTATION_FILE,
-    STATE_DIR,
     WIKI_DIR,
     format_learning_failure,
     load_config,
@@ -1066,7 +1077,7 @@ def loop_health_checks() -> int:
 
     # Queue health — an expired queue silently reverts the daily pick to the
     # legacy coverage algorithm.
-    queue_data = read_json(STATE_DIR / "question_queue.json", default=None)
+    queue_data = read_json(QUESTION_QUEUE_FILE, default=None)
     if not queue_data:
         warn("planner queue missing", "daily pick is using legacy coverage rotation; run planner-queue")
     else:
@@ -1083,7 +1094,7 @@ def loop_health_checks() -> int:
             check("planner queue valid", True, f"{remaining} item(s) remaining")
 
     # Candidate backlog — inflow must not permanently exceed outflow.
-    cand_data = read_json(STATE_DIR / "question_candidates.json", default=None) or {}
+    cand_data = read_json(QUESTION_CANDIDATES_FILE, default=None) or {}
     promotable = [c for c in cand_data.get("candidates", [])
                   if c.get("status") in ("candidate", "accepted", "deferred", "needs_review")]
     if promotable:
@@ -1099,7 +1110,7 @@ def loop_health_checks() -> int:
         check("candidate backlog healthy", True, "no unresolved candidates")
 
     # Cadence — has the weekly/monthly actually run?
-    profile = read_json(STATE_DIR / "quality_profile.json", default=None) or {}
+    profile = read_json(QUALITY_PROFILE_FILE, default=None) or {}
     weekly_age = _days_since(profile.get("computed_at") or profile.get("last_updated") or profile.get("updated_at") or "")
     if weekly_age is None:
         warn("weekly cadence unknown", "quality profile has never been updated — has weekly_maintenance.sh ever run?")
@@ -1108,7 +1119,7 @@ def loop_health_checks() -> int:
     else:
         check("weekly cadence", True, f"quality profile updated {weekly_age:.0f}d ago")
 
-    roster = read_json(STATE_DIR / "entity_rosters" / "person.json", default=None) or {}
+    roster = read_json(ENTITY_ROSTERS_DIR / "person.json", default=None) or {}
     monthly_age = _days_since(roster.get("resolved_at", ""))
     if monthly_age is not None and monthly_age > 35:
         warn("monthly cadence stalled", f"person roster last resolved {monthly_age:.0f} days ago (expected ~30)")
@@ -1117,7 +1128,7 @@ def loop_health_checks() -> int:
 
     # Roster continuity — an empty roster is how the Jul-2026 regression looked.
     for etype in ("person", "place", "period", "object", "theme"):
-        data = read_json(STATE_DIR / "entity_rosters" / f"{etype}.json", default=None)
+        data = read_json(ENTITY_ROSTERS_DIR / f"{etype}.json", default=None)
         if data is not None and not (data.get("entities") or []):
             warn(f"{etype} roster is EMPTY", "a refresh may have wiped it — restore from git and re-resolve")
 
@@ -1134,8 +1145,7 @@ def loop_health_checks() -> int:
         warn("zombie-focus check unavailable", str(exc)[:80])
 
     # Classification coverage — the learning loop starves without it.
-    classifications_dir = STATE_DIR / "classifications"
-    classified = len(list(classifications_dir.glob("*.json"))) if classifications_dir.exists() else 0
+    classified = len(list(CLASSIFICATIONS_DIR.glob("*.json"))) if CLASSIFICATIONS_DIR.exists() else 0
     answers = len(list(ANSWERS_DIR.glob("*.md"))) if ANSWERS_DIR.exists() else 0
     if answers and not classified:
         warn("no sources classified", f"{answers} answers, 0 classifications — the learning loop has never run")
@@ -1221,6 +1231,12 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Lifehug script-first workflow wrapper")
+    parser.add_argument(
+        "--vault-root",
+        type=Path,
+        default=REPO_DIR,
+        help="Data-only vault root (overrides LIFEHUG_VAULT_ROOT)",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p = sub.add_parser("status", help="Show coverage and pass status")

--- a/system/lifehug_core.py
+++ b/system/lifehug_core.py
@@ -11,50 +11,68 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from vault_paths import (
-    EMBEDDED_FRAMEWORK_SYSTEM_DIR,
+    framework_path,
+    resolve_framework_system_dir,
     resolve_vault_root,
     validate_contained_path,
+    vault_data_path,
+    vault_layout,
 )
 
-SYSTEM_DIR = EMBEDDED_FRAMEWORK_SYSTEM_DIR
+SYSTEM_DIR = resolve_framework_system_dir()
 FRAMEWORK_ROOT = SYSTEM_DIR.parent
-# Current installs embed framework + vault in one checkout.  A future
-# vault-only install (#46) points the same framework at a separate data root.
 REPO_DIR = resolve_vault_root(framework_system_dir=SYSTEM_DIR)
-_EMBEDDED_DATA = REPO_DIR / "system"
-if _EMBEDDED_DATA.is_dir():
-    QUESTIONS_FILE = _EMBEDDED_DATA / "question-bank.md"
-    ROTATION_FILE = _EMBEDDED_DATA / "rotation.json"
-    COVERAGE_FILE = _EMBEDDED_DATA / "coverage.json"
-else:
-    QUESTIONS_FILE = REPO_DIR / "question-bank.md"
-    ROTATION_FILE = REPO_DIR / "state" / "rotation.json"
-    COVERAGE_FILE = REPO_DIR / "state" / "coverage.json"
-CONFIG_FILE = REPO_DIR / "config.yaml"
-PROFILE_FILE = REPO_DIR / "profile.yaml"
-README_FILE = REPO_DIR / "README.md"
-ANSWERS_DIR = REPO_DIR / "answers"
-OUTPUTS_DIR = REPO_DIR / "outputs"
-TEMPLATES_DIR = (REPO_DIR / "templates") if (REPO_DIR / "templates").is_dir() else FRAMEWORK_ROOT / "templates"
-STATE_DIR = REPO_DIR / "state"
-WIKI_DIR = REPO_DIR / "wiki"
-SOURCES_DIR = REPO_DIR / "sources"
-MANUAL_SOURCES_DIR = SOURCES_DIR / "manual"
-IMPORT_SOURCES_DIR = SOURCES_DIR / "imports"
-CORRECTION_SOURCES_DIR = SOURCES_DIR / "corrections"
-ARTIFACT_SOURCES_DIR = SOURCES_DIR / "artifacts"
-QUESTION_CANDIDATES_FILE = STATE_DIR / "question_candidates.json"
-QUESTION_QUEUE_FILE = STATE_DIR / "question_queue.json"
-PLANNER_STATE_FILE = STATE_DIR / "planner_state.json"
-SOURCE_MANIFEST_FILE = STATE_DIR / "source_manifest.json"
-SOURCE_LINT_FINDINGS_FILE = STATE_DIR / "source_lint_findings.json"
-LEARNING_FAILURES_FILE = STATE_DIR / "learning_failures.jsonl"
-MISSION_FILE = SYSTEM_DIR / "mission.md"
-CLASSIFICATIONS_DIR = STATE_DIR / "classifications"
-NEIGHBORHOODS_FILE = STATE_DIR / "neighborhoods.json"
-FOCUS_RECS_FILE = STATE_DIR / "focus_recommendations.json"
-LEGACY_FOCUS_RECS_FILE = STATE_DIR / ("spot" "light_recommendations.json")
-CONNECTORS_DIR = SYSTEM_DIR / "connectors"
+VAULT_LAYOUT = vault_layout(REPO_DIR, framework_system_dir=SYSTEM_DIR)
+
+
+def _data(name: str) -> Path:
+    return vault_data_path(name, vault_root=REPO_DIR, framework_system_dir=SYSTEM_DIR)
+
+
+QUESTIONS_FILE = _data("question_bank")
+ROTATION_FILE = _data("rotation")
+COVERAGE_FILE = _data("coverage")
+CONFIG_FILE = _data("config")
+PROFILE_FILE = _data("profile")
+README_FILE = _data("readme")
+ANSWERS_DIR = _data("answers")
+OUTPUTS_DIR = _data("outputs")
+STATE_DIR = _data("state")
+WIKI_DIR = _data("wiki")
+SOURCES_DIR = _data("sources")
+MANUAL_SOURCES_DIR = _data("manual_sources")
+IMPORT_SOURCES_DIR = _data("import_sources")
+CORRECTION_SOURCES_DIR = _data("correction_sources")
+ARTIFACT_SOURCES_DIR = _data("artifact_sources")
+QUESTION_CANDIDATES_FILE = _data("question_candidates")
+QUESTION_QUEUE_FILE = _data("question_queue")
+PLANNER_STATE_FILE = _data("planner_state")
+SOURCE_MANIFEST_FILE = _data("source_manifest")
+SOURCE_LINT_FINDINGS_FILE = _data("source_lint_findings")
+LEARNING_FAILURES_FILE = _data("learning_failures")
+CLASSIFICATIONS_DIR = _data("classifications")
+NEIGHBORHOODS_FILE = _data("neighborhoods")
+FOCUS_RECS_FILE = _data("focus_recommendations")
+LEGACY_FOCUS_RECS_FILE = _data("legacy_focus_recommendations")
+ROADMAP_FILE = _data("roadmap")
+QUALITY_PROFILE_FILE = _data("quality_profile")
+ANSWER_SCORES_FILE = _data("answer_scores")
+ENTITY_ROSTERS_DIR = _data("entity_rosters")
+CONNECTORS_STATE_DIR = _data("connectors_state")
+SECOND_VOICE_OFFERS_FILE = _data("second_voice_offers")
+BOOK_OFFERS_FILE = _data("book_offers")
+TIMELINE_PLACEMENTS_FILE = _data("timeline_placements")
+PERENNIALS_FILE = _data("perennials")
+WIKI_SYNTHESIS_CACHE_FILE = _data("wiki_synthesis_cache")
+SYNTHESIS_DIR = _data("synthesis")
+REPORTS_DIR = _data("reports")
+AGENT_TASKS_DIR = _data("agent_tasks")
+JOBS_DIR = _data("jobs")
+COMPILE_NEEDED_FILE = _data("compile_needed")
+
+TEMPLATES_DIR = framework_path("templates", framework_system_dir=SYSTEM_DIR)
+MISSION_FILE = framework_path("mission", framework_system_dir=SYSTEM_DIR)
+CONNECTORS_DIR = framework_path("connectors", framework_system_dir=SYSTEM_DIR)
 
 QUESTION_ID_RE = r"[A-Z]\d+[a-z]*"
 QUESTION_LINE_RE = re.compile(

--- a/system/lifehug_core.py
+++ b/system/lifehug_core.py
@@ -13,12 +13,15 @@ from vault_paths import (
     append_vault_text,
     atomic_write_vault_text,
     framework_path,
+    ensure_vault_directory,
+    open_vault_file,
     read_vault_bytes,
     read_vault_text,
     resolve_framework_system_dir,
     resolve_vault_root,
     vault_data_path,
     vault_layout,
+    unlink_vault_file,
 )
 
 SYSTEM_DIR = resolve_framework_system_dir()
@@ -27,8 +30,106 @@ REPO_DIR = resolve_vault_root(framework_system_dir=SYSTEM_DIR, bind_process=True
 VAULT_LAYOUT = vault_layout(REPO_DIR, framework_system_dir=SYSTEM_DIR)
 
 
+class VaultPath(type(Path())):
+    """A durable-data path whose ordinary pathlib I/O stays no-follow.
+
+    ``Path`` preserves its concrete class through joins and globbing.  Making
+    every contract-derived durable path a ``VaultPath`` therefore keeps legacy
+    callers that use ``.read_text()`` or ``.mkdir()`` inside the single
+    no-follow authority, including paths discovered after the initial vault
+    preflight.
+    """
+
+    def _inside_selected_vault(self) -> bool:
+        try:
+            Path(os.path.abspath(self)).relative_to(REPO_DIR)
+            return True
+        except ValueError:
+            return False
+
+    def read_text(self, encoding: str | None = None, errors: str | None = None) -> str:
+        if not self._inside_selected_vault():
+            return super().read_text(encoding=encoding, errors=errors)
+        return read_vault_text(self, vault_root=REPO_DIR, encoding=encoding or "utf-8", errors=errors)
+
+    def read_bytes(self) -> bytes:
+        if not self._inside_selected_vault():
+            return super().read_bytes()
+        return read_vault_bytes(self, vault_root=REPO_DIR)
+
+    def write_text(
+        self,
+        data: str,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> int:
+        if not self._inside_selected_vault():
+            return super().write_text(data, encoding=encoding, errors=errors, newline=newline)
+        if errors is not None or newline is not None:
+            raise ValueError("VaultPath writes support UTF-8 without newline conversion")
+        atomic_write_vault_text(self, data, vault_root=REPO_DIR, encoding=encoding or "utf-8")
+        return len(data)
+
+    def write_bytes(self, data: bytes) -> int:
+        if not self._inside_selected_vault():
+            return super().write_bytes(data)
+        from vault_paths import atomic_write_vault_bytes
+
+        atomic_write_vault_bytes(self, data, vault_root=REPO_DIR)
+        return len(data)
+
+    def open(
+        self,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ):
+        if not self._inside_selected_vault():
+            return super().open(
+                mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline
+            )
+        if buffering != -1 or newline is not None:
+            raise ValueError("VaultPath open does not support buffering or newline overrides")
+        return open_vault_file(
+            self,
+            mode,
+            vault_root=REPO_DIR,
+            encoding=encoding,
+            errors=errors,
+            create_parents=mode in {"w", "wb", "a", "ab", "x", "xb"},
+        )
+
+    def mkdir(self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False) -> None:
+        if not self._inside_selected_vault():
+            return super().mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
+        if self.exists() and not exist_ok:
+            raise FileExistsError(self)
+        ensure_vault_directory(self, vault_root=REPO_DIR)
+
+    def touch(self, mode: int = 0o666, exist_ok: bool = True) -> None:
+        if not self._inside_selected_vault():
+            return super().touch(mode=mode, exist_ok=exist_ok)
+        if self.exists():
+            if not exist_ok:
+                raise FileExistsError(self)
+            with open_vault_file(self, "a", vault_root=REPO_DIR, file_mode=mode):
+                return
+        with open_vault_file(
+            self, "x", vault_root=REPO_DIR, create_parents=True, file_mode=mode
+        ):
+            return
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        if not self._inside_selected_vault():
+            return super().unlink(missing_ok=missing_ok)
+        unlink_vault_file(self, vault_root=REPO_DIR, missing_ok=missing_ok)
+
+
 def _data(name: str) -> Path:
-    return vault_data_path(name, vault_root=REPO_DIR, framework_system_dir=SYSTEM_DIR)
+    return VaultPath(vault_data_path(name, vault_root=REPO_DIR, framework_system_dir=SYSTEM_DIR))
 
 
 QUESTIONS_FILE = _data("question_bank")

--- a/system/lifehug_core.py
+++ b/system/lifehug_core.py
@@ -6,22 +6,24 @@ from __future__ import annotations
 import json
 import os
 import re
-import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from vault_paths import (
+    append_vault_text,
+    atomic_write_vault_text,
     framework_path,
+    read_vault_bytes,
+    read_vault_text,
     resolve_framework_system_dir,
     resolve_vault_root,
-    validate_contained_path,
     vault_data_path,
     vault_layout,
 )
 
 SYSTEM_DIR = resolve_framework_system_dir()
 FRAMEWORK_ROOT = SYSTEM_DIR.parent
-REPO_DIR = resolve_vault_root(framework_system_dir=SYSTEM_DIR)
+REPO_DIR = resolve_vault_root(framework_system_dir=SYSTEM_DIR, bind_process=True)
 VAULT_LAYOUT = vault_layout(REPO_DIR, framework_system_dir=SYSTEM_DIR)
 
 
@@ -111,45 +113,58 @@ def now_utc() -> str:
 
 def read_json(path: Path, default=None):
     try:
-        with path.open() as f:
-            return json.load(f)
+        if _is_vault_path(path):
+            return json.loads(read_vault_text(path, vault_root=REPO_DIR))
+        with path.open(encoding="utf-8") as handle:
+            return json.load(handle)
     except FileNotFoundError:
         return default
 
 
+def read_text(path: Path, *, encoding: str = "utf-8", errors: str | None = None) -> str:
+    if _is_vault_path(path):
+        return read_vault_text(path, vault_root=REPO_DIR, encoding=encoding, errors=errors)
+    return path.read_text(encoding=encoding, errors=errors)
+
+
+def read_bytes(path: Path) -> bytes:
+    if _is_vault_path(path):
+        return read_vault_bytes(path, vault_root=REPO_DIR)
+    return path.read_bytes()
+
+
 def write_json(path: Path, data) -> None:
-    _guard_private_write(path)
+    content = json.dumps(data, indent=2) + "\n"
+    if _is_vault_path(path):
+        atomic_write_vault_text(path, content, vault_root=REPO_DIR)
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile("w", delete=False, dir=path.parent) as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
-        tmp = Path(f.name)
-    tmp.replace(path)
+    path.write_text(content, encoding="utf-8")
 
 
 def write_text(path: Path, text: str) -> None:
-    _guard_private_write(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile("w", delete=False, dir=path.parent) as f:
-        f.write(text)
-        tmp = Path(f.name)
-    tmp.replace(path)
-
-
-def _guard_private_write(path: Path) -> None:
-    """Prevent answer/source/output helpers from traversing symlinked refs."""
-    candidate = Path(path).absolute()
-    for root, label in (
-        (ANSWERS_DIR, "answer path"),
-        (SOURCES_DIR, "source path"),
-        (OUTPUTS_DIR, "output path"),
-    ):
-        try:
-            candidate.relative_to(Path(root).absolute())
-        except ValueError:
-            continue
-        validate_contained_path(candidate, root, label=label)
+    if _is_vault_path(path):
+        atomic_write_vault_text(path, text, vault_root=REPO_DIR)
         return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def append_text(path: Path, text: str) -> None:
+    if _is_vault_path(path):
+        append_vault_text(path, text, vault_root=REPO_DIR)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(text)
+
+
+def _is_vault_path(path: Path) -> bool:
+    try:
+        Path(os.path.abspath(path)).relative_to(REPO_DIR)
+        return True
+    except ValueError:
+        return False
 
 
 def record_learning_failure(
@@ -172,9 +187,13 @@ def record_learning_failure(
         record["exit_code"] = exit_code
     if context:
         record["context"] = context
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+    if _is_vault_path(path):
+        append_vault_text(path, line, vault_root=REPO_DIR)
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
     return record
 
 

--- a/system/lifehug_core.py
+++ b/system/lifehug_core.py
@@ -26,8 +26,11 @@ from vault_paths import (
 
 SYSTEM_DIR = resolve_framework_system_dir()
 FRAMEWORK_ROOT = SYSTEM_DIR.parent
-REPO_DIR = resolve_vault_root(framework_system_dir=SYSTEM_DIR, bind_process=True)
-VAULT_LAYOUT = vault_layout(REPO_DIR, framework_system_dir=SYSTEM_DIR)
+_RESOLVED_VAULT_ROOT = resolve_vault_root(
+    framework_system_dir=SYSTEM_DIR,
+    bind_process=True,
+)
+VAULT_LAYOUT = vault_layout(_RESOLVED_VAULT_ROOT, framework_system_dir=SYSTEM_DIR)
 
 
 class VaultPath(type(Path())):
@@ -126,6 +129,14 @@ class VaultPath(type(Path())):
         if not self._inside_selected_vault():
             return super().unlink(missing_ok=missing_ok)
         unlink_vault_file(self, vault_root=REPO_DIR, missing_ok=missing_ok)
+
+
+# The root itself must retain the authority too: many runtime commands build
+# user-selected descendants with ``REPO_DIR / relative_path`` rather than a
+# named contract constant.  pathlib preserves this subclass through joins,
+# globbing, and rglobbing, so those legacy call sites cannot silently fall
+# back to symlink-following I/O after process binding.
+REPO_DIR = VaultPath(_RESOLVED_VAULT_ROOT)
 
 
 def _data(name: str) -> Path:

--- a/system/mirror.py
+++ b/system/mirror.py
@@ -256,7 +256,7 @@ def emit_task(out_dir: Path) -> int:
         return 0
     out_dir.mkdir(parents=True, exist_ok=True)
     prompt_file = out_dir / "mirror.prompt.md"
-    prompt_file.write_text(build_mirror_prompt(entries), encoding="utf-8")
+    write_text(prompt_file, build_mirror_prompt(entries))
     manifest = out_dir / "manifest.json"
     write_json(manifest, {
         "task": "mirror",

--- a/system/monthly_research.sh
+++ b/system/monthly_research.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="${WORKSPACE:-$(dirname "$SCRIPT_DIR")}"
+WORKSPACE="${WORKSPACE:-${LIFEHUG_VAULT_ROOT:-$(dirname "$SCRIPT_DIR")}}"
+WORKSPACE="$(python3 "$SCRIPT_DIR/vault_paths.py" root --vault-root "$WORKSPACE")" || exit 1
+export LIFEHUG_VAULT_ROOT="$WORKSPACE"
 cd "$WORKSPACE"
 
 DRY_RUN="${LIFEHUG_MONTHLY_DRY_RUN:-0}"
@@ -21,8 +23,11 @@ fi
 # v86 (issue #35): Telegram gets a short summary; the full output is
 # persisted as a committed report document.
 START_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-REPORT_DIR="state/reports"
+REPORT_DIR="$(python3 "$SCRIPT_DIR/vault_paths.py" data-path reports --vault-root "$WORKSPACE")"
 REPORT_FILE="$REPORT_DIR/monthly-$(date +%F).md"
+QUESTION_QUEUE_PATH="$WORKSPACE/$(python3 "$SCRIPT_DIR/vault_paths.py" data-path question_queue --vault-root "$WORKSPACE")"
+AGENT_TASKS_DIR="$(python3 "$SCRIPT_DIR/vault_paths.py" data-path agent_tasks --vault-root "$WORKSPACE")"
+export QUESTION_QUEUE_PATH
 
 # --- Telegram notification helper ---
 # Delegates to `lifehug.py notify` (resolves chat/token, chunks under the
@@ -87,20 +92,10 @@ run_optional() {
 }
 
 safe_autocommit() {
-  local paths=(
-    README.md
-    question-bank.md
-    state/rotation.json
-    state/coverage.json
-    system/question-bank.md
-    system/rotation.json
-    system/coverage.json
-    answers
-    outputs
-    sources
-    state
-    wiki
-  )
+  local paths=()
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && paths+=("$path")
+  done < <(python3 "$SCRIPT_DIR/vault_paths.py" git-paths --vault-root "$WORKSPACE")
   local existing=()
   for path in "${paths[@]}"; do
     [[ -e "$path" ]] && existing+=("$path")
@@ -146,6 +141,7 @@ PY
 select_gap_targets() {
   python3 - "$WORKSPACE" "$GAP_LIMIT" <<'PY'
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -158,7 +154,7 @@ import research_expand as research  # noqa: E402
 # the cron acting on it. Low urgency (Focuses still have room) → no new
 # neighborhoods this month; the archive deepens instead of widening.
 try:
-    queue = json.loads((workspace / "state" / "question_queue.json").read_text(encoding="utf-8"))
+    queue = json.loads(Path(os.environ["QUESTION_QUEUE_PATH"]).read_text(encoding="utf-8"))
     urgency = float(queue.get("allocation", {}).get("expansion", {}).get("urgency", 1.0))
 except (OSError, ValueError):
     urgency = 1.0  # no queue signal → don't block expansion
@@ -226,13 +222,13 @@ generate_topic() {
     # --from-response (see skills/maintenance).
     local slug
     slug=$(printf '%s' "$topic" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-')
-    mkdir -p state/agent_tasks/research
+    mkdir -p "$AGENT_TASKS_DIR/research"
     if python3 "$SCRIPT_DIR/research_expand.py" --topic "$topic" --type "$topic_type" --output "$output" --prompt \
-        > "state/agent_tasks/research/${slug}.prompt.md" 2>&1; then
-      echo "⏸ keyless — expansion prompt for '${topic}' emitted to state/agent_tasks/research/${slug}.prompt.md"
+        > "$AGENT_TASKS_DIR/research/${slug}.prompt.md" 2>&1; then
+      echo "⏸ keyless — expansion prompt for '${topic}' emitted to $AGENT_TASKS_DIR/research/${slug}.prompt.md"
       echo "  complete: python3 system/research_expand.py --topic \"$topic\" --type $topic_type --output $output --from-response <response-file>"
     else
-      echo "skip: could not emit prompt for ${topic} (see state/agent_tasks/research/${slug}.prompt.md)"
+      echo "skip: could not emit prompt for ${topic} (see $AGENT_TASKS_DIR/research/${slug}.prompt.md)"
     fi
     return 0
   fi
@@ -314,9 +310,9 @@ for etype in person place period object theme; do
   if [[ "$KEYLESS" == "1" ]]; then
     # Keyless: emit the resolution task for agent completion. NEVER fall back
     # to the deterministic roster — it stateless-refreshes junk (v90 lesson).
-    mkdir -p state/agent_tasks/roster
+    mkdir -p "$AGENT_TASKS_DIR/roster"
     set +e
-    ETYPE_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" entity-roster --type "$etype" --emit-task "state/agent_tasks/roster/${etype}.json" 2>&1)
+    ETYPE_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" entity-roster --type "$etype" --emit-task "$AGENT_TASKS_DIR/roster/${etype}.json" 2>&1)
     ETYPE_STATUS=$?
     set -e
     if [[ "$ETYPE_STATUS" -ne 0 ]]; then

--- a/system/process_answer.py
+++ b/system/process_answer.py
@@ -142,7 +142,16 @@ def _push_failed(operation: str, result: subprocess.CompletedProcess) -> None:
 def git_commit(message: str, push: bool) -> None:
     paths = [
         vault_relative_path(name, vault_root=REPO_DIR, framework_system_dir=SYSTEM_DIR).as_posix()
-        for name in ("readme", "question_bank", "rotation", "coverage", "answers", "state", "wiki")
+        for name in (
+            "readme",
+            "question_bank",
+            "rotation",
+            "coverage",
+            "answers",
+            "source_manifest",
+            "answer_scores",
+            "wiki",
+        )
     ]
     existing = [path for path in paths if (REPO_DIR / path).exists()]
     subprocess.run(["git", "-C", str(REPO_DIR), "add", "--", *existing], check=True)

--- a/system/process_answer.py
+++ b/system/process_answer.py
@@ -15,6 +15,7 @@ from lifehug_core import (
     README_FILE,
     REPO_DIR,
     ROTATION_FILE,
+    SYSTEM_DIR,
     mark_answered_in_bank,
     parse_categories,
     parse_questions,
@@ -27,6 +28,7 @@ from lifehug_core import (
 )
 from source_integrity import SCHEMA_VERSION, format_frontmatter, payload_sha256, register_source
 from update_readme import update_readme
+from vault_paths import vault_relative_path
 
 FOLLOWUP_HEADER = "📖 Lifehug — since you're on a roll"
 FOLLOWUP_FOOTER = "(Totally optional — tomorrow's question comes either way)"
@@ -139,15 +141,11 @@ def _push_failed(operation: str, result: subprocess.CompletedProcess) -> None:
 
 def git_commit(message: str, push: bool) -> None:
     paths = [
-        "README.md",
-        "system/question-bank.md",
-        "system/rotation.json",
-        "system/coverage.json",
-        "answers",
-        "state",
-        "wiki",
+        vault_relative_path(name, vault_root=REPO_DIR, framework_system_dir=SYSTEM_DIR).as_posix()
+        for name in ("readme", "question_bank", "rotation", "coverage", "answers", "state", "wiki")
     ]
-    subprocess.run(["git", "-C", str(REPO_DIR), "add", "--", *paths], check=True)
+    existing = [path for path in paths if (REPO_DIR / path).exists()]
+    subprocess.run(["git", "-C", str(REPO_DIR), "add", "--", *existing], check=True)
     diff = subprocess.run(["git", "-C", str(REPO_DIR), "diff", "--cached", "--quiet"])
     if diff.returncode == 0:
         return
@@ -175,7 +173,7 @@ def git_commit(message: str, push: bool) -> None:
 
 def compile_wiki() -> None:
     subprocess.run(
-        [sys.executable, str(REPO_DIR / "system" / "wiki_compile.py")],
+        [sys.executable, str(SYSTEM_DIR / "wiki_compile.py")],
         cwd=REPO_DIR,
         check=True,
     )

--- a/system/quality_profile.py
+++ b/system/quality_profile.py
@@ -21,17 +21,15 @@ import sys
 from pathlib import Path
 
 from lifehug_core import (
+    ANSWER_SCORES_FILE,
     ANSWERS_DIR,
     QUESTIONS_FILE,
-    REPO_DIR,
+    QUALITY_PROFILE_FILE,
     now_utc,
     parse_questions,
     read_json,
     write_json,
 )
-
-ANSWER_SCORES_FILE = REPO_DIR / "state" / "answer_scores.json"
-QUALITY_PROFILE_FILE = REPO_DIR / "state" / "quality_profile.json"
 
 # Minimum scored answers before the profile activates and influences anything.
 ACTIVATION_THRESHOLD = 20

--- a/system/question_candidates.py
+++ b/system/question_candidates.py
@@ -12,8 +12,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from lifehug_core import (
+    PERENNIALS_FILE,
     QUESTION_CANDIDATES_FILE,
     QUESTIONS_FILE,
+    REPO_DIR,
+    WIKI_DIR,
     now_utc,
     parse_categories,
     parse_questions,
@@ -645,10 +648,7 @@ def harvest_wiki_questions(dry_run: bool = False, cap: int = WIKI_HARVEST_CAP) -
     """Pull non-boilerplate 'Open Questions' from compiled wiki pages into the
     candidate store. Before this, compile was a dead end for question
     generation — insights the synthesis surfaced never became questions."""
-    from lifehug_core import REPO_DIR  # noqa: PLC0415
-
-    wiki_dir = REPO_DIR / "wiki"
-    if not wiki_dir.exists():
+    if not WIKI_DIR.exists():
         return []
     data = load_store()
     existing_pairs = [(c.get("id", ""), str(c.get("text", ""))) for c in data.get("candidates", [])]
@@ -659,7 +659,7 @@ def harvest_wiki_questions(dry_run: bool = False, cap: int = WIKI_HARVEST_CAP) -
     bank_pairs = [(str(q.get("id", "")), str(q.get("text", ""))) for q in bank_questions]
 
     harvested: list[str] = []
-    for page in sorted(wiki_dir.rglob("*.md")):
+    for page in sorted(WIKI_DIR.rglob("*.md")):
         if len(harvested) >= cap:
             break
         if page.name in ("index.md", "log.md", "SCHEMA.md"):
@@ -743,7 +743,6 @@ def score_candidate_for_promotion(candidate: dict, quality_profile: dict | None 
 # product: "a year ago you said X — what's true today?"
 # ---------------------------------------------------------------------------
 
-PERENNIALS_FILE = QUESTION_CANDIDATES_FILE.parent / "perennials.json"
 PERENNIAL_INTERVAL_DAYS = 350  # a touch under a year so the slot lands annually
 
 

--- a/system/question_planner.py
+++ b/system/question_planner.py
@@ -23,6 +23,7 @@ from lifehug_core import (
     QUESTION_QUEUE_FILE,
     QUESTIONS_FILE,
     REPO_DIR,
+    SECOND_VOICE_OFFERS_FILE,
     SOURCES_DIR,
     STATE_DIR,
     FOCUS_RECS_FILE,
@@ -416,7 +417,6 @@ def build_focus_index(focuses: list[dict], questions: list[dict]) -> dict:
 # NEVER repeated.
 # ---------------------------------------------------------------------------
 
-SECOND_VOICE_OFFERS_FILE = STATE_DIR / "second_voice_offers.json"
 DEFAULT_SECOND_VOICE_OFFERS_PER_MONTH = 2
 
 

--- a/system/roadmap.py
+++ b/system/roadmap.py
@@ -27,6 +27,7 @@ if str(_SYSTEM_DIR) not in sys.path:
 
 from lifehug_core import (  # noqa: E402
     QUESTIONS_FILE,
+    ROADMAP_FILE,
     STATE_DIR,
     WIKI_DIR,
     load_config,
@@ -39,8 +40,6 @@ from lifehug_core import (  # noqa: E402
     write_json,
     write_text,
 )
-
-ROADMAP_FILE = STATE_DIR / "roadmap.json"
 
 # Tier → default target depth (number of answers that count as "well-known").
 TIER_TARGETS = {"basic": 8, "standard": 20, "extreme": 50}

--- a/system/serve_wiki.py
+++ b/system/serve_wiki.py
@@ -27,6 +27,7 @@ from lifehug_core import (
     QUESTIONS_FILE,
     REPO_DIR,
     ROTATION_FILE,
+    SECOND_VOICE_OFFERS_FILE,
     SOURCE_LINT_FINDINGS_FILE,
     SOURCE_MANIFEST_FILE,
     STATE_DIR,
@@ -893,8 +894,6 @@ def view_status():
 # strip below shows state (not debt). Design notes: 3–5 cards max, at most one
 # heavy introspective card, absence reads as stillness.
 # ---------------------------------------------------------------------------
-
-SECOND_VOICE_OFFERS_FILE = STATE_DIR / "second_voice_offers.json"
 
 # Left-rule accent per invitation kind. Calm palette — no reds on the home page.
 _HUB_ACCENTS = {

--- a/system/serve_wiki.py
+++ b/system/serve_wiki.py
@@ -36,6 +36,7 @@ from lifehug_core import (
     parse_categories,
     parse_questions,
     read_json,
+    read_text,
     slugify,
 )
 from entity_roster import ENTITY_TYPES, load_roster
@@ -92,8 +93,7 @@ _GROUP_LABELS = {
 def page_field(path: Path, key: str) -> str:
     """Read a single frontmatter scalar (e.g. `title`, `project`) from a page."""
     try:
-        with path.open(encoding="utf-8", errors="replace") as fh:
-            head = fh.read(1024)
+        head = read_text(path, errors="replace")[:1024]
         m = re.search(rf'^{re.escape(key)}:\s*"?(.+?)"?\s*$', head, re.MULTILINE)
         if m:
             return m.group(1).strip()

--- a/system/source_integrity.py
+++ b/system/source_integrity.py
@@ -30,6 +30,7 @@ from lifehug_core import (
     WIKI_DIR,
     answer_id_from_filename,
     now_utc,
+    read_bytes,
     read_json,
     slugify,
     split_frontmatter,
@@ -108,11 +109,7 @@ def payload_sha256(text: str) -> str:
 
 
 def file_sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+    return hashlib.sha256(read_bytes(path)).hexdigest()
 
 
 def source_payload(content: str) -> str:

--- a/system/source_integrity.py
+++ b/system/source_integrity.py
@@ -22,10 +22,12 @@ from pathlib import Path
 from lifehug_core import (
     ANSWERS_DIR,
     CORRECTION_SOURCES_DIR,
+    ENTITY_ROSTERS_DIR,
     REPO_DIR,
     SOURCE_LINT_FINDINGS_FILE,
     SOURCE_MANIFEST_FILE,
     SOURCES_DIR,
+    WIKI_DIR,
     answer_id_from_filename,
     now_utc,
     read_json,
@@ -404,10 +406,9 @@ def _parse_sources_block(lines: list[str]) -> set[str]:
 
 def _wiki_source_refs() -> dict[str, set[str]]:
     refs: dict[str, set[str]] = {}
-    wiki_dir = REPO_DIR / "wiki"
-    if not wiki_dir.exists():
+    if not WIKI_DIR.exists():
         return refs
-    for page in sorted(wiki_dir.rglob("*.md")):
+    for page in sorted(WIKI_DIR.rglob("*.md")):
         if page.name in {"SCHEMA.md", "index.md", "log.md"}:
             continue
         text = page.read_text(encoding="utf-8", errors="replace")
@@ -432,9 +433,8 @@ def _frontmatter_value(text: str, key: str) -> str:
 def _wiki_entity_pages() -> list[dict]:
     """Scan wiki entity dirs → [{path, type, origin, slug, sources}] per page."""
     pages: list[dict] = []
-    wiki_dir = REPO_DIR / "wiki"
     for dir_name, entity_type in _ENTITY_PAGE_DIRS.items():
-        directory = wiki_dir / dir_name
+        directory = WIKI_DIR / dir_name
         if not directory.exists():
             continue
         for page in sorted(directory.glob("*.md")):
@@ -454,7 +454,7 @@ def _wiki_entity_pages() -> list[dict]:
 def _roster_slug_index(entity_type: str) -> set[str] | None:
     """All slugs an entity roster accounts for (slug + name + aliases, slugified).
     None when the roster is missing/empty — callers must skip judgment then."""
-    data = read_json(REPO_DIR / "state" / "entity_rosters" / f"{entity_type}.json", default=None)
+    data = read_json(ENTITY_ROSTERS_DIR / f"{entity_type}.json", default=None)
     entities = (data or {}).get("entities") or []
     if not entities:
         return None

--- a/system/timeline.py
+++ b/system/timeline.py
@@ -37,8 +37,11 @@ import timeline_corroboration as tcorr  # noqa: E402
 
 from lifehug_core import (  # noqa: E402
     CLASSIFICATIONS_DIR,
+    CONNECTORS_STATE_DIR,
+    ENTITY_ROSTERS_DIR,
     MANUAL_SOURCES_DIR,
     STATE_DIR,
+    TIMELINE_PLACEMENTS_FILE,
     WIKI_DIR,
     read_json,
     slugify,
@@ -90,7 +93,7 @@ def load_periods() -> list[dict]:
     """Chrono-ordered periods: roster entries joined with their wiki pages'
     source lists. Falls back to page frontmatter `chrono:` when the roster is
     missing. Periods without a chrono sort last (a visible gap in itself)."""
-    roster = read_json(STATE_DIR / "entity_rosters" / "period.json", default=None) or {}
+    roster = read_json(ENTITY_ROSTERS_DIR / "period.json", default=None) or {}
     by_slug: dict[str, dict] = {}
     for ent in roster.get("entities", []) or []:
         if not ent.get("page_eligible"):
@@ -360,7 +363,7 @@ def learned_era_vocabulary(periods: list[dict], events: list[dict]) -> dict[str,
 # surfacing as stale notices for the owner to resolve.
 # ---------------------------------------------------------------------------
 
-PLACEMENTS_FILE = STATE_DIR / "timeline_placements.json"
+PLACEMENTS_FILE = TIMELINE_PLACEMENTS_FILE
 
 
 def placement_key(event: dict) -> str:
@@ -578,8 +581,13 @@ def timeline_data(evidence: list[dict] | None = None) -> dict:
     # `evidence` overrides the on-disk files (excavation passes its fresh
     # assertions so candidates never lag a run). No evidence → nothing
     # attached, nothing renders differently.
-    corroboration = tcorr.corroborate(periods, event_lineup, unplaced_events,
-                                      STATE_DIR / "connectors", evidence=evidence)
+    corroboration = tcorr.corroborate(
+        periods,
+        event_lineup,
+        unplaced_events,
+        CONNECTORS_STATE_DIR,
+        evidence=evidence,
+    )
 
     # Placements whose event no longer exists (reclassification rewrote the
     # description) or whose period page is gone — surfaced, never silently

--- a/system/vault_contract.json
+++ b/system/vault_contract.json
@@ -1,0 +1,77 @@
+{
+  "contract_version": 1,
+  "external_forbidden_paths": [
+    "system"
+  ],
+  "framework_paths": {
+    "system": "system",
+    "templates": "templates",
+    "mission": "system/mission.md",
+    "research": "system/research.md",
+    "version": "system/version.json",
+    "connectors": "system/connectors"
+  },
+  "data_paths": {
+    "question_bank": {
+      "path": "question-bank.md",
+      "embedded_path": "system/question-bank.md",
+      "kind": "file",
+      "required": true,
+      "tracked": true,
+      "schema": {"format": "markdown", "version_field": null, "supported": []}
+    },
+    "rotation": {
+      "path": "state/rotation.json",
+      "embedded_path": "system/rotation.json",
+      "kind": "file",
+      "required": true,
+      "tracked": true,
+      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+    },
+    "coverage": {
+      "path": "state/coverage.json",
+      "embedded_path": "system/coverage.json",
+      "kind": "file",
+      "required": true,
+      "tracked": true,
+      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+    },
+    "profile": {"path": "profile.yaml", "kind": "file", "required": false, "tracked": true, "schema": {"format": "yaml", "version_field": null, "supported": []}},
+    "config": {"path": "config.yaml", "kind": "file", "required": false, "tracked": false, "schema": {"format": "yaml", "version_field": null, "supported": []}},
+    "readme": {"path": "README.md", "kind": "file", "required": false, "tracked": true, "schema": {"format": "markdown", "version_field": null, "supported": []}},
+    "answers": {"path": "answers", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
+    "outputs": {"path": "outputs", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "artifact_family", "version_field": null, "supported": []}},
+    "sources": {"path": "sources", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
+    "manual_sources": {"path": "sources/manual", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
+    "import_sources": {"path": "sources/imports", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
+    "correction_sources": {"path": "sources/corrections", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
+    "artifact_sources": {"path": "sources/artifacts", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
+    "wiki": {"path": "wiki", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "compiled_markdown_family", "version_field": null, "supported": []}},
+    "state": {"path": "state", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "directory", "version_field": null, "supported": []}},
+    "question_candidates": {"path": "state/question_candidates.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "question_queue": {"path": "state/question_queue.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [2, 3]}},
+    "planner_state": {"path": "state/planner_state.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "source_manifest": {"path": "state/source_manifest.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "source_lint_findings": {"path": "state/source_lint_findings.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "learning_failures": {"path": "state/learning_failures.jsonl", "kind": "file", "required": false, "tracked": true, "schema": {"format": "jsonl", "version_field": null, "supported": []}},
+    "classifications": {"path": "state/classifications", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "json_family", "version_field": null, "supported": []}},
+    "neighborhoods": {"path": "state/neighborhoods.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "focus_recommendations": {"path": "state/focus_recommendations.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "legacy_focus_recommendations": {"path": "state/spotlight_recommendations.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "roadmap": {"path": "state/roadmap.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "quality_profile": {"path": "state/quality_profile.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "answer_scores": {"path": "state/answer_scores.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "entity_rosters": {"path": "state/entity_rosters", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "json_family", "version_field": "version", "supported": [1]}},
+    "connectors_state": {"path": "state/connectors", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "connector_family", "version_field": null, "supported": []}},
+    "second_voice_offers": {"path": "state/second_voice_offers.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "book_offers": {"path": "state/book_offers.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "timeline_placements": {"path": "state/timeline_placements.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "perennials": {"path": "state/perennials.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
+    "wiki_synthesis_cache": {"path": "state/wiki_synthesis_cache.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": null, "supported": []}},
+    "synthesis": {"path": "state/synthesis", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": null, "supported": []}},
+    "reports": {"path": "state/reports", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": null, "supported": []}},
+    "agent_tasks": {"path": "state/agent_tasks", "kind": "directory", "required": false, "tracked": false, "schema": {"format": "task_family", "version_field": null, "supported": []}},
+    "jobs": {"path": "state/jobs", "kind": "directory", "required": false, "tracked": false, "schema": {"format": "job_family", "version_field": "record_version", "supported": [2]}},
+    "compile_needed": {"path": "state/.compile-needed", "kind": "file", "required": false, "tracked": false, "schema": {"format": "sentinel", "version_field": null, "supported": []}}
+  }
+}

--- a/system/vault_contract.json
+++ b/system/vault_contract.json
@@ -1,7 +1,27 @@
 {
   "contract_version": 1,
+  "identity": {
+    "framework": "lifehug/lifehug",
+    "framework_version": 120,
+    "revision": "vault-contract-v1",
+    "content_digest": "sha256:335369282eb9b1c3f205eb784c1f8b17cdbb6681e04baeabdcbc356b3d27a635"
+  },
+  "special_file_policy": {
+    "regular_files": "allow",
+    "directories": "allow",
+    "symlinks": "reject",
+    "fifos": "reject",
+    "sockets": "reject",
+    "devices": "reject"
+  },
   "external_forbidden_paths": [
-    "system"
+    "system",
+    "templates"
+  ],
+  "required_data_paths": [
+    "question_bank",
+    "rotation",
+    "coverage"
   ],
   "framework_paths": {
     "system": "system",
@@ -18,7 +38,7 @@
       "kind": "file",
       "required": true,
       "tracked": true,
-      "schema": {"format": "markdown", "version_field": null, "supported": []}
+      "schema": {"format": "markdown", "version_field": null, "supported": [], "validation_policy": "opaque", "required_keys": {}, "unknown_fields": "allow"}
     },
     "rotation": {
       "path": "state/rotation.json",
@@ -26,7 +46,24 @@
       "kind": "file",
       "required": true,
       "tracked": true,
-      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+      "schema": {
+        "format": "json",
+        "version_field": "version",
+        "supported": [1],
+        "validation_policy": "blocking",
+        "required_keys": {
+          "version": "integer",
+          "current_pass": "integer",
+          "pass_names": "array",
+          "last_question_id": "string|null",
+          "last_asked_at": "string|null",
+          "questions_asked": "integer",
+          "questions_answered": "integer",
+          "next_question_id": "string|null",
+          "focus_frequency": "integer"
+        },
+        "unknown_fields": "allow"
+      }
     },
     "coverage": {
       "path": "state/coverage.json",
@@ -34,7 +71,18 @@
       "kind": "file",
       "required": true,
       "tracked": true,
-      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+      "schema": {
+        "format": "json",
+        "version_field": "version",
+        "supported": [1],
+        "validation_policy": "blocking",
+        "required_keys": {
+          "version": "integer",
+          "last_updated": "string|null",
+          "categories": "object"
+        },
+        "unknown_fields": "allow"
+      }
     },
     "profile": {"path": "profile.yaml", "kind": "file", "required": false, "tracked": true, "schema": {"format": "yaml", "version_field": null, "supported": []}},
     "config": {"path": "config.yaml", "kind": "file", "required": false, "tracked": false, "schema": {"format": "yaml", "version_field": null, "supported": []}},
@@ -47,7 +95,7 @@
     "correction_sources": {"path": "sources/corrections", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
     "artifact_sources": {"path": "sources/artifacts", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": "schema_version", "supported": [1]}},
     "wiki": {"path": "wiki", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "compiled_markdown_family", "version_field": null, "supported": []}},
-    "state": {"path": "state", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "directory", "version_field": null, "supported": []}},
+    "state": {"path": "state", "kind": "directory", "required": false, "tracked": false, "schema": {"format": "directory", "version_field": null, "supported": []}},
     "question_candidates": {"path": "state/question_candidates.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
     "question_queue": {"path": "state/question_queue.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [2, 3]}},
     "planner_state": {"path": "state/planner_state.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
@@ -62,7 +110,7 @@
     "quality_profile": {"path": "state/quality_profile.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
     "answer_scores": {"path": "state/answer_scores.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
     "entity_rosters": {"path": "state/entity_rosters", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "json_family", "version_field": "version", "supported": [1]}},
-    "connectors_state": {"path": "state/connectors", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "connector_family", "version_field": null, "supported": []}},
+    "connectors_state": {"path": "state/connectors", "kind": "directory", "required": false, "tracked": false, "schema": {"format": "connector_family", "version_field": null, "supported": []}},
     "second_voice_offers": {"path": "state/second_voice_offers.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
     "book_offers": {"path": "state/book_offers.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},
     "timeline_placements": {"path": "state/timeline_placements.json", "kind": "file", "required": false, "tracked": true, "schema": {"format": "json", "version_field": "version", "supported": [1]}},

--- a/system/vault_paths.py
+++ b/system/vault_paths.py
@@ -1,31 +1,86 @@
 #!/usr/bin/env python3
-"""One path authority for the installed framework and active user vault.
+"""Authoritative framework/vault roots and versioned durable-data contract.
 
-The repository embeds both today, while a future vault-only layout can point
-an installed framework at a separate data directory.  Callers should keep
-these roots distinct: executable assets come from ``framework_system_dir``;
-durable user data comes from ``resolve_vault_root``.
+Executable assets always come from the installed framework. Durable user data
+always comes from the selected vault. ``vault_contract.json`` is the one
+machine-readable path/minimum-shape/schema table consumed here and, after an
+explicit package pin, by hosted import/preflight parity checks.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
+import sys
 from pathlib import Path
 
 EMBEDDED_FRAMEWORK_SYSTEM_DIR = Path(__file__).resolve().parent
+VAULT_CONTRACT_FILE = EMBEDDED_FRAMEWORK_SYSTEM_DIR / "vault_contract.json"
+
+
+def _relative_contract_path(value: object, *, label: str) -> Path:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise RuntimeError(f"invalid {label} in vault contract")
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts or path == Path("."):
+        raise RuntimeError(f"unsafe {label} in vault contract")
+    return path
+
+
+def _load_contract() -> dict[str, object]:
+    try:
+        value = json.loads(VAULT_CONTRACT_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Lifehug vault contract is missing or invalid") from exc
+    if not isinstance(value, dict) or value.get("contract_version") != 1:
+        raise RuntimeError("unsupported Lifehug vault contract")
+    data_paths = value.get("data_paths")
+    framework_paths = value.get("framework_paths")
+    if not isinstance(data_paths, dict) or not isinstance(framework_paths, dict):
+        raise RuntimeError("Lifehug vault contract has no path tables")
+    for name, raw in data_paths.items():
+        if not isinstance(name, str) or not isinstance(raw, dict):
+            raise RuntimeError("invalid durable-data entry in vault contract")
+        _relative_contract_path(raw.get("path"), label=f"data path {name}")
+        if "embedded_path" in raw:
+            _relative_contract_path(raw["embedded_path"], label=f"embedded data path {name}")
+        if raw.get("kind") not in {"file", "directory"}:
+            raise RuntimeError(f"invalid durable-data kind for {name}")
+    for name, raw in framework_paths.items():
+        _relative_contract_path(raw, label=f"framework path {name}")
+    return value
+
+
+VAULT_CONTRACT = _load_contract()
+VAULT_DATA_PATHS: dict[str, dict[str, object]] = VAULT_CONTRACT["data_paths"]  # type: ignore[assignment]
+FRAMEWORK_PATHS: dict[str, str] = VAULT_CONTRACT["framework_paths"]  # type: ignore[assignment]
+MINIMUM_VAULT_SHAPE = tuple(
+    name for name, entry in VAULT_DATA_PATHS.items() if entry.get("required") is True
+)
+STATE_SCHEMA_TABLE = {
+    name: entry["schema"] for name, entry in VAULT_DATA_PATHS.items() if "schema" in entry
+}
+
+
+def _absolute_without_symlinks(value: str | os.PathLike[str], *, label: str) -> Path:
+    candidate = Path(os.path.abspath(Path(value).expanduser()))
+    current = Path(candidate.anchor)
+    for part in candidate.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"{label} may not traverse symlinks")
+    return candidate
 
 
 def _real_directory(value: str | os.PathLike[str], *, label: str) -> Path:
     candidate = Path(value).expanduser()
     if not candidate.is_absolute():
         candidate = Path.cwd() / candidate
-    # Check the supplied path before any resolve(), which would erase the fact
-    # that the configured vault root itself was a symlink.
-    if candidate.is_symlink():
-        raise ValueError(f"{label} may not be a symlink")
+    candidate = _absolute_without_symlinks(candidate, label=label)
     if not candidate.is_dir():
         raise ValueError(f"{label} must be an existing directory")
-    return candidate.absolute()
+    return candidate
 
 
 def resolve_framework_system_dir(
@@ -39,6 +94,106 @@ def resolve_framework_system_dir(
     )
 
 
+def resolve_framework_root(
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    return resolve_framework_system_dir(framework_system_dir).parent
+
+
+def vault_layout(
+    vault_root: str | os.PathLike[str],
+    *,
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> str:
+    vault = _real_directory(vault_root, label="vault root")
+    framework = resolve_framework_system_dir(framework_system_dir)
+    return "embedded" if vault == framework.parent else "external"
+
+
+def vault_relative_path(
+    name: str,
+    *,
+    vault_root: str | os.PathLike[str],
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    try:
+        entry = VAULT_DATA_PATHS[name]
+    except KeyError as exc:
+        raise KeyError(f"unknown Lifehug durable-data path: {name}") from exc
+    layout = vault_layout(vault_root, framework_system_dir=framework_system_dir)
+    raw = entry.get("embedded_path") if layout == "embedded" else None
+    return _relative_contract_path(raw or entry["path"], label=f"data path {name}")
+
+
+def vault_data_path(
+    name: str,
+    *,
+    vault_root: str | os.PathLike[str],
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    vault = _real_directory(vault_root, label="vault root")
+    relative = vault_relative_path(
+        name,
+        vault_root=vault,
+        framework_system_dir=framework_system_dir,
+    )
+    return validate_contained_path(vault / relative, vault, label=f"vault data path {name}")
+
+
+def framework_path(
+    name: str,
+    *,
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    try:
+        relative = _relative_contract_path(FRAMEWORK_PATHS[name], label=f"framework path {name}")
+    except KeyError as exc:
+        raise KeyError(f"unknown Lifehug framework path: {name}") from exc
+    root = resolve_framework_root(framework_system_dir)
+    return validate_contained_path(root / relative, root, label=f"framework path {name}")
+
+
+def _validate_required_json(name: str, path: Path, entry: dict[str, object]) -> None:
+    schema = entry.get("schema")
+    if not isinstance(schema, dict) or schema.get("format") != "json":
+        return
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError) as exc:
+        raise ValueError(f"vault {name} must be valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"vault {name} must be a JSON object")
+    field = schema.get("version_field")
+    supported = schema.get("supported")
+    if field and isinstance(supported, list) and value.get(field) not in supported:
+        raise ValueError(f"vault {name} has an unsupported schema version")
+
+
+def validate_minimum_vault_shape(
+    vault_root: str | os.PathLike[str],
+    *,
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    vault = _real_directory(vault_root, label="vault root")
+    framework = resolve_framework_system_dir(framework_system_dir)
+    layout = vault_layout(vault, framework_system_dir=framework)
+    if layout == "external":
+        for raw in VAULT_CONTRACT.get("external_forbidden_paths", []):
+            relative = _relative_contract_path(raw, label="external forbidden path")
+            candidate = vault / relative
+            if candidate.exists() or candidate.is_symlink():
+                raise ValueError(f"external vault may not contain {relative.as_posix()}")
+    for name in MINIMUM_VAULT_SHAPE:
+        entry = VAULT_DATA_PATHS[name]
+        path = vault_data_path(name, vault_root=vault, framework_system_dir=framework)
+        expected = entry["kind"]
+        present = path.is_file() if expected == "file" else path.is_dir()
+        if not present:
+            raise ValueError(f"vault is missing required {name}")
+        _validate_required_json(name, path, entry)
+    return vault
+
+
 def resolve_vault_root(
     explicit: str | os.PathLike[str] | None = None,
     *,
@@ -47,7 +202,53 @@ def resolve_vault_root(
     """Resolve explicit argument > environment > embedded framework parent."""
     framework = resolve_framework_system_dir(framework_system_dir)
     selected = explicit or os.environ.get("LIFEHUG_VAULT_ROOT") or framework.parent
-    return _real_directory(selected, label="vault root")
+    return validate_minimum_vault_shape(selected, framework_system_dir=framework)
+
+
+def bootstrap_cli_vault_root(
+    argv: list[str] | tuple[str, ...] | None = None,
+    *,
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    """Apply a top-level ``--vault-root`` before data modules are imported."""
+    values = list(sys.argv[1:] if argv is None else argv)
+    selected: str | None = None
+    for index, value in enumerate(values):
+        if value == "--vault-root":
+            if index + 1 >= len(values):
+                return None  # argparse emits the canonical missing-value error
+            selected = values[index + 1]
+        elif value.startswith("--vault-root="):
+            selected = value.split("=", 1)[1]
+    if selected is None:
+        return None
+    root = resolve_vault_root(selected, framework_system_dir=framework_system_dir)
+    os.environ["LIFEHUG_VAULT_ROOT"] = str(root)
+    return root
+
+
+def tracked_vault_paths(
+    vault_root: str | os.PathLike[str],
+    *,
+    framework_system_dir: str | os.PathLike[str] | None = None,
+) -> tuple[str, ...]:
+    """Relative roots safe for canonical git housekeeping (never secrets)."""
+    vault = resolve_vault_root(vault_root, framework_system_dir=framework_system_dir)
+    selected = [
+        (vault_relative_path(name, vault_root=vault, framework_system_dir=framework_system_dir), entry["kind"])
+        for name, entry in VAULT_DATA_PATHS.items()
+        if entry.get("tracked") is True
+    ]
+    paths: list[Path] = []
+    for path, _kind in selected:
+        if path not in paths:
+            paths.append(path)
+    directories = [path for path, kind in selected if kind == "directory"]
+    roots = [
+        path for path in paths
+        if not any(directory != path and directory in path.parents for directory in directories)
+    ]
+    return tuple(path.as_posix() for path in roots)
 
 
 def validate_contained_path(
@@ -63,8 +264,8 @@ def validate_contained_path(
         candidate = Path.cwd() / candidate
     if not boundary.is_absolute():
         boundary = Path.cwd() / boundary
-    candidate = candidate.absolute()
-    boundary = boundary.absolute()
+    candidate = Path(os.path.abspath(candidate))
+    boundary = Path(os.path.abspath(boundary))
     try:
         relative = candidate.relative_to(boundary)
     except ValueError as exc:
@@ -78,3 +279,33 @@ def validate_contained_path(
         if current.exists() and current != candidate and not current.is_dir():
             raise ValueError(f"{label} has a non-directory parent")
     return candidate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Lifehug vault path contract")
+    sub = parser.add_subparsers(dest="command", required=True)
+    paths = sub.add_parser("git-paths", help="Print tracked vault roots, one per line")
+    paths.add_argument("--vault-root", type=Path)
+    data_path = sub.add_parser("data-path", help="Print one selected vault-relative path")
+    data_path.add_argument("name", choices=sorted(VAULT_DATA_PATHS))
+    data_path.add_argument("--vault-root", type=Path)
+    root_path = sub.add_parser("root", help="Validate and print the selected vault root")
+    root_path.add_argument("--vault-root", type=Path)
+    sub.add_parser("contract", help="Print the versioned JSON contract")
+    args = parser.parse_args(argv)
+    if args.command == "contract":
+        print(json.dumps(VAULT_CONTRACT, indent=2))
+        return 0
+    root = resolve_vault_root(args.vault_root)
+    if args.command == "root":
+        print(root)
+        return 0
+    if args.command == "data-path":
+        print(vault_relative_path(args.name, vault_root=root))
+        return 0
+    print("\n".join(tracked_vault_paths(root)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system/vault_paths.py
+++ b/system/vault_paths.py
@@ -817,6 +817,41 @@ def append_vault_text(
         os.fsync(handle.fileno())
 
 
+def unlink_vault_file(
+    path: str | os.PathLike[str],
+    *,
+    vault_root: str | os.PathLike[str],
+    missing_ok: bool = False,
+) -> None:
+    """Remove one regular vault file without following its parent or final node."""
+    relative = _relative_to_vault(path, vault_root)
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_relative_dir_no_follow(
+            root_fd,
+            relative.parent if relative.parent != Path(".") else Path(),
+            create=False,
+        )
+        _verify_directory_binding(vault_root, relative.parent, parent_fd)
+        try:
+            info = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            if missing_ok:
+                return
+            raise
+        if not stat.S_ISREG(info.st_mode):
+            raise ValueError("vault path must be a regular file")
+        os.unlink(relative.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except OSError as exc:
+        raise ValueError("vault delete target is special, symlinked, or changed") from exc
+    finally:
+        if parent_fd is not None:
+            os.close(parent_fd)
+        os.close(root_fd)
+
+
 def classify_contract_path(
     relative_path: str | os.PathLike[str],
     *,

--- a/system/vault_paths.py
+++ b/system/vault_paths.py
@@ -10,13 +10,23 @@ explicit package pin, by hosted import/preflight parity checks.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import hashlib
 import json
 import os
+import secrets
+import stat
 import sys
 from pathlib import Path
+from typing import Callable
 
 EMBEDDED_FRAMEWORK_SYSTEM_DIR = Path(__file__).resolve().parent
 VAULT_CONTRACT_FILE = EMBEDDED_FRAMEWORK_SYSTEM_DIR / "vault_contract.json"
+
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_BOUND_VAULT_ROOT: Path | None = None
+_BOUND_VAULT_IDENTITY: tuple[int, int] | None = None
 
 
 def _relative_contract_path(value: object, *, label: str) -> Path:
@@ -52,12 +62,67 @@ def _load_contract() -> dict[str, object]:
     return value
 
 
-VAULT_CONTRACT = _load_contract()
+def _contract_digest(value: dict[str, object]) -> str:
+    canonical = json.loads(json.dumps(value))
+    identity = canonical.get("identity")
+    if isinstance(identity, dict):
+        identity.pop("content_digest", None)
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _normalized_contract(value: dict[str, object]) -> dict[str, object]:
+    """Return the stable, JSON-only export consumed by hosted preflight."""
+    normalized = json.loads(json.dumps(value))
+    data_paths = normalized["data_paths"]
+    assert isinstance(data_paths, dict)
+    for name, entry in data_paths.items():
+        assert isinstance(entry, dict)
+        external = entry.pop("path", entry.get("external_path", ""))
+        entry["external_path"] = external
+        entry["embedded_path"] = entry.get("embedded_path", external)
+        entry["classification"] = "durable_data"
+        schema = entry.get("schema")
+        if isinstance(schema, dict):
+            if "supported" in schema and "supported_versions" not in schema:
+                schema["supported_versions"] = schema.pop("supported")
+            schema.setdefault("validation_policy", "deferred")
+            schema.setdefault("required_keys", {})
+            schema.setdefault("unknown_fields", "allow")
+    framework_paths = normalized["framework_paths"]
+    assert isinstance(framework_paths, dict)
+    normalized["framework_paths"] = {
+        name: {
+            "path": path,
+            "kind": "directory" if name in {"system", "templates", "connectors"} else "file",
+            "classification": "framework",
+        }
+        for name, path in framework_paths.items()
+    }
+    normalized["data_paths"] = dict(sorted(data_paths.items()))
+    normalized["framework_paths"] = dict(sorted(normalized["framework_paths"].items()))
+    normalized["path_classifications"] = ["durable_data", "framework", "unknown"]
+    normalized.setdefault("special_file_policy", {
+        "regular_files": "allow",
+        "directories": "allow",
+        "symlinks": "reject",
+        "fifos": "reject",
+        "sockets": "reject",
+        "devices": "reject",
+    })
+    return normalized
+
+
+_RAW_VAULT_CONTRACT = _load_contract()
+VAULT_CONTRACT = _normalized_contract(_RAW_VAULT_CONTRACT)
+_CONTRACT_IDENTITY = VAULT_CONTRACT.get("identity")
+if not isinstance(_CONTRACT_IDENTITY, dict) or _CONTRACT_IDENTITY.get(
+    "content_digest"
+) != _contract_digest(VAULT_CONTRACT):
+    raise RuntimeError("Lifehug vault contract identity digest does not match its content")
 VAULT_DATA_PATHS: dict[str, dict[str, object]] = VAULT_CONTRACT["data_paths"]  # type: ignore[assignment]
-FRAMEWORK_PATHS: dict[str, str] = VAULT_CONTRACT["framework_paths"]  # type: ignore[assignment]
-MINIMUM_VAULT_SHAPE = tuple(
-    name for name, entry in VAULT_DATA_PATHS.items() if entry.get("required") is True
-)
+FRAMEWORK_PATHS: dict[str, dict[str, object]] = VAULT_CONTRACT["framework_paths"]  # type: ignore[assignment]
+MINIMUM_VAULT_SHAPE = tuple(VAULT_CONTRACT["required_data_paths"])
 STATE_SCHEMA_TABLE = {
     name: entry["schema"] for name, entry in VAULT_DATA_PATHS.items() if "schema" in entry
 }
@@ -121,8 +186,8 @@ def vault_relative_path(
     except KeyError as exc:
         raise KeyError(f"unknown Lifehug durable-data path: {name}") from exc
     layout = vault_layout(vault_root, framework_system_dir=framework_system_dir)
-    raw = entry.get("embedded_path") if layout == "embedded" else None
-    return _relative_contract_path(raw or entry["path"], label=f"data path {name}")
+    raw = entry["embedded_path"] if layout == "embedded" else entry["external_path"]
+    return _relative_contract_path(raw, label=f"data path {name}")
 
 
 def vault_data_path(
@@ -146,27 +211,56 @@ def framework_path(
     framework_system_dir: str | os.PathLike[str] | None = None,
 ) -> Path:
     try:
-        relative = _relative_contract_path(FRAMEWORK_PATHS[name], label=f"framework path {name}")
+        relative = _relative_contract_path(
+            FRAMEWORK_PATHS[name]["path"], label=f"framework path {name}"
+        )
     except KeyError as exc:
         raise KeyError(f"unknown Lifehug framework path: {name}") from exc
     root = resolve_framework_root(framework_system_dir)
     return validate_contained_path(root / relative, root, label=f"framework path {name}")
 
 
-def _validate_required_json(name: str, path: Path, entry: dict[str, object]) -> None:
+def _schema_value_matches(value: object, expected: str) -> bool:
+    allowed = expected.split("|")
+    matches = {
+        "null": value is None,
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "number": isinstance(value, int | float) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+        "array": isinstance(value, list),
+        "object": isinstance(value, dict),
+    }
+    return any(matches.get(option, False) for option in allowed)
+
+
+def _validate_required_json(
+    name: str,
+    path: Path,
+    entry: dict[str, object],
+    *,
+    vault_root: Path,
+) -> None:
     schema = entry.get("schema")
     if not isinstance(schema, dict) or schema.get("format") != "json":
         return
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        value = json.loads(read_vault_text(path, vault_root=vault_root))
     except (OSError, json.JSONDecodeError, UnicodeError) as exc:
         raise ValueError(f"vault {name} must be valid JSON") from exc
     if not isinstance(value, dict):
         raise ValueError(f"vault {name} must be a JSON object")
     field = schema.get("version_field")
-    supported = schema.get("supported")
+    supported = schema.get("supported_versions")
     if field and isinstance(supported, list) and value.get(field) not in supported:
         raise ValueError(f"vault {name} has an unsupported schema version")
+    required_keys = schema.get("required_keys")
+    if schema.get("validation_policy") == "blocking" and isinstance(required_keys, dict):
+        for key, expected in required_keys.items():
+            if key not in value or not isinstance(expected, str) or not _schema_value_matches(
+                value[key], expected
+            ):
+                raise ValueError(f"vault {name} has invalid required key {key}")
 
 
 def validate_minimum_vault_shape(
@@ -187,10 +281,20 @@ def validate_minimum_vault_shape(
         entry = VAULT_DATA_PATHS[name]
         path = vault_data_path(name, vault_root=vault, framework_system_dir=framework)
         expected = entry["kind"]
-        present = path.is_file() if expected == "file" else path.is_dir()
-        if not present:
-            raise ValueError(f"vault is missing required {name}")
-        _validate_required_json(name, path, entry)
+        try:
+            if expected == "file":
+                fd = open_vault_fd(path, os.O_RDONLY, vault_root=vault)
+                os.close(fd)
+            else:
+                directory_fd = _open_absolute_dir_no_follow(path)
+                os.close(directory_fd)
+        except FileNotFoundError as exc:
+            raise ValueError(f"vault is missing required {name}") from exc
+        except (ValueError, OSError) as exc:
+            raise ValueError(f"vault has invalid required {name}: {exc}") from exc
+        _validate_required_json(name, path, entry, vault_root=vault)
+    if layout == "external":
+        walk_vault_tree(vault, layout="external")
     return vault
 
 
@@ -198,11 +302,44 @@ def resolve_vault_root(
     explicit: str | os.PathLike[str] | None = None,
     *,
     framework_system_dir: str | os.PathLike[str] | None = None,
+    bind_process: bool = False,
 ) -> Path:
     """Resolve explicit argument > environment > embedded framework parent."""
     framework = resolve_framework_system_dir(framework_system_dir)
     selected = explicit or os.environ.get("LIFEHUG_VAULT_ROOT") or framework.parent
-    return validate_minimum_vault_shape(selected, framework_system_dir=framework)
+    root = validate_minimum_vault_shape(selected, framework_system_dir=framework)
+    return bind_vault_root(root) if bind_process else root
+
+
+def bind_vault_root(vault_root: str | os.PathLike[str]) -> Path:
+    """Bind this interpreter to one vault; unsafe in-process switching rejects."""
+    global _BOUND_VAULT_IDENTITY, _BOUND_VAULT_ROOT
+    root = _real_directory(vault_root, label="vault root")
+    root_fd = _open_absolute_dir_no_follow(root)
+    try:
+        info = os.fstat(root_fd)
+        identity = (info.st_dev, info.st_ino)
+    finally:
+        os.close(root_fd)
+    if _BOUND_VAULT_ROOT is None:
+        _BOUND_VAULT_ROOT = root
+        _BOUND_VAULT_IDENTITY = identity
+    elif _BOUND_VAULT_ROOT != root or _BOUND_VAULT_IDENTITY != identity:
+        raise RuntimeError(
+            f"process is already bound to vault {_BOUND_VAULT_ROOT}; start a new process to use {root}"
+        )
+    return root
+
+
+def bound_vault_root() -> Path | None:
+    return _BOUND_VAULT_ROOT
+
+
+def _reset_process_binding_for_tests() -> None:
+    """Test-only reset; runtime code must never rebind import-bound constants."""
+    global _BOUND_VAULT_IDENTITY, _BOUND_VAULT_ROOT
+    _BOUND_VAULT_ROOT = None
+    _BOUND_VAULT_IDENTITY = None
 
 
 def bootstrap_cli_vault_root(
@@ -222,9 +359,40 @@ def bootstrap_cli_vault_root(
             selected = value.split("=", 1)[1]
     if selected is None:
         return None
-    root = resolve_vault_root(selected, framework_system_dir=framework_system_dir)
+    root = resolve_vault_root(
+        selected,
+        framework_system_dir=framework_system_dir,
+        bind_process=True,
+    )
     os.environ["LIFEHUG_VAULT_ROOT"] = str(root)
     return root
+
+
+def normalize_cli_vault_args(argv: list[str] | tuple[str, ...]) -> list[str]:
+    """Move the reserved global vault selector before the subcommand."""
+    values = list(argv)
+    selected: list[str] = []
+    remaining: list[str] = []
+    index = 0
+    while index < len(values):
+        value = values[index]
+        if value == "--vault-root":
+            if index + 1 >= len(values):
+                return values  # argparse owns the canonical missing-value error
+            if selected:
+                raise ValueError("--vault-root may be supplied only once")
+            selected = ["--vault-root", values[index + 1]]
+            index += 2
+            continue
+        if value.startswith("--vault-root="):
+            if selected:
+                raise ValueError("--vault-root may be supplied only once")
+            selected = ["--vault-root", value.split("=", 1)[1]]
+            index += 1
+            continue
+        remaining.append(value)
+        index += 1
+    return [*selected, *remaining]
 
 
 def tracked_vault_paths(
@@ -281,6 +449,458 @@ def validate_contained_path(
     return candidate
 
 
+def _relative_to_vault(
+    path: str | os.PathLike[str],
+    vault_root: str | os.PathLike[str],
+) -> Path:
+    root = Path(os.path.abspath(Path(vault_root).expanduser()))
+    raw = Path(path).expanduser()
+    candidate = Path(os.path.abspath(raw if raw.is_absolute() else root / raw))
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("vault path escaped its selected root") from exc
+    if relative == Path(".") or ".." in relative.parts:
+        raise ValueError("vault file path must name a child of the selected root")
+    return relative
+
+
+def _open_absolute_dir_no_follow(path: str | os.PathLike[str]) -> int:
+    """Open an absolute directory one component at a time without symlinks."""
+    absolute = Path(os.path.abspath(Path(path).expanduser()))
+    flags = os.O_RDONLY | _DIRECTORY | _NOFOLLOW
+    fd = os.open(absolute.anchor, flags)
+    try:
+        for part in absolute.parts[1:]:
+            next_fd = os.open(part, flags, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        if _BOUND_VAULT_ROOT == absolute and _BOUND_VAULT_IDENTITY is not None:
+            info = os.fstat(fd)
+            if (info.st_dev, info.st_ino) != _BOUND_VAULT_IDENTITY:
+                raise ValueError("bound vault root identity changed during process lifetime")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _open_relative_dir_no_follow(root_fd: int, relative: Path, *, create: bool) -> int:
+    fd = os.dup(root_fd)
+    flags = os.O_RDONLY | _DIRECTORY | _NOFOLLOW
+    try:
+        for part in relative.parts:
+            try:
+                next_fd = os.open(part, flags, dir_fd=fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, flags, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _verify_directory_binding(
+    vault_root: str | os.PathLike[str],
+    parent: Path,
+    pinned_fd: int,
+) -> None:
+    """Reject a root/intermediate swap after the pinned dirfd was acquired."""
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    try:
+        current_fd = _open_relative_dir_no_follow(root_fd, parent, create=False)
+        try:
+            current = os.fstat(current_fd)
+            pinned = os.fstat(pinned_fd)
+            if (current.st_dev, current.st_ino) != (pinned.st_dev, pinned.st_ino):
+                raise ValueError("vault directory binding changed during operation")
+        finally:
+            os.close(current_fd)
+    except OSError as exc:
+        raise ValueError("vault directory binding changed during operation") from exc
+    finally:
+        os.close(root_fd)
+
+
+def ensure_vault_directory(
+    path: str | os.PathLike[str],
+    *,
+    vault_root: str | os.PathLike[str],
+) -> Path:
+    """Create/open one vault directory using no-follow component traversal."""
+    relative = _relative_to_vault(path, vault_root)
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    try:
+        directory_fd = _open_relative_dir_no_follow(root_fd, relative, create=True)
+        try:
+            _verify_directory_binding(vault_root, relative, directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError as exc:
+        raise ValueError("vault directory is missing, special, or symlinked") from exc
+    finally:
+        os.close(root_fd)
+    return Path(os.path.abspath(Path(vault_root).expanduser())) / relative
+
+
+def open_vault_file(
+    path: str | os.PathLike[str],
+    mode: str = "r",
+    *,
+    vault_root: str | os.PathLike[str],
+    encoding: str | None = None,
+    errors: str | None = None,
+    create_parents: bool = False,
+    file_mode: int = 0o600,
+    _before_final_open: Callable[[], None] | None = None,
+):
+    """Open a regular vault file through pinned no-follow directory handles."""
+    if mode not in {"r", "rb", "w", "wb", "a", "ab", "x", "xb"}:
+        raise ValueError(f"unsupported secure vault open mode: {mode}")
+    relative = _relative_to_vault(path, vault_root)
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_relative_dir_no_follow(
+            root_fd,
+            relative.parent if relative.parent != Path(".") else Path(),
+            create=create_parents,
+        )
+        if _before_final_open:
+            _before_final_open()
+        _verify_directory_binding(vault_root, relative.parent, parent_fd)
+        access = {
+            "r": os.O_RDONLY,
+            "rb": os.O_RDONLY,
+            "w": os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            "wb": os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            "a": os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            "ab": os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            "x": os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            "xb": os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        }[mode]
+        fd = os.open(relative.name, access | _NOFOLLOW, file_mode, dir_fd=parent_fd)
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            raise ValueError("vault path must be a regular file")
+        kwargs: dict[str, object] = {}
+        if "b" not in mode:
+            kwargs = {"encoding": encoding or "utf-8", "errors": errors}
+        return os.fdopen(fd, mode, **kwargs)
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise ValueError("vault file is missing, special, or symlinked") from exc
+    finally:
+        if parent_fd is not None:
+            os.close(parent_fd)
+        os.close(root_fd)
+
+
+def open_vault_fd(
+    path: str | os.PathLike[str],
+    flags: int,
+    *,
+    vault_root: str | os.PathLike[str],
+    mode: int = 0o600,
+    create_parents: bool = False,
+) -> int:
+    """Open a regular vault file descriptor through the same no-follow boundary."""
+    relative = _relative_to_vault(path, vault_root)
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_relative_dir_no_follow(
+            root_fd,
+            relative.parent if relative.parent != Path(".") else Path(),
+            create=create_parents,
+        )
+        _verify_directory_binding(vault_root, relative.parent, parent_fd)
+        fd = os.open(relative.name, flags | _NOFOLLOW, mode, dir_fd=parent_fd)
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            raise ValueError("vault path must be a regular file")
+        return fd
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise ValueError("vault file is missing, special, or symlinked") from exc
+    finally:
+        if parent_fd is not None:
+            os.close(parent_fd)
+        os.close(root_fd)
+
+
+def read_vault_bytes(
+    path: str | os.PathLike[str],
+    *,
+    vault_root: str | os.PathLike[str],
+    _before_final_open: Callable[[], None] | None = None,
+) -> bytes:
+    with open_vault_file(
+        path,
+        "rb",
+        vault_root=vault_root,
+        _before_final_open=_before_final_open,
+    ) as handle:
+        return handle.read()
+
+
+def read_vault_text(
+    path: str | os.PathLike[str],
+    *,
+    vault_root: str | os.PathLike[str],
+    encoding: str = "utf-8",
+    errors: str | None = None,
+    _before_final_open: Callable[[], None] | None = None,
+) -> str:
+    with open_vault_file(
+        path,
+        "r",
+        vault_root=vault_root,
+        encoding=encoding,
+        errors=errors,
+        _before_final_open=_before_final_open,
+    ) as handle:
+        return handle.read()
+
+
+def atomic_write_vault_bytes(
+    path: str | os.PathLike[str],
+    content: bytes,
+    *,
+    vault_root: str | os.PathLike[str],
+    mode: int = 0o600,
+    _before_replace: Callable[[], None] | None = None,
+) -> None:
+    """Atomically write without following roots, parents, or destinations."""
+    relative = _relative_to_vault(path, vault_root)
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    parent_fd: int | None = None
+    tmp_name = f".{relative.name}.{secrets.token_hex(8)}.tmp"
+    try:
+        parent_fd = _open_relative_dir_no_follow(
+            root_fd,
+            relative.parent if relative.parent != Path(".") else Path(),
+            create=True,
+        )
+        fd = os.open(
+            tmp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+            mode,
+            dir_fd=parent_fd,
+        )
+        try:
+            with os.fdopen(fd, "wb", closefd=False) as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            os.close(fd)
+        if _before_replace:
+            _before_replace()
+        _verify_directory_binding(vault_root, relative.parent, parent_fd)
+        try:
+            destination = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            destination = None
+        if destination is not None and not stat.S_ISREG(destination.st_mode):
+            raise ValueError("vault destination must be a regular file")
+        os.rename(tmp_name, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except OSError as exc:
+        raise ValueError("vault write target is special, symlinked, or changed") from exc
+    finally:
+        if parent_fd is not None:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            os.close(parent_fd)
+        os.close(root_fd)
+
+
+def atomic_write_vault_text(
+    path: str | os.PathLike[str],
+    content: str,
+    *,
+    vault_root: str | os.PathLike[str],
+    encoding: str = "utf-8",
+    mode: int = 0o600,
+    _before_replace: Callable[[], None] | None = None,
+) -> None:
+    atomic_write_vault_bytes(
+        path,
+        content.encode(encoding),
+        vault_root=vault_root,
+        mode=mode,
+        _before_replace=_before_replace,
+    )
+
+
+def atomic_create_vault_bytes(
+    path: str | os.PathLike[str],
+    content: bytes,
+    *,
+    vault_root: str | os.PathLike[str],
+    mode: int = 0o600,
+) -> None:
+    """Publish a new regular file atomically; never replace an existing node."""
+    relative = _relative_to_vault(path, vault_root)
+    root_fd = _open_absolute_dir_no_follow(vault_root)
+    parent_fd: int | None = None
+    tmp_name = f".{relative.name}.{secrets.token_hex(8)}.tmp"
+    try:
+        parent_fd = _open_relative_dir_no_follow(
+            root_fd,
+            relative.parent if relative.parent != Path(".") else Path(),
+            create=True,
+        )
+        fd = os.open(
+            tmp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+            mode,
+            dir_fd=parent_fd,
+        )
+        try:
+            with os.fdopen(fd, "wb", closefd=False) as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            os.close(fd)
+        _verify_directory_binding(vault_root, relative.parent, parent_fd)
+        os.link(
+            tmp_name,
+            relative.name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        os.fsync(parent_fd)
+    except FileExistsError:
+        raise
+    except OSError as exc:
+        raise ValueError("vault create target is special, symlinked, or changed") from exc
+    finally:
+        if parent_fd is not None:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            os.close(parent_fd)
+        os.close(root_fd)
+
+
+def append_vault_text(
+    path: str | os.PathLike[str],
+    content: str,
+    *,
+    vault_root: str | os.PathLike[str],
+    encoding: str = "utf-8",
+    mode: int = 0o600,
+) -> None:
+    with open_vault_file(
+        path,
+        "a",
+        vault_root=vault_root,
+        encoding=encoding,
+        create_parents=True,
+        file_mode=mode,
+    ) as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def classify_contract_path(
+    relative_path: str | os.PathLike[str],
+    *,
+    authority: str,
+    layout: str = "external",
+) -> str:
+    """Classify a relative path without consulting policy or the filesystem."""
+    relative = _relative_contract_path(str(relative_path), label="classification path")
+    if authority == "vault":
+        if layout not in {"embedded", "external"}:
+            raise ValueError("layout must be embedded or external")
+        for entry in VAULT_DATA_PATHS.values():
+            raw = entry[f"{layout}_path"]
+            candidate = _relative_contract_path(raw, label="data classification path")
+            if relative == candidate or (
+                entry["kind"] == "directory" and candidate in relative.parents
+            ):
+                return "durable_data"
+        return "unknown"
+    if authority == "framework":
+        for entry in FRAMEWORK_PATHS.values():
+            candidate = _relative_contract_path(entry["path"], label="framework classification path")
+            if relative == candidate or (
+                entry["kind"] == "directory" and candidate in relative.parents
+            ):
+                return "framework"
+        return "unknown"
+    raise ValueError("authority must be vault or framework")
+
+
+def walk_vault_tree(
+    vault_root: str | os.PathLike[str],
+    *,
+    layout: str = "external",
+) -> tuple[dict[str, str], ...]:
+    """Deterministically walk regular files/directories; reject every special node."""
+    root = _real_directory(vault_root, label="vault root")
+    root_fd = _open_absolute_dir_no_follow(root)
+    rows: list[dict[str, str]] = []
+
+    def visit(directory_fd: int, prefix: Path) -> None:
+        with os.scandir(directory_fd) as scan:
+            entries = sorted(scan, key=lambda entry: entry.name)
+        for entry in entries:
+            relative = prefix / entry.name
+            info = entry.stat(follow_symlinks=False)
+            if stat.S_ISLNK(info.st_mode) or not (
+                stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)
+            ):
+                raise ValueError(f"vault tree contains forbidden special path {relative.as_posix()}")
+            kind = "directory" if stat.S_ISDIR(info.st_mode) else "file"
+            rows.append({
+                "path": relative.as_posix(),
+                "kind": kind,
+                "classification": classify_contract_path(
+                    relative, authority="vault", layout=layout
+                ),
+            })
+            if kind == "directory":
+                child_fd = os.open(
+                    entry.name,
+                    os.O_RDONLY | _DIRECTORY | _NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                try:
+                    visit(child_fd, relative)
+                finally:
+                    os.close(child_fd)
+
+    try:
+        visit(root_fd, Path())
+        _verify_directory_binding(root, Path(), root_fd)
+    except OSError as exc:
+        raise ValueError("vault tree changed or contains a forbidden path") from exc
+    finally:
+        os.close(root_fd)
+    return tuple(rows)
+
+
+def exported_contract() -> dict[str, object]:
+    """Stable one-way export for hosted parity; contains no machine-local roots."""
+    return json.loads(json.dumps(VAULT_CONTRACT, sort_keys=True))
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Lifehug vault path contract")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -292,9 +912,18 @@ def main(argv: list[str] | None = None) -> int:
     root_path = sub.add_parser("root", help="Validate and print the selected vault root")
     root_path.add_argument("--vault-root", type=Path)
     sub.add_parser("contract", help="Print the versioned JSON contract")
+    classify = sub.add_parser("classify", help="Classify one contract-relative path")
+    classify.add_argument("path")
+    classify.add_argument("--authority", choices=("vault", "framework"), required=True)
+    classify.add_argument("--layout", choices=("embedded", "external"), default="external")
+    walk = sub.add_parser("walk", help="No-follow deterministic vault tree preflight")
+    walk.add_argument("--vault-root", type=Path)
     args = parser.parse_args(argv)
     if args.command == "contract":
-        print(json.dumps(VAULT_CONTRACT, indent=2))
+        print(json.dumps(exported_contract(), indent=2, sort_keys=True))
+        return 0
+    if args.command == "classify":
+        print(classify_contract_path(args.path, authority=args.authority, layout=args.layout))
         return 0
     root = resolve_vault_root(args.vault_root)
     if args.command == "root":
@@ -302,6 +931,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == "data-path":
         print(vault_relative_path(args.name, vault_root=root))
+        return 0
+    if args.command == "walk":
+        print(json.dumps(walk_vault_tree(root, layout=vault_layout(root)), indent=2))
         return 0
     print("\n".join(tracked_vault_paths(root)))
     return 0

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 120,
+  "version": 121,
   "released": "2026-08-06",
-  "changelog": "v120: vault-only mode (issue #64). One versioned authority now separates immutable installed framework code/templates from the selected user-data vault across the CLI, queue worker, answer filing, compiler, viewer, source integrity, and scheduled maintenance flows. Explicit --vault-root overrides LIFEHUG_VAULT_ROOT, while the embedded checkout remains the zero-configuration default. External vaults require root question-bank.md plus schema-v1 state/rotation.json and state/coverage.json, forbid a system/ subtree, reject symlinked or incomplete shapes before mutation, preserve vault-relative manifests and wiki content, and ignore hosted markers. A subprocess smoke runs status, lint, queued filing, no-AI compile, and the loopback viewer against a synthetic Git vault with no code or templates; structural guards prevent competing runtime root derivations.",
+  "changelog": "v121: vault-root descendants retain the same no-follow authority as named durable paths. A source symlink introduced after process binding is now rejected consistently by compilation and source-prompt flows, so it cannot cause Lifehug to read outside the selected vault. The guard test prevents later runtime code from downcasting the selected vault root back to ordinary pathlib I/O.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 119,
+  "version": 120,
   "released": "2026-08-06",
-  "changelog": "v119: durable restart-safe local job runner and vault-wide single-writer seam (issue #56). Viewer writes, Telegram answer filing, artifact actions, compiles, and daily/weekly/monthly schedules now converge through a typed allowlist and kernel-backed writer lock; canonical unqueued mutators acquire the same lock directly. Jobs expose metadata-only queued/running/succeeded/failed/safely-retryable states, completion receipts prevent repeat-after-finalize crashes, only success-preserving compile work is retryable after ambiguity, and failed private payloads remain mode-0600 until explicit owner purge. Re-entry is bound to a live unguessable lease token; private values cross child boundaries through stdin rather than process argv; exact loopback Host/Origin checks, symlink-safe answer/source/output containment, atomic cold-start identity keys, queue draining, cleanup, and fixed public error surfaces close the adversarial seams. Framework and vault roots now share one future-vault-only path authority, and launchd examples install the worker plus canonical schedules.",
+  "changelog": "v120: vault-only mode (issue #64). One versioned authority now separates immutable installed framework code/templates from the selected user-data vault across the CLI, queue worker, answer filing, compiler, viewer, source integrity, and scheduled maintenance flows. Explicit --vault-root overrides LIFEHUG_VAULT_ROOT, while the embedded checkout remains the zero-configuration default. External vaults require root question-bank.md plus schema-v1 state/rotation.json and state/coverage.json, forbid a system/ subtree, reject symlinked or incomplete shapes before mutation, preserve vault-relative manifests and wiki content, and ignore hosted markers. A subprocess smoke runs status, lint, queued filing, no-AI compile, and the loopback viewer against a synthetic Git vault with no code or templates; structural guards prevent competing runtime root derivations.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -72,6 +72,7 @@
     "system/timeline_corroboration.py",
     "system/update.py",
     "system/update_readme.py",
+    "system/vault_contract.json",
     "system/vault_paths.py",
     "system/version.json",
     "system/weekly_maintenance.sh",
@@ -105,6 +106,7 @@
     "tests/test_v16_focus_skill.py",
     "tests/test_v117_multi_writer.py",
     "tests/test_v119_jobs.py",
+    "tests/test_v120_vault_only.py",
     "tests/test_v68_loop.py",
     "tests/test_v69_signal.py",
     "tests/test_v70_v71_craft.py",

--- a/system/weekly_maintenance.sh
+++ b/system/weekly_maintenance.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="${WORKSPACE:-$(dirname "$SCRIPT_DIR")}"
+WORKSPACE="${WORKSPACE:-${LIFEHUG_VAULT_ROOT:-$(dirname "$SCRIPT_DIR")}}"
+WORKSPACE="$(python3 "$SCRIPT_DIR/vault_paths.py" root --vault-root "$WORKSPACE")" || exit 1
+export LIFEHUG_VAULT_ROOT="$WORKSPACE"
 cd "$WORKSPACE"
 
 DRY_RUN="${LIFEHUG_WEEKLY_DRY_RUN:-0}"
@@ -27,8 +29,12 @@ fi
 # state by safe_autocommit, so it's readable from the phone via GitHub
 # and on the desktop via the wiki viewer's Reports view).
 START_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-REPORT_DIR="state/reports"
+REPORT_DIR="$(python3 "$SCRIPT_DIR/vault_paths.py" data-path reports --vault-root "$WORKSPACE")"
 REPORT_FILE="$REPORT_DIR/weekly-$(date +%F).md"
+SOURCE_FINDINGS_FILE="$WORKSPACE/$(python3 "$SCRIPT_DIR/vault_paths.py" data-path source_lint_findings --vault-root "$WORKSPACE")"
+FOCUS_RECS_FILE="$WORKSPACE/$(python3 "$SCRIPT_DIR/vault_paths.py" data-path focus_recommendations --vault-root "$WORKSPACE")"
+AGENT_TASKS_DIR="$(python3 "$SCRIPT_DIR/vault_paths.py" data-path agent_tasks --vault-root "$WORKSPACE")"
+export FOCUS_RECS_FILE
 
 # --- Telegram notification helper ---
 # Delegates to `lifehug.py notify`, which resolves chat/token and CHUNKS long
@@ -79,20 +85,10 @@ PY
 }
 
 safe_autocommit() {
-  local paths=(
-    README.md
-    question-bank.md
-    state/rotation.json
-    state/coverage.json
-    system/question-bank.md
-    system/rotation.json
-    system/coverage.json
-    answers
-    outputs
-    sources
-    state
-    wiki
-  )
+  local paths=()
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && paths+=("$path")
+  done < <(python3 "$SCRIPT_DIR/vault_paths.py" git-paths --vault-root "$WORKSPACE")
   local existing=()
   for path in "${paths[@]}"; do
     [[ -e "$path" ]] && existing+=("$path")
@@ -118,7 +114,7 @@ safe_autocommit() {
 }
 
 has_safe_source_findings() {
-  python3 - "$WORKSPACE/state/source_lint_findings.json" <<'PY'
+  python3 - "$SOURCE_FINDINGS_FILE" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -186,7 +182,7 @@ echo
 if [[ "$KEYLESS" == "1" ]]; then
   echo "==> keyless — emitting classification tasks for agent completion"
   set +e
-  CLASSIFY_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" classify-story --classify-all --unclassified --limit "$CLASSIFY_LIMIT" --emit-prompts state/agent_tasks/classify 2>&1)
+  CLASSIFY_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" classify-story --classify-all --unclassified --limit "$CLASSIFY_LIMIT" --emit-prompts "$AGENT_TASKS_DIR/classify" 2>&1)
   CLASSIFY_STATUS=$?
   set -e
   if [[ "$CLASSIFY_STATUS" -ne 0 ]]; then
@@ -254,7 +250,7 @@ if [[ "$KEYLESS" == "1" ]]; then
   echo
   echo "==> keyless — emitting mirror synthesis task for agent completion"
   set +e
-  MIRROR_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" mirror-compile --emit-task state/agent_tasks/mirror 2>&1)
+  MIRROR_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" mirror-compile --emit-task "$AGENT_TASKS_DIR/mirror" 2>&1)
   MIRROR_STATUS=$?
   set -e
   if [[ "$MIRROR_STATUS" -ne 0 ]]; then
@@ -270,9 +266,13 @@ else
 fi
 
 run_learning_step "auto_promote" python3 "$SCRIPT_DIR/lifehug.py" candidates-auto-promote
+# Read indirectly by the report section table below.
+# shellcheck disable=SC2034
 PROMOTE_OUT="$LAST_STEP_OUT"
 
 run_learning_step "planner_queue" python3 "$SCRIPT_DIR/lifehug.py" planner-queue --limit "$QUEUE_LIMIT" --arc-max "$ARC_MAX" --expires-days "$EXPIRES_DAYS"
+# Read indirectly by the report section table below.
+# shellcheck disable=SC2034
 QUEUE_OUT="$LAST_STEP_OUT"
 
 run_step python3 "$SCRIPT_DIR/research_expand.py" --gaps --dry-run
@@ -284,10 +284,10 @@ echo "$LEARNING_OUT"
 # Pending Focus recommendations — 19 once sat unreviewed for weeks because no
 # scheduled surface ever mentioned them. One line, with the approve command.
 RECS_OUT=$(python3 - <<'PY' 2>/dev/null || true
-import json, sys
+import json, os, sys
 from pathlib import Path
 try:
-    data = json.loads(Path("state/focus_recommendations.json").read_text(encoding="utf-8"))
+    data = json.loads(Path(os.environ["FOCUS_RECS_FILE"]).read_text(encoding="utf-8"))
 except (OSError, ValueError):
     sys.exit(0)
 pending = [r for r in data.get("recommendations", []) if r.get("status", "pending") == "pending"]

--- a/system/wiki_compile.py
+++ b/system/wiki_compile.py
@@ -1427,8 +1427,9 @@ def main():
                 "sources": task_sources(d),
                 "related_candidates": others,
             })
-        Path(args.emit_tasks).write_text(
-            json.dumps(tasks, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        write_text(
+            Path(args.emit_tasks), json.dumps(tasks, indent=2, ensure_ascii=False) + "\n"
+        )
         print(f"✓ Emitted {len(tasks)} synthesis task(s) to {args.emit_tasks}")
         if tasks:
             print("  Write each task's prose to its narrative_path, then run: "

--- a/system/wiki_compile.py
+++ b/system/wiki_compile.py
@@ -26,11 +26,15 @@ from pathlib import Path
 
 from lifehug_core import (
     ANSWERS_DIR,
+    CLASSIFICATIONS_DIR,
     QUESTIONS_FILE,
     REPO_DIR,
     SOURCES_DIR,
     STATE_DIR,
+    SYNTHESIS_DIR,
+    TIMELINE_PLACEMENTS_FILE,
     WIKI_DIR,
+    WIKI_SYNTHESIS_CACHE_FILE,
     answer_body,
     answer_id_from_filename,
     load_config,
@@ -93,11 +97,11 @@ THEME_KEYWORDS = {
 # explicit owner-only contract (no sanitizing; the tier system protects
 # sensitive material downstream, not the synthesis).
 CACHE_VERSION = "v3"
-SYNTH_CACHE_FILE = STATE_DIR / "wiki_synthesis_cache.json"
+SYNTH_CACHE_FILE = WIKI_SYNTHESIS_CACHE_FILE
 # Drop-zone for keyless desktop synthesis: when the skill runs through Claude
 # Code, the agent writes each page's prose here (state/synthesis/<slug>.md) and
 # the next compile consumes it into the cache. No API key / gateway needed.
-SYNTH_DIR = STATE_DIR / "synthesis"
+SYNTH_DIR = SYNTHESIS_DIR
 
 MAX_RELATED = 12  # total related links per page
 MAX_SHARED = 8    # shared-source links added per page
@@ -1220,10 +1224,10 @@ def compile_timeline(dry_run: bool = False) -> bool:
     # Honor this module's (possibly monkeypatched) roots for the call.
     saved = (tl_mod.CLASSIFICATIONS_DIR, tl_mod.STATE_DIR, tl_mod.WIKI_DIR,
              tl_mod.PLACEMENTS_FILE)
-    tl_mod.CLASSIFICATIONS_DIR = STATE_DIR / "classifications"
+    tl_mod.CLASSIFICATIONS_DIR = CLASSIFICATIONS_DIR
     tl_mod.STATE_DIR = STATE_DIR
     tl_mod.WIKI_DIR = WIKI_DIR
-    tl_mod.PLACEMENTS_FILE = STATE_DIR / "timeline_placements.json"
+    tl_mod.PLACEMENTS_FILE = TIMELINE_PLACEMENTS_FILE
     try:
         data = tl_mod.timeline_data()
     finally:

--- a/tests/test_lifehug_wrapper.py
+++ b/tests/test_lifehug_wrapper.py
@@ -174,7 +174,8 @@ class LifehugWrapperTests(unittest.TestCase):
     def test_process_answer_learning_state_is_committed(self):
         script = (SYSTEM / "process_answer.py").read_text(encoding="utf-8")
 
-        self.assertIn('"state"', script)
+        self.assertIn('"answer_scores"', script)
+        self.assertIn('"source_manifest"', script)
         self.assertIn('"quality_scoring"', script)
 
     def test_monthly_dry_run_previews_entity_roster_refresh(self):

--- a/tests/test_source_integrity.py
+++ b/tests/test_source_integrity.py
@@ -100,11 +100,23 @@ class EntityPageLintTests(unittest.TestCase):
         self.src = load("source_integrity")
         self.tmp = tempfile.TemporaryDirectory()
         self.root = Path(self.tmp.name)
+        self.original_paths = (
+            self.src.REPO_DIR,
+            self.src.WIKI_DIR,
+            self.src.ENTITY_ROSTERS_DIR,
+        )
         self.src.REPO_DIR = self.root
+        self.src.WIKI_DIR = self.root / "wiki"
+        self.src.ENTITY_ROSTERS_DIR = self.root / "state" / "entity_rosters"
         (self.root / "wiki" / "people").mkdir(parents=True)
         (self.root / "state" / "entity_rosters").mkdir(parents=True)
 
     def tearDown(self):
+        (
+            self.src.REPO_DIR,
+            self.src.WIKI_DIR,
+            self.src.ENTITY_ROSTERS_DIR,
+        ) = self.original_paths
         self.tmp.cleanup()
 
     def write_page(self, slug, sources, origin="mention"):

--- a/tests/test_v101_actions.py
+++ b/tests/test_v101_actions.py
@@ -212,9 +212,21 @@ class PostAuthTests(unittest.TestCase):
 
     def test_job_endpoint_converges_from_queued_to_succeeded(self):
         original = jobs.VAULT_ROOT
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(dir=ROOT.parent) as tmp:
             try:
-                jobs.configure(Path(tmp))
+                vault = Path(tmp)
+                (vault / "question-bank.md").write_text(
+                    "# Questions\n\n## A: Origins\n- [ ] A1: Test?\n",
+                    encoding="utf-8",
+                )
+                (vault / "state").mkdir()
+                (vault / "state" / "rotation.json").write_text(
+                    '{"version": 1}\n', encoding="utf-8"
+                )
+                (vault / "state" / "coverage.json").write_text(
+                    '{"version": 1}\n', encoding="utf-8"
+                )
+                jobs.configure(vault)
                 record = jobs.enqueue("compile", {"no_ai": True}, kick=False)
 
                 def fetch():

--- a/tests/test_v101_actions.py
+++ b/tests/test_v101_actions.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(SYSTEM))
 import jobs  # noqa: E402
 import question_planner as qp  # noqa: E402
 import serve_wiki  # noqa: E402
+import vault_paths  # noqa: E402
 
 
 class PostAuthTests(unittest.TestCase):
@@ -214,6 +215,7 @@ class PostAuthTests(unittest.TestCase):
         original = jobs.VAULT_ROOT
         with tempfile.TemporaryDirectory(dir=ROOT.parent) as tmp:
             try:
+                vault_paths._reset_process_binding_for_tests()
                 vault = Path(tmp)
                 (vault / "question-bank.md").write_text(
                     "# Questions\n\n## A: Origins\n- [ ] A1: Test?\n",
@@ -221,10 +223,26 @@ class PostAuthTests(unittest.TestCase):
                 )
                 (vault / "state").mkdir()
                 (vault / "state" / "rotation.json").write_text(
-                    '{"version": 1}\n', encoding="utf-8"
+                    json.dumps({
+                        "version": 1,
+                        "current_pass": 1,
+                        "pass_names": ["skeleton", "depth", "connections", "polish"],
+                        "last_question_id": None,
+                        "last_asked_at": None,
+                        "questions_asked": 0,
+                        "questions_answered": 0,
+                        "next_question_id": None,
+                        "focus_frequency": 4,
+                    }) + "\n",
+                    encoding="utf-8",
                 )
                 (vault / "state" / "coverage.json").write_text(
-                    '{"version": 1}\n', encoding="utf-8"
+                    json.dumps({
+                        "version": 1,
+                        "last_updated": None,
+                        "categories": {},
+                    }) + "\n",
+                    encoding="utf-8",
                 )
                 jobs.configure(vault)
                 record = jobs.enqueue("compile", {"no_ai": True}, kick=False)
@@ -252,6 +270,7 @@ class PostAuthTests(unittest.TestCase):
                 self.assertIn("state === 'queued'", page)
                 self.assertIn("state === 'succeeded'", page)
             finally:
+                vault_paths._reset_process_binding_for_tests()
                 jobs.configure(original)
 
 

--- a/tests/test_v119_jobs.py
+++ b/tests/test_v119_jobs.py
@@ -93,12 +93,27 @@ def make_minimum_vault(root: Path, *, embedded: bool = False) -> None:
     )
     state_root = data_root if embedded else root / "state"
     state_root.mkdir(parents=True, exist_ok=True)
-    (state_root / "rotation.json").write_text('{"version": 1}\n', encoding="utf-8")
-    (state_root / "coverage.json").write_text('{"version": 1}\n', encoding="utf-8")
+    (state_root / "rotation.json").write_text(json.dumps({
+        "version": 1,
+        "current_pass": 1,
+        "pass_names": ["skeleton", "depth", "connections", "polish"],
+        "last_question_id": None,
+        "last_asked_at": None,
+        "questions_asked": 0,
+        "questions_answered": 0,
+        "next_question_id": None,
+        "focus_frequency": 4,
+    }) + "\n", encoding="utf-8")
+    (state_root / "coverage.json").write_text(json.dumps({
+        "version": 1,
+        "last_updated": None,
+        "categories": {},
+    }) + "\n", encoding="utf-8")
 
 
 class DurableJobsTests(unittest.TestCase):
     def setUp(self):
+        vault_paths._reset_process_binding_for_tests()
         self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-jobs-test-", dir=ROOT.parent))
         self.vault = self.tmp / "vault-only"
         make_minimum_vault(self.vault)
@@ -112,6 +127,7 @@ class DurableJobsTests(unittest.TestCase):
 
     def tearDown(self):
         jobs.FRAMEWORK_SYSTEM_DIR = self.original_framework
+        vault_paths._reset_process_binding_for_tests()
         jobs.configure(self.original_vault)
         shutil.rmtree(self.tmp, ignore_errors=True)
 
@@ -557,7 +573,7 @@ class DurableJobsTests(unittest.TestCase):
         jobs._ensure_layout()
         shutil.rmtree(jobs.PAYLOADS_DIR)
         jobs.PAYLOADS_DIR.symlink_to(escaped, target_is_directory=True)
-        with self.assertRaisesRegex(ValueError, "real directories"):
+        with self.assertRaisesRegex(ValueError, "special, or symlinked"):
             jobs.enqueue("compile", {}, identity="symlink-payload", kick=False)
 
     def test_vault_root_authority_precedence_and_validation(self):

--- a/tests/test_v119_jobs.py
+++ b/tests/test_v119_jobs.py
@@ -83,11 +83,25 @@ raise SystemExit(int(control.get("exit_code", 0)))
 '''
 
 
+def make_minimum_vault(root: Path, *, embedded: bool = False) -> None:
+    """Create the issue #64 minimum shape used by queue-only fixtures."""
+    data_root = root / "system" if embedded else root
+    data_root.mkdir(parents=True, exist_ok=True)
+    (data_root / "question-bank.md").write_text(
+        "# Questions\n\n## A: Origins\n\n- [ ] A1: Test question?\n",
+        encoding="utf-8",
+    )
+    state_root = data_root if embedded else root / "state"
+    state_root.mkdir(parents=True, exist_ok=True)
+    (state_root / "rotation.json").write_text('{"version": 1}\n', encoding="utf-8")
+    (state_root / "coverage.json").write_text('{"version": 1}\n', encoding="utf-8")
+
+
 class DurableJobsTests(unittest.TestCase):
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-jobs-test-"))
+        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-jobs-test-", dir=ROOT.parent))
         self.vault = self.tmp / "vault-only"
-        (self.vault / "state").mkdir(parents=True)
+        make_minimum_vault(self.vault)
         self.framework = self.tmp / "framework" / "system"
         self.framework.mkdir(parents=True)
         (self.framework / "lifehug.py").write_text(FAKE_LIFEHUG, encoding="utf-8")
@@ -97,8 +111,8 @@ class DurableJobsTests(unittest.TestCase):
         jobs.FRAMEWORK_SYSTEM_DIR = self.framework
 
     def tearDown(self):
-        jobs.configure(self.original_vault)
         jobs.FRAMEWORK_SYSTEM_DIR = self.original_framework
+        jobs.configure(self.original_vault)
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def control(self, **values) -> None:
@@ -107,6 +121,7 @@ class DurableJobsTests(unittest.TestCase):
     def worker_process(self, *worker_flags: str) -> subprocess.Popen:
         env = os.environ.copy()
         env["LIFEHUG_FRAMEWORK_SYSTEM_DIR"] = str(self.framework)
+        env["LIFEHUG_VAULT_ROOT"] = str(self.vault)
         env["LIFEHUG_JOB_POLL_SECONDS"] = "0.05"
         return subprocess.Popen(
             [sys.executable, str(SYSTEM / "jobs.py"), "worker", *(worker_flags or ("--once",)),
@@ -172,7 +187,7 @@ class DurableJobsTests(unittest.TestCase):
 
     def test_cold_start_identity_key_is_atomic_across_processes(self):
         cold_vault = self.tmp / "cold-vault"
-        (cold_vault / "state").mkdir(parents=True)
+        make_minimum_vault(cold_vault)
         gate = self.tmp / "cold-start-go"
         program = (
             "import sys,time; from pathlib import Path; "
@@ -399,7 +414,13 @@ class DurableJobsTests(unittest.TestCase):
                 target.unlink()
 
     def test_file_answer_outer_queue_leaves_no_plaintext_temp(self):
-        for name in ("jobs.py", "job_execute.py", "vault_paths.py", "file_answer_bg.sh"):
+        for name in (
+            "jobs.py",
+            "job_execute.py",
+            "vault_contract.json",
+            "vault_paths.py",
+            "file_answer_bg.sh",
+        ):
             shutil.copy2(SYSTEM / name, self.framework / name)
         controlled_tmp = self.tmp / "controlled-tmp"
         controlled_tmp.mkdir()
@@ -527,10 +548,10 @@ class DurableJobsTests(unittest.TestCase):
         escaped.mkdir()
         bad_vault = self.tmp / "bad-vault"
         bad_vault.mkdir()
+        (bad_vault / "question-bank.md").write_text("# Questions\n", encoding="utf-8")
         (bad_vault / "state").symlink_to(escaped, target_is_directory=True)
-        jobs.configure(bad_vault)
         with self.assertRaisesRegex(ValueError, "symlink"):
-            jobs.enqueue("compile", {}, kick=False)
+            jobs.configure(bad_vault)
 
         jobs.configure(self.vault)
         jobs._ensure_layout()
@@ -543,24 +564,25 @@ class DurableJobsTests(unittest.TestCase):
         explicit = self.tmp / "explicit-vault"
         from_env = self.tmp / "environment-vault"
         embedded = self.tmp / "embedded-framework" / "system"
-        for path in (explicit, from_env, embedded):
-            path.mkdir(parents=True)
+        make_minimum_vault(explicit)
+        make_minimum_vault(from_env)
+        make_minimum_vault(embedded.parent, embedded=True)
         with mock.patch.dict(os.environ, {"LIFEHUG_VAULT_ROOT": str(from_env)}):
             self.assertEqual(
                 vault_paths.resolve_vault_root(
                     explicit,
                     framework_system_dir=embedded,
                 ),
-                explicit,
+                explicit.resolve(),
             )
             self.assertEqual(
                 vault_paths.resolve_vault_root(framework_system_dir=embedded),
-                from_env,
+                from_env.resolve(),
             )
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertEqual(
                 vault_paths.resolve_vault_root(framework_system_dir=embedded),
-                embedded.parent,
+                embedded.parent.resolve(),
             )
 
         symlink = self.tmp / "vault-symlink"

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -1,0 +1,447 @@
+"""v120 / issue #64 — installed framework against a data-only vault."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import signal
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSTEM = ROOT / "system"
+sys.path.insert(0, str(SYSTEM))
+
+import vault_paths  # noqa: E402
+
+
+QUESTION_BANK = """# Synthetic Lifehug questions
+
+## A: Origins
+- [ ] A1: What is your earliest synthetic memory?
+"""
+
+EXPECTED_DATA_PATHS = {
+    "agent_tasks",
+    "answer_scores",
+    "answers",
+    "artifact_sources",
+    "book_offers",
+    "classifications",
+    "compile_needed",
+    "config",
+    "connectors_state",
+    "correction_sources",
+    "coverage",
+    "entity_rosters",
+    "focus_recommendations",
+    "import_sources",
+    "jobs",
+    "learning_failures",
+    "legacy_focus_recommendations",
+    "manual_sources",
+    "neighborhoods",
+    "outputs",
+    "perennials",
+    "planner_state",
+    "profile",
+    "quality_profile",
+    "question_bank",
+    "question_candidates",
+    "question_queue",
+    "readme",
+    "reports",
+    "roadmap",
+    "rotation",
+    "second_voice_offers",
+    "source_lint_findings",
+    "source_manifest",
+    "sources",
+    "state",
+    "synthesis",
+    "timeline_placements",
+    "wiki",
+    "wiki_synthesis_cache",
+}
+
+
+def make_vault(root: Path, *, answered: bool = False) -> Path:
+    root.mkdir(parents=True)
+    state = root / "state"
+    state.mkdir()
+    bank = QUESTION_BANK.replace("- [ ] A1", "- [x] A1") if answered else QUESTION_BANK
+    (root / "question-bank.md").write_text(bank, encoding="utf-8")
+    (state / "rotation.json").write_text(
+        json.dumps({
+            "version": 1,
+            "current_pass": 1,
+            "pass_names": ["skeleton", "depth", "connections", "polish"],
+            "last_question_id": "A1" if answered else None,
+            "last_asked_at": None,
+            "questions_asked": 1 if answered else 0,
+            "questions_answered": 1 if answered else 0,
+            "next_question_id": None,
+            "focus_frequency": 4,
+        }, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (state / "coverage.json").write_text(
+        json.dumps({
+            "version": 1,
+            "last_updated": None,
+            "categories": {
+                "A": {
+                    "total": 1,
+                    "answered": 1 if answered else 0,
+                    "status": "green" if answered else "red",
+                }
+            },
+        }, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def tree_digest(root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and "__pycache__" not in path.parts:
+            result[path.relative_to(root).as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+class VaultContractTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-v120-contract-", dir=ROOT.parent))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_versioned_contract_is_the_exported_path_and_schema_authority(self):
+        raw = json.loads((SYSTEM / "vault_contract.json").read_text(encoding="utf-8"))
+        self.assertEqual(vault_paths.VAULT_CONTRACT, raw)
+        self.assertEqual(vault_paths.VAULT_DATA_PATHS, raw["data_paths"])
+        self.assertEqual(set(vault_paths.VAULT_DATA_PATHS), EXPECTED_DATA_PATHS)
+        self.assertEqual(vault_paths.FRAMEWORK_PATHS, raw["framework_paths"])
+        self.assertEqual(
+            vault_paths.MINIMUM_VAULT_SHAPE,
+            ("question_bank", "rotation", "coverage"),
+        )
+        self.assertEqual(
+            {name: raw["data_paths"][name]["path"] for name in vault_paths.MINIMUM_VAULT_SHAPE},
+            {
+                "question_bank": "question-bank.md",
+                "rotation": "state/rotation.json",
+                "coverage": "state/coverage.json",
+            },
+        )
+        self.assertEqual(vault_paths.STATE_SCHEMA_TABLE["rotation"]["supported"], [1])
+        self.assertEqual(vault_paths.STATE_SCHEMA_TABLE["coverage"]["supported"], [1])
+        self.assertEqual(raw["external_forbidden_paths"], ["system"])
+
+    def test_precedence_is_explicit_then_environment_then_embedded(self):
+        explicit = make_vault(self.tmp / "explicit")
+        environment = make_vault(self.tmp / "environment")
+        framework = self.tmp / "framework"
+        framework_system = framework / "system"
+        framework_system.mkdir(parents=True)
+        for name in ("question-bank.md", "rotation.json", "coverage.json"):
+            shutil.copy2(SYSTEM / name, framework_system / name)
+
+        with mock.patch.dict(os.environ, {"LIFEHUG_VAULT_ROOT": str(environment)}):
+            self.assertEqual(
+                vault_paths.resolve_vault_root(explicit, framework_system_dir=framework_system),
+                explicit.resolve(),
+            )
+            self.assertEqual(
+                vault_paths.resolve_vault_root(framework_system_dir=framework_system),
+                environment.resolve(),
+            )
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                vault_paths.resolve_vault_root(framework_system_dir=framework_system),
+                framework.resolve(),
+            )
+
+    def test_missing_invalid_forbidden_and_symlinked_shapes_fail_before_write(self):
+        missing = self.tmp / "missing"
+        missing.mkdir()
+        before = set(missing.rglob("*"))
+        with self.assertRaisesRegex(ValueError, "missing required question_bank"):
+            vault_paths.resolve_vault_root(missing)
+        self.assertEqual(set(missing.rglob("*")), before)
+
+        invalid = make_vault(self.tmp / "invalid")
+        (invalid / "state" / "rotation.json").write_text('{"version": 999}\n')
+        with self.assertRaisesRegex(ValueError, "unsupported schema"):
+            vault_paths.resolve_vault_root(invalid)
+
+        forbidden = make_vault(self.tmp / "forbidden")
+        (forbidden / "system").mkdir()
+        with self.assertRaisesRegex(ValueError, "may not contain system"):
+            vault_paths.resolve_vault_root(forbidden)
+
+        valid = make_vault(self.tmp / "valid")
+        root_link = self.tmp / "root-link"
+        root_link.symlink_to(valid, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            vault_paths.resolve_vault_root(root_link)
+
+        nested_parent = self.tmp / "nested-parent"
+        nested_parent.mkdir()
+        nested_vault = make_vault(nested_parent / "vault")
+        parent_link = self.tmp / "parent-link"
+        parent_link.symlink_to(nested_parent, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            vault_paths.resolve_vault_root(parent_link / nested_vault.name)
+
+        escaped = self.tmp / "escaped"
+        escaped.mkdir()
+        state_link = make_vault(self.tmp / "state-link")
+        shutil.rmtree(state_link / "state")
+        (state_link / "state").symlink_to(escaped, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            vault_paths.resolve_vault_root(state_link)
+
+        file_link = make_vault(self.tmp / "file-link")
+        rotation = file_link / "state" / "rotation.json"
+        rotation.unlink()
+        outside_rotation = self.tmp / "outside-rotation.json"
+        outside_rotation.write_text('{"version": 1}\n')
+        rotation.symlink_to(outside_rotation)
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            vault_paths.resolve_vault_root(file_link)
+
+    def test_external_data_and_framework_assets_resolve_to_disjoint_roots(self):
+        vault = make_vault(self.tmp / "vault")
+        self.assertEqual(
+            vault_paths.vault_data_path("question_bank", vault_root=vault),
+            vault.resolve() / "question-bank.md",
+        )
+        self.assertEqual(
+            vault_paths.vault_data_path("rotation", vault_root=vault),
+            vault.resolve() / "state" / "rotation.json",
+        )
+        templates = vault_paths.framework_path("templates")
+        self.assertTrue(templates.is_relative_to(ROOT.resolve()))
+        self.assertFalse(templates.is_relative_to(vault.resolve()))
+
+    def test_runtime_guard_rejects_competing_root_derivations_and_hosted_marker(self):
+        offenders: list[str] = []
+        hosted_readers: list[str] = []
+        for path in sorted(SYSTEM.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            text = path.read_text(encoding="utf-8")
+            relative = path.relative_to(ROOT).as_posix()
+            if "state/hosted.json" in text or '"hosted.json"' in text or "'hosted.json'" in text:
+                hosted_readers.append(relative)
+            if path.name != "update.py":
+                if "Path(__file__).parent.parent" in text or "Path(__file__).resolve().parents[1]" in text:
+                    offenders.append(relative)
+                if "REPO_DIR = SYSTEM_DIR.parent" in text or "REPO_DIR = _SYSTEM_DIR.parent" in text:
+                    offenders.append(relative)
+        self.assertEqual(hosted_readers, [], "hosted marker must not affect OSS runtime")
+        self.assertEqual(offenders, [], "runtime modules must import the vault authority")
+
+    def test_shell_entrypoints_validate_the_selected_root_before_cd_or_write(self):
+        target = make_vault(self.tmp / "shell-target")
+        selected = self.tmp / "shell-root-link"
+        selected.symlink_to(target, target_is_directory=True)
+        before = tree_digest(target)
+        for name in (
+            "daily_question.sh",
+            "weekly_maintenance.sh",
+            "monthly_research.sh",
+            "compile_and_commit.sh",
+            "file_answer_bg.sh",
+        ):
+            text = (SYSTEM / name).read_text(encoding="utf-8")
+            validation = text.index('vault_paths.py" root --vault-root "$WORKSPACE"')
+            for needle in ('cd "$WORKSPACE"', 'touch "$WORKSPACE/'):
+                if needle in text:
+                    self.assertLess(validation, text.index(needle), name)
+            env = os.environ.copy()
+            env["WORKSPACE"] = str(selected)
+            args = ["bash", str(SYSTEM / name)]
+            if name == "file_answer_bg.sh":
+                args.append("A1")
+            result = subprocess.run(
+                args,
+                input="synthetic answer\n",
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=10,
+            )
+            self.assertNotEqual(result.returncode, 0, name)
+        self.assertEqual(tree_digest(target), before)
+
+
+class ExternalVaultSubprocessTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-v120-smoke-", dir=ROOT.parent))
+        self.framework = self.tmp / "framework"
+        shutil.copytree(SYSTEM, self.framework / "system", ignore=shutil.ignore_patterns("__pycache__"))
+        shutil.copytree(ROOT / "templates", self.framework / "templates")
+        self.script = self.framework / "system" / "lifehug.py"
+        self.vault = make_vault(self.tmp / "vault")
+        self.other_vault = make_vault(self.tmp / "other-vault", answered=True)
+        subprocess.run(["git", "init", "-q"], cwd=self.vault, check=True)
+        subprocess.run(["git", "config", "user.email", "synthetic@example.invalid"], cwd=self.vault, check=True)
+        subprocess.run(["git", "config", "user.name", "Synthetic Fixture"], cwd=self.vault, check=True)
+        subprocess.run(["git", "add", "."], cwd=self.vault, check=True)
+        subprocess.run(["git", "commit", "-qm", "synthetic baseline"], cwd=self.vault, check=True)
+        self.env = os.environ.copy()
+        self.env.update({
+            "LIFEHUG_FRAMEWORK_SYSTEM_DIR": str(self.framework / "system"),
+            "LIFEHUG_VAULT_ROOT": str(self.vault),
+            "LIFEHUG_JOB_DRAIN_IDLE": "0.05",
+            "LIFEHUG_JOB_POLL_SECONDS": "0.02",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        })
+        self.env.pop("WORKSPACE", None)
+        self.framework_before = tree_digest(self.framework)
+        for path in self.framework.rglob("*"):
+            if path.is_file():
+                path.chmod(0o444)
+
+    def tearDown(self):
+        for path in self.framework.rglob("*") if self.framework.exists() else ():
+            if path.is_file():
+                path.chmod(0o644)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def run_cli(
+        self,
+        *args: str,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(self.script), *args],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            env=env or self.env,
+            timeout=30,
+        )
+
+    def assert_cli_ok(self, *args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+        result = self.run_cli(*args, input_text=input_text)
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        return result
+
+    def test_data_only_vault_runs_read_write_queue_compile_and_viewer_flows(self):
+        status = self.assert_cli_ok("status")
+        self.assertIn("Total: 0/1", status.stdout)
+        lint = self.assert_cli_ok("source-lint", "--no-write-findings")
+        self.assertIn("0 error(s)", lint.stdout)
+
+        filed = self.assert_cli_ok(
+            "process-answer",
+            "A1",
+            "--no-compile-wiki",
+            input_text="A bright synthetic kitchen and a red toy train.\n",
+        )
+        self.assertIn("process-answer job succeeded", filed.stdout)
+        compiled = self.assert_cli_ok("compile", "--no-ai")
+        self.assertIn("compile job succeeded", compiled.stdout)
+
+        records = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in (self.vault / "state" / "jobs").glob("[0-9a-f]*.json")
+        ]
+        self.assertGreaterEqual(len(records), 2)
+        self.assertTrue(all(record["state"] == "succeeded" for record in records))
+
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+        viewer = subprocess.Popen(
+            [sys.executable, str(self.script), "serve", "--port", str(port)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self.env,
+            start_new_session=True,
+        )
+        try:
+            body = ""
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                try:
+                    with urllib.request.urlopen(f"http://localhost:{port}/", timeout=1) as response:
+                        body = response.read().decode("utf-8")
+                    break
+                except (OSError, urllib.error.URLError):
+                    if viewer.poll() is not None:
+                        break
+                    time.sleep(0.05)
+            self.assertIsNone(viewer.poll(), "viewer exited before serving the vault")
+            self.assertIn("Lifehug", body)
+            self.assertIn("Origins", body)
+        finally:
+            if viewer.poll() is None:
+                os.killpg(viewer.pid, signal.SIGTERM)
+            try:
+                viewer.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(viewer.pid, signal.SIGKILL)
+                viewer.communicate(timeout=5)
+
+        self.assertFalse((self.vault / "system").exists())
+        self.assertEqual(list(self.vault.rglob("*.py")), [])
+        self.assertFalse((self.vault / "templates").exists())
+        self.assertTrue((self.vault / "answers" / "A1.md").is_file())
+        self.assertTrue((self.vault / "wiki" / "index.md").is_file())
+
+        forbidden = (str(self.vault.resolve()), str(self.framework.resolve()), "vault/system")
+        inspectable = {".json", ".jsonl", ".md", ".yaml", ".yml"}
+        for path in self.vault.rglob("*"):
+            if path.is_file() and ".git" not in path.parts and path.suffix in inspectable:
+                text = path.read_text(encoding="utf-8")
+                for value in forbidden:
+                    self.assertNotIn(value, text, path)
+
+        subprocess.run(["git", "add", "-A"], cwd=self.vault, check=True)
+        staged = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            cwd=self.vault,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        self.assertTrue(staged)
+        self.assertFalse(any(path == "system" or path.startswith("system/") for path in staged))
+        self.assertEqual(tree_digest(self.framework), self.framework_before)
+
+    def test_explicit_cli_root_beats_environment_and_embedded_default_is_identical(self):
+        embedded_env = self.env.copy()
+        embedded_env.pop("LIFEHUG_VAULT_ROOT", None)
+        embedded = self.run_cli("status", env=embedded_env)
+        self.assertEqual(embedded.returncode, 0, embedded.stderr)
+
+        hostile_env = self.env.copy()
+        hostile_env["LIFEHUG_VAULT_ROOT"] = str(self.other_vault)
+        explicit = self.run_cli("--vault-root", str(self.framework), "status", env=hostile_env)
+        self.assertEqual(explicit.returncode, 0, explicit.stderr)
+        self.assertEqual(explicit.stdout, embedded.stdout)
+
+        selected_environment = self.run_cli("status", env=hostile_env)
+        self.assertEqual(selected_environment.returncode, 0, selected_environment.stderr)
+        self.assertIn("Total: 1/1", selected_environment.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import signal
 import shutil
 import socket
@@ -122,32 +123,73 @@ def tree_digest(root: Path) -> dict[str, str]:
 
 class VaultContractTests(unittest.TestCase):
     def setUp(self):
+        vault_paths._reset_process_binding_for_tests()
         self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-v120-contract-", dir=ROOT.parent))
 
     def tearDown(self):
+        vault_paths._reset_process_binding_for_tests()
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def test_versioned_contract_is_the_exported_path_and_schema_authority(self):
         raw = json.loads((SYSTEM / "vault_contract.json").read_text(encoding="utf-8"))
-        self.assertEqual(vault_paths.VAULT_CONTRACT, raw)
-        self.assertEqual(vault_paths.VAULT_DATA_PATHS, raw["data_paths"])
+        exported = vault_paths.exported_contract()
+        self.assertEqual(vault_paths.VAULT_CONTRACT, exported)
+        self.assertEqual(vault_paths.VAULT_DATA_PATHS, exported["data_paths"])
         self.assertEqual(set(vault_paths.VAULT_DATA_PATHS), EXPECTED_DATA_PATHS)
-        self.assertEqual(vault_paths.FRAMEWORK_PATHS, raw["framework_paths"])
+        self.assertEqual(vault_paths.FRAMEWORK_PATHS, exported["framework_paths"])
+        self.assertEqual(list(exported["data_paths"]), sorted(exported["data_paths"]))
+        self.assertEqual(list(exported["framework_paths"]), sorted(exported["framework_paths"]))
+        self.assertEqual(exported["identity"]["framework_version"], 120)
+        self.assertEqual(
+            exported["identity"]["content_digest"],
+            vault_paths._contract_digest(exported),
+        )
         self.assertEqual(
             vault_paths.MINIMUM_VAULT_SHAPE,
             ("question_bank", "rotation", "coverage"),
         )
         self.assertEqual(
-            {name: raw["data_paths"][name]["path"] for name in vault_paths.MINIMUM_VAULT_SHAPE},
+            {
+                name: exported["data_paths"][name]["external_path"]
+                for name in vault_paths.MINIMUM_VAULT_SHAPE
+            },
             {
                 "question_bank": "question-bank.md",
                 "rotation": "state/rotation.json",
                 "coverage": "state/coverage.json",
             },
         )
-        self.assertEqual(vault_paths.STATE_SCHEMA_TABLE["rotation"]["supported"], [1])
-        self.assertEqual(vault_paths.STATE_SCHEMA_TABLE["coverage"]["supported"], [1])
-        self.assertEqual(raw["external_forbidden_paths"], ["system"])
+        for entry in exported["data_paths"].values():
+            self.assertIn("external_path", entry)
+            self.assertIn("embedded_path", entry)
+            self.assertEqual(entry["classification"], "durable_data")
+            self.assertIn(entry["schema"]["validation_policy"], {"blocking", "deferred", "opaque"})
+            self.assertIn("required_keys", entry["schema"])
+            self.assertEqual(entry["schema"]["unknown_fields"], "allow")
+        self.assertEqual(vault_paths.STATE_SCHEMA_TABLE["rotation"]["supported_versions"], [1])
+        self.assertEqual(vault_paths.STATE_SCHEMA_TABLE["coverage"]["supported_versions"], [1])
+        self.assertEqual(raw["external_forbidden_paths"], ["system", "templates"])
+        serialized = json.dumps(exported, sort_keys=True)
+        self.assertNotIn(str(ROOT), serialized)
+        self.assertNotIn("hosted", serialized.lower())
+        self.assertEqual(exported["special_file_policy"]["symlinks"], "reject")
+        self.assertEqual(
+            vault_paths.classify_contract_path(
+                "state/rotation.json", authority="vault", layout="external"
+            ),
+            "durable_data",
+        )
+        self.assertEqual(
+            vault_paths.classify_contract_path("system/lifehug.py", authority="framework"),
+            "framework",
+        )
+        self.assertEqual(
+            vault_paths.classify_contract_path("mystery.bin", authority="vault"),
+            "unknown",
+        )
+
+        core = (SYSTEM / "lifehug_core.py").read_text(encoding="utf-8")
+        self.assertEqual(set(re.findall(r'_data\("([^"]+)"\)', core)), EXPECTED_DATA_PATHS)
 
     def test_precedence_is_explicit_then_environment_then_embedded(self):
         explicit = make_vault(self.tmp / "explicit")
@@ -172,6 +214,10 @@ class VaultContractTests(unittest.TestCase):
                 vault_paths.resolve_vault_root(framework_system_dir=framework_system),
                 framework.resolve(),
             )
+        self.assertEqual(vault_paths.bind_vault_root(explicit), explicit.resolve())
+        self.assertEqual(vault_paths.bind_vault_root(explicit), explicit.resolve())
+        with self.assertRaisesRegex(RuntimeError, "already bound.*start a new process"):
+            vault_paths.bind_vault_root(environment)
 
     def test_missing_invalid_forbidden_and_symlinked_shapes_fail_before_write(self):
         missing = self.tmp / "missing"
@@ -185,6 +231,13 @@ class VaultContractTests(unittest.TestCase):
         (invalid / "state" / "rotation.json").write_text('{"version": 999}\n')
         with self.assertRaisesRegex(ValueError, "unsupported schema"):
             vault_paths.resolve_vault_root(invalid)
+
+        invalid_keys = make_vault(self.tmp / "invalid-keys")
+        (invalid_keys / "state" / "coverage.json").write_text(
+            '{"version": 1, "last_updated": null}\n'
+        )
+        with self.assertRaisesRegex(ValueError, "invalid required key categories"):
+            vault_paths.resolve_vault_root(invalid_keys)
 
         forbidden = make_vault(self.tmp / "forbidden")
         (forbidden / "system").mkdir()
@@ -222,6 +275,90 @@ class VaultContractTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "symlink"):
             vault_paths.resolve_vault_root(file_link)
 
+    def test_no_follow_io_rejects_traversal_special_files_and_deterministic_swaps(self):
+        vault = make_vault(self.tmp / "secure-vault")
+        outside = self.tmp / "outside"
+        outside.mkdir()
+        outside_file = outside / "target.txt"
+        outside_file.write_text("outside stays untouched\n", encoding="utf-8")
+
+        target = vault / "state" / "target.txt"
+        vault_paths.atomic_write_vault_text(target, "original\n", vault_root=vault)
+        self.assertEqual(
+            vault_paths.read_vault_text("state/target.txt", vault_root=vault),
+            "original\n",
+        )
+        with self.assertRaisesRegex(ValueError, "escaped"):
+            vault_paths.read_vault_text("../outside/target.txt", vault_root=vault)
+        with self.assertRaisesRegex(ValueError, "escaped"):
+            vault_paths.atomic_write_vault_text(
+                outside_file.resolve(), "escape\n", vault_root=vault
+            )
+
+        def swap_final_before_read() -> None:
+            target.unlink()
+            target.symlink_to(outside_file)
+
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            vault_paths.read_vault_text(
+                target,
+                vault_root=vault,
+                _before_final_open=swap_final_before_read,
+            )
+        self.assertEqual(outside_file.read_text(encoding="utf-8"), "outside stays untouched\n")
+        target.unlink()
+        target.write_text("original\n", encoding="utf-8")
+
+        def swap_final_before_write() -> None:
+            target.unlink()
+            target.symlink_to(outside_file)
+
+        with self.assertRaisesRegex(ValueError, "regular file"):
+            vault_paths.atomic_write_vault_text(
+                target,
+                "must not escape\n",
+                vault_root=vault,
+                _before_replace=swap_final_before_write,
+            )
+        self.assertEqual(outside_file.read_text(encoding="utf-8"), "outside stays untouched\n")
+        target.unlink()
+        target.write_text("original\n", encoding="utf-8")
+
+        original_state = vault / "state-original"
+
+        def swap_parent_before_write() -> None:
+            (vault / "state").rename(original_state)
+            (vault / "state").symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaisesRegex(ValueError, "binding changed"):
+            vault_paths.atomic_write_vault_text(
+                target,
+                "must not escape\n",
+                vault_root=vault,
+                _before_replace=swap_parent_before_write,
+            )
+        self.assertFalse((outside / "target.txt.tmp").exists())
+        self.assertEqual(outside_file.read_text(encoding="utf-8"), "outside stays untouched\n")
+        (vault / "state").unlink()
+        original_state.rename(vault / "state")
+
+        fifo = vault / "state" / "forbidden.fifo"
+        os.mkfifo(fifo)
+        with self.assertRaisesRegex(ValueError, "forbidden special"):
+            vault_paths.walk_vault_tree(vault)
+        fifo.unlink()
+
+        rows = vault_paths.walk_vault_tree(vault)
+        self.assertEqual([row["path"] for row in rows], sorted(row["path"] for row in rows))
+        self.assertTrue(all(row["classification"] in {"durable_data", "unknown"} for row in rows))
+
+        vault_paths.bind_vault_root(vault)
+        original_vault = self.tmp / "secure-vault-original"
+        vault.rename(original_vault)
+        make_vault(vault)
+        with self.assertRaisesRegex(ValueError, "root identity changed"):
+            vault_paths.read_vault_text("question-bank.md", vault_root=vault)
+
     def test_external_data_and_framework_assets_resolve_to_disjoint_roots(self):
         vault = make_vault(self.tmp / "vault")
         self.assertEqual(
@@ -239,6 +376,7 @@ class VaultContractTests(unittest.TestCase):
     def test_runtime_guard_rejects_competing_root_derivations_and_hosted_marker(self):
         offenders: list[str] = []
         hosted_readers: list[str] = []
+        direct_writers: list[str] = []
         for path in sorted(SYSTEM.rglob("*.py")):
             if "__pycache__" in path.parts:
                 continue
@@ -251,8 +389,18 @@ class VaultContractTests(unittest.TestCase):
                     offenders.append(relative)
                 if "REPO_DIR = SYSTEM_DIR.parent" in text or "REPO_DIR = _SYSTEM_DIR.parent" in text:
                     offenders.append(relative)
+                if re.search(
+                    r'(?:REPO_DIR|VAULT_ROOT)\s*/\s*["\'](?:state|answers|outputs|sources|wiki)',
+                    text,
+                ):
+                    offenders.append(relative)
+            if path.name not in {"lifehug_core.py", "update.py", "vault_paths.py"} and re.search(
+                r"\.(?:write_text|write_bytes|open)\(", text
+            ):
+                direct_writers.append(relative)
         self.assertEqual(hosted_readers, [], "hosted marker must not affect OSS runtime")
         self.assertEqual(offenders, [], "runtime modules must import the vault authority")
+        self.assertEqual(direct_writers, [], "vault writes must use the no-follow I/O authority")
 
     def test_shell_entrypoints_validate_the_selected_root_before_cd_or_write(self):
         target = make_vault(self.tmp / "shell-target")
@@ -287,6 +435,61 @@ class VaultContractTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0, name)
         self.assertEqual(tree_digest(target), before)
 
+        quoted = make_vault(self.tmp / "vault with spaces and 'quotes'")
+        stub_dir = self.tmp / "stub bin"
+        stub_dir.mkdir()
+        stub_log = self.tmp / "python argv.jsonl"
+        stub = stub_dir / "python3"
+        stub.write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, sys\n"
+            "with open(os.environ['STUB_LOG'], 'a', encoding='utf-8') as handle:\n"
+            "    handle.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+            "if len(sys.argv) >= 5 and sys.argv[1].endswith('vault_paths.py') and sys.argv[2] == 'root':\n"
+            "    print(sys.argv[4])\n"
+            "    raise SystemExit(0)\n"
+            "raise SystemExit(23)\n",
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        caller_cwd = self.tmp / "unrelated caller cwd"
+        caller_cwd.mkdir()
+        framework_before = tree_digest(SYSTEM)
+        for name in (
+            "daily_question.sh",
+            "weekly_maintenance.sh",
+            "monthly_research.sh",
+            "compile_and_commit.sh",
+            "file_answer_bg.sh",
+        ):
+            stub_log.unlink(missing_ok=True)
+            env = os.environ.copy()
+            env.update({
+                "WORKSPACE": str(quoted),
+                "PATH": f"{stub_dir}{os.pathsep}{env['PATH']}",
+                "STUB_LOG": str(stub_log),
+            })
+            args = ["/bin/bash", str(SYSTEM / name)]
+            if name == "file_answer_bg.sh":
+                args.append("A1")
+            result = subprocess.run(
+                args,
+                input="synthetic answer\n",
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=caller_cwd,
+                timeout=10,
+            )
+            self.assertNotEqual(result.returncode, 0, name)
+            first = json.loads(stub_log.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(
+                first,
+                [str(SYSTEM / "vault_paths.py"), "root", "--vault-root", str(quoted)],
+                name,
+            )
+        self.assertEqual(tree_digest(SYSTEM), framework_before)
+
 
 class ExternalVaultSubprocessTests(unittest.TestCase):
     def setUp(self):
@@ -295,6 +498,8 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
         shutil.copytree(SYSTEM, self.framework / "system", ignore=shutil.ignore_patterns("__pycache__"))
         shutil.copytree(ROOT / "templates", self.framework / "templates")
         self.script = self.framework / "system" / "lifehug.py"
+        self.caller_cwd = self.tmp / "cwd independent of framework and vault"
+        self.caller_cwd.mkdir()
         self.vault = make_vault(self.tmp / "vault")
         self.other_vault = make_vault(self.tmp / "other-vault", answered=True)
         subprocess.run(["git", "init", "-q"], cwd=self.vault, check=True)
@@ -311,6 +516,7 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
             "PYTHONDONTWRITEBYTECODE": "1",
         })
         self.env.pop("WORKSPACE", None)
+        self.env.pop("PYTHONPATH", None)
         self.framework_before = tree_digest(self.framework)
         for path in self.framework.rglob("*"):
             if path.is_file():
@@ -334,6 +540,7 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
             capture_output=True,
             text=True,
             env=env or self.env,
+            cwd=self.caller_cwd,
             timeout=30,
         )
 
@@ -352,9 +559,29 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
             "process-answer",
             "A1",
             "--no-compile-wiki",
+            "--commit",
             input_text="A bright synthetic kitchen and a red toy train.\n",
         )
         self.assertIn("process-answer job succeeded", filed.stdout)
+        committed = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            cwd=self.vault,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        self.assertEqual(
+            committed,
+            [
+                "answers/A1.md",
+                "question-bank.md",
+                "state/answer_scores.json",
+                "state/coverage.json",
+                "state/rotation.json",
+                "state/source_manifest.json",
+            ],
+        )
+        self.assertFalse(any(path.startswith("state/jobs/") for path in committed))
         compiled = self.assert_cli_ok("compile", "--no-ai")
         self.assertIn("compile job succeeded", compiled.stdout)
 
@@ -374,6 +601,7 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
             stderr=subprocess.PIPE,
             text=True,
             env=self.env,
+            cwd=self.caller_cwd,
             start_new_session=True,
         )
         try:
@@ -414,16 +642,16 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
                 for value in forbidden:
                     self.assertNotIn(value, text, path)
 
-        subprocess.run(["git", "add", "-A"], cwd=self.vault, check=True)
-        staged = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
+        changed = subprocess.run(
+            ["git", "status", "--porcelain=v1", "-uall"],
             cwd=self.vault,
             check=True,
             capture_output=True,
             text=True,
-        ).stdout.splitlines()
-        self.assertTrue(staged)
-        self.assertFalse(any(path == "system" or path.startswith("system/") for path in staged))
+        ).stdout
+        self.assertTrue(changed)
+        self.assertNotIn(" system/", changed)
+        self.assertNotIn(" vault/system/", changed)
         self.assertEqual(tree_digest(self.framework), self.framework_before)
 
     def test_explicit_cli_root_beats_environment_and_embedded_default_is_identical(self):
@@ -438,9 +666,87 @@ class ExternalVaultSubprocessTests(unittest.TestCase):
         self.assertEqual(explicit.returncode, 0, explicit.stderr)
         self.assertEqual(explicit.stdout, embedded.stdout)
 
+        post_subcommand = self.run_cli(
+            "status", "--vault-root", str(self.framework), env=hostile_env
+        )
+        self.assertEqual(post_subcommand.returncode, 0, post_subcommand.stderr)
+        self.assertEqual(post_subcommand.stdout, embedded.stdout)
+
+        equals_form = self.run_cli(
+            "status", f"--vault-root={self.framework}", env=hostile_env
+        )
+        self.assertEqual(equals_form.returncode, 0, equals_form.stderr)
+        self.assertEqual(equals_form.stdout, embedded.stdout)
+
         selected_environment = self.run_cli("status", env=hostile_env)
         self.assertEqual(selected_environment.returncode, 0, selected_environment.stderr)
         self.assertIn("Total: 1/1", selected_environment.stdout)
+
+        contract = subprocess.run(
+            [sys.executable, str(self.framework / "system" / "vault_paths.py"), "contract"],
+            cwd=self.caller_cwd,
+            env=self.env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(contract.returncode, 0, contract.stderr)
+        contract_value = json.loads(contract.stdout)
+        self.assertNotIn(str(self.framework), json.dumps(contract_value))
+        self.assertNotIn(str(self.vault), json.dumps(contract_value))
+
+    def test_same_process_vault_switch_and_hostile_worker_root_reject(self):
+        program = """
+import importlib
+import os
+import sys
+sys.path.insert(0, sys.argv[1])
+os.environ['LIFEHUG_FRAMEWORK_SYSTEM_DIR'] = sys.argv[1]
+os.environ['LIFEHUG_VAULT_ROOT'] = sys.argv[2]
+import lifehug_core
+assert str(lifehug_core.REPO_DIR) == sys.argv[2]
+os.environ['LIFEHUG_VAULT_ROOT'] = sys.argv[3]
+try:
+    importlib.reload(lifehug_core)
+except RuntimeError as exc:
+    assert 'already bound' in str(exc)
+else:
+    raise SystemExit('unsafe in-process vault switch was accepted')
+print('rebind rejected')
+"""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                program,
+                str(self.framework / "system"),
+                str(self.vault),
+                str(self.other_vault),
+            ],
+            cwd=self.caller_cwd,
+            env={"PATH": self.env["PATH"], "PYTHONDONTWRITEBYTECODE": "1"},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("rebind rejected", result.stdout)
+
+        root_link = self.tmp / "hostile worker root"
+        root_link.symlink_to(self.vault, target_is_directory=True)
+        hostile_env = self.env.copy()
+        hostile_env["LIFEHUG_VAULT_ROOT"] = str(root_link)
+        child = subprocess.run(
+            [sys.executable, str(self.framework / "system" / "job_execute.py")],
+            input='{"arguments": ["status"], "stdin_text": null}',
+            cwd=self.caller_cwd,
+            env=hostile_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(child.returncode, 77, child.stderr)
+        self.assertEqual(tree_digest(self.framework), self.framework_before)
 
 
 if __name__ == "__main__":

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -748,6 +748,39 @@ print('rebind rejected')
         self.assertEqual(child.returncode, 77, child.stderr)
         self.assertEqual(tree_digest(self.framework), self.framework_before)
 
+    def test_post_bind_symlinked_source_is_never_followed(self):
+        outside = self.tmp / "outside-source.md"
+        outside.write_text("outside sentinel must stay private\n", encoding="utf-8")
+        program = """
+import os
+import sys
+from pathlib import Path
+sys.path.insert(0, os.environ['LIFEHUG_FRAMEWORK_SYSTEM_DIR'])
+from lifehug_core import SOURCES_DIR
+import wiki_compile
+
+outside = Path(os.environ['LIFEHUG_TEST_OUTSIDE_SOURCE'])
+SOURCES_DIR.mkdir(parents=True, exist_ok=True)
+(SOURCES_DIR / 'post-bind.md').symlink_to(outside)
+try:
+    wiki_compile.read_manual_sources()
+except ValueError as exc:
+    assert 'symlink' in str(exc)
+else:
+    raise SystemExit('post-bind source symlink was followed')
+"""
+        env = self.env.copy()
+        env["LIFEHUG_TEST_OUTSIDE_SOURCE"] = str(outside)
+        result = subprocess.run(
+            [sys.executable, "-c", program],
+            cwd=self.caller_cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -377,6 +377,7 @@ class VaultContractTests(unittest.TestCase):
         offenders: list[str] = []
         hosted_readers: list[str] = []
         direct_writers: list[str] = []
+        authority_escapes: list[str] = []
         for path in sorted(SYSTEM.rglob("*.py")):
             if "__pycache__" in path.parts:
                 continue
@@ -398,9 +399,15 @@ class VaultContractTests(unittest.TestCase):
                 r"\.(?:write_text|write_bytes|open)\(", text
             ):
                 direct_writers.append(relative)
+            if path.name != "update.py" and re.search(
+                r"Path\(REPO_DIR\)|REPO_DIR\.(?:joinpath|open|read_text|read_bytes|write_text|write_bytes|unlink|mkdir|touch)",
+                text,
+            ):
+                authority_escapes.append(relative)
         self.assertEqual(hosted_readers, [], "hosted marker must not affect OSS runtime")
         self.assertEqual(offenders, [], "runtime modules must import the vault authority")
         self.assertEqual(direct_writers, [], "vault writes must use the no-follow I/O authority")
+        self.assertEqual(authority_escapes, [], "runtime paths must preserve VaultPath authority")
 
     def test_shell_entrypoints_validate_the_selected_root_before_cd_or_write(self):
         target = make_vault(self.tmp / "shell-target")
@@ -756,18 +763,27 @@ import os
 import sys
 from pathlib import Path
 sys.path.insert(0, os.environ['LIFEHUG_FRAMEWORK_SYSTEM_DIR'])
-from lifehug_core import SOURCES_DIR
+from lifehug_core import REPO_DIR, SOURCES_DIR, VaultPath
+import classify_story
 import wiki_compile
 
 outside = Path(os.environ['LIFEHUG_TEST_OUTSIDE_SOURCE'])
 SOURCES_DIR.mkdir(parents=True, exist_ok=True)
 (SOURCES_DIR / 'post-bind.md').symlink_to(outside)
+assert isinstance(REPO_DIR, VaultPath)
+assert isinstance(REPO_DIR / 'sources' / 'post-bind.md', VaultPath)
 try:
     wiki_compile.read_manual_sources()
 except ValueError as exc:
     assert 'symlink' in str(exc)
 else:
     raise SystemExit('post-bind source symlink was followed')
+try:
+    classify_story.cmd_prompt(type('Args', (), {'prompt_file': 'sources/post-bind.md'})())
+except ValueError as exc:
+    assert 'symlink' in str(exc)
+else:
+    raise SystemExit('post-bind classify prompt symlink was followed')
 """
         env = self.env.copy()
         env["LIFEHUG_TEST_OUTSIDE_SOURCE"] = str(outside)

--- a/tests/test_wiki_views.py
+++ b/tests/test_wiki_views.py
@@ -18,7 +18,10 @@ import lifehug_core  # noqa: E402
 
 class WikiViewsTests(unittest.TestCase):
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp())
+        # Keep the fixture under the real-path worktree parent. On macOS the
+        # default /var/folders prefix traverses the /var symlink, which the
+        # production no-follow vault I/O authority correctly rejects.
+        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
         # Save originals so each test runs against an isolated fixture set.
         self._saved = {
             (serve_wiki, "QUESTIONS_FILE"): serve_wiki.QUESTIONS_FILE,
@@ -382,7 +385,7 @@ class RevisionFooterTests(unittest.TestCase):
     Thoughts group for subjectless essays."""
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp())
+        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
         self._saved = {
             (roadmap, "ROADMAP_FILE"): roadmap.ROADMAP_FILE,
             (lifehug_core, "REPO_DIR"): lifehug_core.REPO_DIR,


### PR DESCRIPTION
## Summary

- keep one process-scoped vault authority with explicit `--vault-root` > `LIFEHUG_VAULT_ROOT` > embedded checkout precedence, including legal global-option placement before or after the subcommand
- reject same-process vault switching and same-path root replacement; validate the worker root again at execution time before importing job state
- route canonical vault mutations and job storage through pinned-directory, no-follow/openat helpers with atomic replace/create and deterministic root/intermediate/final swap rejection
- export a stable v120 contract identity/digest with sorted normalized data/framework tables, explicit embedded/external mappings, required and forbidden paths, schema validation policy, special-file policy, and durable/framework/unknown classification
- keep external vaults data-only: no framework writes, no `system/` or `templates/`, no hosted-marker behavior, and exact answer-pipeline Git staging that excludes job records and connector state

This PR is intentionally stacked on `feat/56-durable-local-job-runner` / PR #71.

## Executable proof

`tests/test_v120_vault_only.py` copies the framework to a read-only synthetic install and drives a separate Git-backed vault from an unrelated cwd with `PYTHONPATH` removed. The subprocess smoke verifies:

| Flow | Result |
|---|---|
| `lifehug.py status` | reads root `question-bank.md` + blocking `state/` schemas |
| CLI precedence | explicit root wins in pre-subcommand, post-subcommand, and equals forms; environment wins otherwise |
| `source-lint --no-write-findings` | 0 errors |
| queued `process-answer A1 --no-compile-wiki --commit` | succeeded with an exact six-path Git commit and no `state/jobs/` files |
| queued `compile --no-ai` | succeeded; wiki stays vault-relative |
| `serve` + loopback HTTP GET | viewer serves the compiled Origins page |
| worker/root attacks | symlinked execution root and same-process A→B reuse reject before work |
| no-follow I/O | traversal, root/intermediate/final symlinks, FIFO, final-file swaps, parent swaps, and same-path root replacement reject without touching the outside target |
| framework snapshot | byte-identical before/after all external-vault flows |
| shell entrypoints | roots containing spaces and quotes preserve exact argv from an unrelated cwd |

`vault_paths.py contract`, `classify`, and `walk` expose the public, machine-independent contract and deterministic preflight needed by issue #65. Contract JSON contains no absolute roots or hosted semantics.

## Local gates

Verified at `f9f2638fc88157de482466ac8a2885d69e9a6372`:

- 256 scoped tests passed across v101 viewer actions, v119 queue/worker, v120 vault-only, core/wrapper, source integrity, wiki compile/views, updater, answer filing, multi-writer, and pass-transition modules
- modified Python files compile; contract JSON parses and its normalized digest verifies
- `bash -n` + ShellCheck passed for all five schedule/maintenance wrappers
- conflict-marker scan, `git diff HEAD^ --check`, and clean-worktree check passed
- GitHub CI remains the full-suite arbiter

No visible UI state changed, so screenshot/GIF evidence does not apply; the unchanged viewer is exercised over real loopback HTTP by the external-vault smoke.

Closes #64

🤖 Generated with GPT-5.6 Sol via Codex
