### PR TITLE
Green suite: vault-root rebind authority + mutator classification (v129)

### DIFF
--- a/system/connectors/base.py
+++ b/system/connectors/base.py
@@ -263,18 +263,22 @@ class BaseConnector:
             import timeline as tl_mod  # noqa: PLC0415
         except Exception:  # noqa: BLE001
             return []
-        saved = (tl_mod.CLASSIFICATIONS_DIR, tl_mod.MANUAL_SOURCES_DIR,
-                 tl_mod.STATE_DIR, tl_mod.WIKI_DIR, tl_mod.PLACEMENTS_FILE)
-        tl_mod.CLASSIFICATIONS_DIR = self.repo_dir / "state" / "classifications"
-        tl_mod.MANUAL_SOURCES_DIR = self.repo_dir / "sources" / "manual"
-        tl_mod.STATE_DIR = self.repo_dir / "state"
-        tl_mod.WIKI_DIR = self.repo_dir / "wiki"
-        tl_mod.PLACEMENTS_FILE = self.repo_dir / "state" / "timeline_placements.json"
-        try:
+        # The excavation reads THIS connector's repo, not the process vault —
+        # every timeline root at once, through the timeline's own authority so
+        # a newly added root can never be missed here (v120 moved
+        # entity_rosters/ and connectors/ off STATE_DIR and this site kept
+        # reading the process vault for both).
+        state = self.repo_dir / "state"
+        with tl_mod.vault_roots(
+            CLASSIFICATIONS_DIR=state / "classifications",
+            CONNECTORS_STATE_DIR=state / "connectors",
+            ENTITY_ROSTERS_DIR=state / "entity_rosters",
+            MANUAL_SOURCES_DIR=self.repo_dir / "sources" / "manual",
+            PLACEMENTS_FILE=state / "timeline_placements.json",
+            STATE_DIR=state,
+            WIKI_DIR=self.repo_dir / "wiki",
+        ):
             data = tl_mod.timeline_data(evidence=evidence)
-        finally:
-            (tl_mod.CLASSIFICATIONS_DIR, tl_mod.MANUAL_SOURCES_DIR,
-             tl_mod.STATE_DIR, tl_mod.WIKI_DIR, tl_mod.PLACEMENTS_FILE) = saved
         corroboration = data.get("corroboration") or {}
         if not corroboration.get("available"):
             return []

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -78,6 +78,10 @@ DIRECT_MUTATION_COMMANDS = frozenset({
     "planner-clear", "planner-objective-add", "planner-objective-clear", "planner-queue",
     "planner-state", "quality-update", "rebuild", "recommend-focuses", "reflect-source",
     "research-expand", "retract-source", "roadmap-rebuild", "second-voice-ack",
+    # v123: renames correction/retraction sources on disk AND rewrites every
+    # state index that points at them — a vault mutator, so it takes the
+    # writer lock like the rest of the source-repair family.
+    "source-filenames-repair",
     "source-lint", "source-manifest", "timeline-place", "timeline-retire",
     "timeline-unplace", "unretract",
 })

--- a/system/timeline.py
+++ b/system/timeline.py
@@ -25,6 +25,7 @@ Zero AI calls; read-only over live state.
 
 from __future__ import annotations
 
+import contextlib
 import re
 import sys
 from pathlib import Path
@@ -46,6 +47,54 @@ from lifehug_core import (  # noqa: E402
     read_json,
     slugify,
 )
+
+# ---------------------------------------------------------------------------
+# The vault roots this module reads — one authoritative list (issue #129).
+#
+# `timeline_data()` is also run *on behalf of another vault root* by callers
+# that own their own roots: wiki_compile's timeline export and a connector's
+# excavation. Each used to rebind this module's globals by hand, and v120's
+# vault-only refactor moved entity_rosters/ and connectors/ off hand-derived
+# STATE_DIR subpaths onto their own contract names — so every hand-written
+# rebind site silently kept HALF the call reading the process vault and half
+# reading the caller's. `vault_roots()` is the single definition; it REQUIRES
+# the complete set, so the next root added here fails loudly at every rebind
+# site instead of quietly splitting a run across two vaults.
+#
+# (PLACEMENTS_FILE is defined further down, next to the placement store; the
+# names are resolved out of module globals at rebind time.)
+VAULT_ROOT_NAMES = (
+    "CLASSIFICATIONS_DIR",
+    "CONNECTORS_STATE_DIR",
+    "ENTITY_ROSTERS_DIR",
+    "MANUAL_SOURCES_DIR",
+    "PLACEMENTS_FILE",
+    "STATE_DIR",
+    "WIKI_DIR",
+)
+
+
+@contextlib.contextmanager
+def vault_roots(**roots: Path):
+    """Run the enclosed timeline call against `roots` instead of this process's
+    vault, restoring the originals afterwards. Every name in
+    :data:`VAULT_ROOT_NAMES` must be supplied."""
+    unknown = sorted(set(roots) - set(VAULT_ROOT_NAMES))
+    if unknown:
+        raise ValueError(f"not a timeline vault root: {', '.join(unknown)}")
+    missing = sorted(set(VAULT_ROOT_NAMES) - set(roots))
+    if missing:
+        raise ValueError(
+            "timeline vault rebind must supply every root; missing: "
+            f"{', '.join(missing)}"
+        )
+    saved = {name: globals()[name] for name in VAULT_ROOT_NAMES}
+    globals().update(roots)
+    try:
+        yield
+    finally:
+        globals().update(saved)
+
 
 # Entity dirs that line up against the period spine (dir name -> type label).
 LINEUP_DIRS = {

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 128,
+  "version": 129,
   "released": "2026-08-08",
-  "changelog": "v128: the Review view — Question Candidates, Focus Recommendations, and Entity Candidates were three faces of one thing: the system growing itself from your material, with a threshold gate and a chance for your eye. They are now one page (/views/review) with three collapsible lanes, each stating its autonomy policy on its bar: question candidates auto-promote past the quality bar (the rest wait for you, actionable statuses first), focus ideas are never created without you (a completion-gated threshold is designed in issue #79), and entity candidates graduate into wiki pages automatically — previewed, no action needed. All promote/approve/dismiss/defer actions unchanged; post-action flashes land back on Review. The three old URLs redirect permanently. The viewer is now 11 pages where this morning it was 16: Foundation is the material, Studio is where you work it, Review is what the system proposes, The Loop is how it's running.",
+  "changelog": "v129: the test suite is fully green again (810 passed, 0 failures) — 16 failures that crept in at v120/v123 are fixed at the root. One shared cause behind 14 of them: v120 gave entity_rosters/ and connectors/ their own vault-contract roots, and two call sites (wiki_compile's timeline export, connector excavation) kept rebinding only the old partial set — a run could silently read half of one vault and half of another. timeline.py now owns a single VAULT_ROOT_NAMES authority with a vault_roots() context manager that rejects partial rebinds, both call sites use it, and guard tests pin it (recurring-defect doctrine). Also: source-filenames-repair (v123) now takes the writer lease like the rest of the source-repair family — it renames sources and rewrites state indexes and was never classified as the mutator it is.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/system/wiki_compile.py
+++ b/system/wiki_compile.py
@@ -27,6 +27,9 @@ from pathlib import Path
 from lifehug_core import (
     ANSWERS_DIR,
     CLASSIFICATIONS_DIR,
+    CONNECTORS_STATE_DIR,
+    ENTITY_ROSTERS_DIR,
+    MANUAL_SOURCES_DIR,
     QUESTIONS_FILE,
     REPO_DIR,
     SOURCES_DIR,
@@ -1221,18 +1224,19 @@ def compile_timeline(dry_run: bool = False) -> bool:
     import timeline as tl_mod  # noqa: PLC0415
     import timeline_corroboration as tcorr  # noqa: PLC0415
 
-    # Honor this module's (possibly monkeypatched) roots for the call.
-    saved = (tl_mod.CLASSIFICATIONS_DIR, tl_mod.STATE_DIR, tl_mod.WIKI_DIR,
-             tl_mod.PLACEMENTS_FILE)
-    tl_mod.CLASSIFICATIONS_DIR = CLASSIFICATIONS_DIR
-    tl_mod.STATE_DIR = STATE_DIR
-    tl_mod.WIKI_DIR = WIKI_DIR
-    tl_mod.PLACEMENTS_FILE = TIMELINE_PLACEMENTS_FILE
-    try:
+    # The export reads THIS module's vault roots — all of them, through the
+    # timeline's own authority, so a root added there can never be forgotten
+    # here (see timeline.VAULT_ROOT_NAMES).
+    with tl_mod.vault_roots(
+        CLASSIFICATIONS_DIR=CLASSIFICATIONS_DIR,
+        CONNECTORS_STATE_DIR=CONNECTORS_STATE_DIR,
+        ENTITY_ROSTERS_DIR=ENTITY_ROSTERS_DIR,
+        MANUAL_SOURCES_DIR=MANUAL_SOURCES_DIR,
+        PLACEMENTS_FILE=TIMELINE_PLACEMENTS_FILE,
+        STATE_DIR=STATE_DIR,
+        WIKI_DIR=WIKI_DIR,
+    ):
         data = tl_mod.timeline_data()
-    finally:
-        (tl_mod.CLASSIFICATIONS_DIR, tl_mod.STATE_DIR, tl_mod.WIKI_DIR,
-         tl_mod.PLACEMENTS_FILE) = saved
 
     total = data["counts"]["events_placed"] + data["counts"]["events_unplaced"]
     if not total:

--- a/tests/test_v110_timeline_corroboration.py
+++ b/tests/test_v110_timeline_corroboration.py
@@ -10,6 +10,7 @@ question candidates. No evidence file → the timeline renders exactly as
 before.
 """
 
+import contextlib
 import importlib.util
 import json
 import sys
@@ -43,6 +44,46 @@ def load(name):
 core = load("lifehug_core")
 tl = load("timeline")
 tcorr = load("timeline_corroboration")
+
+
+def timeline_roots(root: Path) -> dict[str, Path]:
+    """Every vault root timeline.py reads, pointed at a fixture `root`. Keyed
+    by timeline.VAULT_ROOT_NAMES so a root added there fails here loudly
+    instead of silently reading the real vault."""
+    state = root / "state"
+    roots = {
+        "CLASSIFICATIONS_DIR": state / "classifications",
+        "CONNECTORS_STATE_DIR": state / "connectors",
+        "ENTITY_ROSTERS_DIR": state / "entity_rosters",
+        "MANUAL_SOURCES_DIR": root / "sources" / "manual",
+        "PLACEMENTS_FILE": state / "timeline_placements.json",
+        "STATE_DIR": state,
+        "WIKI_DIR": root / "wiki",
+    }
+    assert set(roots) == set(tl.VAULT_ROOT_NAMES), sorted(
+        set(roots).symmetric_difference(tl.VAULT_ROOT_NAMES))
+    return roots
+
+
+# wiki_compile forwards its OWN roots into the timeline for the export, under
+# lifehug_core's names (the placements file is TIMELINE_PLACEMENTS_FILE there).
+_WIKI_COMPILE_NAMES = {"PLACEMENTS_FILE": "TIMELINE_PLACEMENTS_FILE"}
+
+
+@contextlib.contextmanager
+def wiki_compile_vault(wc, root: Path):
+    """Point a loaded wiki_compile at `root` — all of it, so compile_timeline's
+    export reads the fixture rather than half of the real vault."""
+    bindings = {_WIKI_COMPILE_NAMES.get(name, name): value
+                for name, value in timeline_roots(root).items()}
+    saved = {name: getattr(wc, name) for name in bindings}
+    for name, value in bindings.items():
+        setattr(wc, name, value)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            setattr(wc, name, value)
 
 PERIOD_PAGE = """---
 title: "{title}"
@@ -105,17 +146,18 @@ class CorroborationFixture(unittest.TestCase):
         }), encoding="utf-8")
         self.write_evidence(ASU_RECORDS + [CHASE_RECORD])
 
-        self._orig = (tl.WIKI_DIR, tl.MANUAL_SOURCES_DIR, tl.CLASSIFICATIONS_DIR,
-                      tl.STATE_DIR, tl.PLACEMENTS_FILE)
-        tl.WIKI_DIR = root / "wiki"
-        tl.MANUAL_SOURCES_DIR = root / "sources" / "manual"
-        tl.CLASSIFICATIONS_DIR = root / "state" / "classifications"
-        tl.STATE_DIR = root / "state"
-        tl.PLACEMENTS_FILE = root / "state" / "timeline_placements.json"
+        # v120 gave the roster and connector-evidence directories their own
+        # contract names — timeline.py no longer derives them from STATE_DIR,
+        # so the fixture binds every root the module actually reads
+        # (timeline.VAULT_ROOT_NAMES is the authority).
+        self._orig = {name: getattr(tl, name) for name in tl.VAULT_ROOT_NAMES}
+        self.timeline_roots = timeline_roots(root)
+        for name, value in self.timeline_roots.items():
+            setattr(tl, name, value)
 
     def tearDown(self):
-        (tl.WIKI_DIR, tl.MANUAL_SOURCES_DIR, tl.CLASSIFICATIONS_DIR,
-         tl.STATE_DIR, tl.PLACEMENTS_FILE) = self._orig
+        for name, value in self._orig.items():
+            setattr(tl, name, value)
         self.tmp.cleanup()
 
     def write_roster(self, approximate_dates="2010–2013", aliases=None):
@@ -272,14 +314,9 @@ class RenderTests(CorroborationFixture):
 
     def test_export_carries_the_same_badges(self):
         wc = load("wiki_compile")
-        orig = (wc.STATE_DIR, wc.WIKI_DIR)
-        wc.STATE_DIR = self.root / "state"
-        wc.WIKI_DIR = self.root / "wiki"
         sys.modules["timeline"] = tl
-        try:
+        with wiki_compile_vault(wc, self.root):
             self.assertTrue(wc.compile_timeline())
-        finally:
-            wc.STATE_DIR, wc.WIKI_DIR = orig
         text = (self.root / "wiki" / "timeline.md").read_text(encoding="utf-8")
         self.assertIn("## College — ✉ asu ×4 · 2010–2013", text)
         self.assertIn("Moved into the ASU dorms", text)
@@ -313,17 +350,12 @@ class NoEvidenceNoopTests(CorroborationFixture):
         self.assertEqual(body_without, body_unmatched)
 
         wc = load("wiki_compile")
-        orig = (wc.STATE_DIR, wc.WIKI_DIR)
-        wc.STATE_DIR = self.root / "state"
-        wc.WIKI_DIR = self.root / "wiki"
-        try:
+        with wiki_compile_vault(wc, self.root):
             wc.compile_timeline()
             export_unmatched = (self.root / "wiki" / "timeline.md").read_text(encoding="utf-8")
             self.remove_evidence()
             wc.compile_timeline()
             export_without = (self.root / "wiki" / "timeline.md").read_text(encoding="utf-8")
-        finally:
-            wc.STATE_DIR, wc.WIKI_DIR = orig
         self.assertEqual(export_without, export_unmatched)
         self.assertNotIn("✉", export_without)
 
@@ -366,6 +398,38 @@ class AggregationCapTests(CorroborationFixture):
         self.assertEqual([e["entity"] for e in badge["entities"]],
                          ["asu", "mit", "chase", "delta"])  # count desc, name asc
         self.assertIn("+ 1 more", tcorr.badge_text(badge))
+
+
+class VaultRootRebindTests(unittest.TestCase):
+    """The rebind seam every off-process-vault caller goes through
+    (wiki_compile's export, a connector's excavation). A PARTIAL rebind is the
+    v120 regression that split one timeline run across two vaults — the
+    contract is all-or-nothing, enforced here so a newly added root can't be
+    quietly forgotten at a call site."""
+
+    def test_partial_rebind_is_rejected(self):
+        with self.assertRaises(ValueError) as caught:
+            with tl.vault_roots(WIKI_DIR=Path("/nowhere/wiki")):
+                pass
+        message = str(caught.exception)
+        self.assertIn("missing", message)
+        self.assertIn("CONNECTORS_STATE_DIR", message)
+        self.assertIn("ENTITY_ROSTERS_DIR", message)
+
+    def test_unknown_root_is_rejected(self):
+        roots = dict(timeline_roots(Path("/nowhere")), OUTPUTS_DIR=Path("/nowhere/outputs"))
+        with self.assertRaises(ValueError) as caught:
+            with tl.vault_roots(**roots):
+                pass
+        self.assertIn("OUTPUTS_DIR", str(caught.exception))
+
+    def test_complete_rebind_restores_every_root(self):
+        before = {name: getattr(tl, name) for name in tl.VAULT_ROOT_NAMES}
+        swapped = timeline_roots(Path("/nowhere"))
+        with tl.vault_roots(**swapped):
+            for name, value in swapped.items():
+                self.assertEqual(getattr(tl, name), value)
+        self.assertEqual({name: getattr(tl, name) for name in tl.VAULT_ROOT_NAMES}, before)
 
 
 class PureFunctionTests(unittest.TestCase):

--- a/tests/test_v70_v71_craft.py
+++ b/tests/test_v70_v71_craft.py
@@ -1,6 +1,7 @@
 """v70 (question craft) + v71 (time & self): why→what lint, deferral,
 rumination detector, period arc, perennials, wiki harvest, timeline."""
 
+import contextlib
 import importlib.util
 import json
 import sys
@@ -222,16 +223,49 @@ class WikiHarvestTests(unittest.TestCase):
             (root / "wiki" / "people" / "dad.md").write_text(self.PAGE, encoding="utf-8")
             bank = root / "bank.md"
             bank.write_text("## A: Origins\n- [ ] A1: What's your earliest memory?\n", encoding="utf-8")
-            live_core = sys.modules["lifehug_core"]  # call-time import target
-            orig = (live_core.REPO_DIR, qc.QUESTIONS_FILE)
-            live_core.REPO_DIR = root
+            # v120: the harvester binds wiki/ and the candidate store at import
+            # from the vault contract instead of re-deriving them from
+            # lifehug_core.REPO_DIR inside the call, so the fixture binds the
+            # module's own names (REPO_DIR still relativizes the page ref).
+            names = ("REPO_DIR", "WIKI_DIR", "QUESTIONS_FILE", "QUESTION_CANDIDATES_FILE")
+            orig = {name: getattr(qc, name) for name in names}
+            qc.REPO_DIR = root
+            qc.WIKI_DIR = root / "wiki"
             qc.QUESTIONS_FILE = bank
+            qc.QUESTION_CANDIDATES_FILE = root / "state" / "question_candidates.json"
             try:
                 harvested = qc.harvest_wiki_questions(dry_run=True)
             finally:
-                live_core.REPO_DIR, qc.QUESTIONS_FILE = orig
+                for name, value in orig.items():
+                    setattr(qc, name, value)
             self.assertEqual(len(harvested), 1)
             self.assertTrue(harvested[0].startswith("cand-wiki-dad-"))
+
+
+@contextlib.contextmanager
+def wiki_compile_vault(wc, root: Path):
+    """Point a loaded wiki_compile at a fixture vault. compile_timeline forwards
+    THIS module's roots into the timeline, and v120 gave the roster and
+    connector-evidence directories their own contract names — binding only
+    STATE_DIR leaves the export reading half the real vault."""
+    state = root / "state"
+    bindings = {
+        "CLASSIFICATIONS_DIR": state / "classifications",
+        "CONNECTORS_STATE_DIR": state / "connectors",
+        "ENTITY_ROSTERS_DIR": state / "entity_rosters",
+        "MANUAL_SOURCES_DIR": root / "sources" / "manual",
+        "TIMELINE_PLACEMENTS_FILE": state / "timeline_placements.json",
+        "STATE_DIR": state,
+        "WIKI_DIR": root / "wiki",
+    }
+    saved = {name: getattr(wc, name) for name in bindings}
+    for name, value in bindings.items():
+        setattr(wc, name, value)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            setattr(wc, name, value)
 
 
 class TimelineTests(unittest.TestCase):
@@ -249,13 +283,8 @@ class TimelineTests(unittest.TestCase):
             }), encoding="utf-8")
             wiki = root / "wiki"
             wiki.mkdir()
-            orig = (wc.STATE_DIR, wc.WIKI_DIR)
-            wc.STATE_DIR = root / "state"
-            wc.WIKI_DIR = wiki
-            try:
+            with wiki_compile_vault(wc, root):
                 self.assertTrue(wc.compile_timeline())
-            finally:
-                wc.STATE_DIR, wc.WIKI_DIR = orig
             text = (wiki / "timeline.md").read_text(encoding="utf-8")
             self.assertIn("Moved the young family to Seattle", text)
             self.assertIn("when James had just been born", text)
@@ -266,12 +295,8 @@ class TimelineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "state").mkdir()
-            orig = wc.STATE_DIR
-            wc.STATE_DIR = root / "state"
-            try:
+            with wiki_compile_vault(wc, root):
                 self.assertFalse(wc.compile_timeline())
-            finally:
-                wc.STATE_DIR = orig
 
 
 class ClassifierSchemaTests(unittest.TestCase):

--- a/tests/test_v86_weekly_report.py
+++ b/tests/test_v86_weekly_report.py
@@ -41,6 +41,7 @@ def load(name):
 
 
 wr = load("weekly_report")
+vault_paths = load("vault_paths")
 
 NOW = datetime.now(timezone.utc)
 SINCE = NOW - timedelta(hours=2)
@@ -182,8 +183,17 @@ class OrchestratorContractTests(unittest.TestCase):
         self.assertIn("${SUMMARY}", tail)
 
     def test_weekly_persists_report_and_calls_summary(self):
-        self.assertIn("state/reports", self.weekly)
+        # v120 (vault-only): the script no longer hardcodes `state/reports` —
+        # it asks the vault contract where the reports directory lives, so the
+        # contract is what pins the location and the script is checked against
+        # it rather than against a literal that can silently drift.
+        self.assertEqual(
+            vault_paths.VAULT_DATA_PATHS["reports"]["external_path"], "state/reports")
+        self.assertIn('vault_paths.py" data-path reports', self.weekly)
+        self.assertIn('REPORT_FILE="$REPORT_DIR/weekly-$(date +%F).md"', self.weekly)
+        self.assertIn('} > "$REPORT_FILE"', self.weekly)  # the full report is written
         self.assertIn("weekly-summary", self.weekly)
+        self.assertIn('--report-path "$REPORT_FILE"', self.weekly)
         self.assertIn("--doctor-file -", self.weekly)
 
     def test_monthly_no_raw_dump_in_notify(self):


### PR DESCRIPTION
Fixes the 16 v120/v123 regressions found by the platform's package-certification harness (lifehug-platform#323). Full suite: 810 passed, 0 failures, 0 errors. Root causes, not paper: a single vault-root rebind authority (recurring-defect doctrine) and an honest writer classification for source-filenames-repair. No assertions weakened, nothing skipped.

🤖 Generated with Claude Fable 5 via Claude Code