### PR TITLE
Pin v130's blocker fixes with regression tests (v131)

### DIFF
--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 130,
+  "version": 131,
   "released": "2026-08-08",
-  "changelog": "v130: two fixes for the update path every external vault takes. (1) process-answer no longer writes asked_at: \"None\" when rotation's last_asked_at is null (the v120 contract made the key present-but-nullable); it falls back to the answer's own date, exactly as pre-v120 behavior did when the key was absent. (2) updating a pre-v120 vault now migrates it to the v120 durable-data contract instead of leaving new code that refuses to read the vault it just updated: required keys are derived from vault_contract.json itself at run time, defaults are the framework's own (never arbitrary zeros), wrong-typed values are parked under legacy_* rather than deleted, corrupt or non-object files are salvaged to <name>.pre-v120 before any rebuild (and the rebuild refuses to proceed if the salvage copy cannot be written), and the whole pass is idempotent. Vaults already updated past this release can repair themselves with `python3 system/update.py --migrate-vault [--vault-root PATH]`, which honors LIFEHUG_VAULT_ROOT and exits nonzero with the reason instead of reporting false success.",
+  "changelog": "v131: regression tests for v130's merge-gate blockers — corrupt-JSON salvage (interrupted-write rotation.json is preserved as .pre-v120, never destroyed) and --migrate-vault target resolution (LIFEHUG_VAULT_ROOT honored, --vault-root beats it, missing target exits nonzero instead of false success). Test-only release; v130 shipped the fixes, this pins them.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_v130_migration.py
+++ b/tests/test_v130_migration.py
@@ -368,6 +368,52 @@ class V120MigrationTests(TmpVaultCase):
         salvage = vault / "system" / "rotation.json.pre-v120"
         self.assertEqual(salvage.read_text(encoding="utf-8"), "[1, 2, 3]\n")
 
+    def test_corrupt_json_is_salvaged_not_destroyed(self):
+        # Merge-gate blocker (PR #82): a parse error — the interrupted-write
+        # case, the most common real reason a vault won't bind — used to fall
+        # through the salvage branch and rebuild over the user's bytes.
+        vault = make_embedded_vault(
+            self.tmp / "corrupt",
+            rotation=V116_TEMPLATE_ROTATION, coverage=V116_TEMPLATE_COVERAGE,
+        )
+        truncated = '{"version": 1, "current_pass": 1, "pass_names": ["skel'
+        (vault / "system" / "rotation.json").write_text(truncated, encoding="utf-8")
+        update.migrate_vault_to_v120(vault)
+        binds(vault, layout="embedded")
+        salvage = vault / "system" / "rotation.json.pre-v120"
+        self.assertTrue(salvage.exists())
+        self.assertEqual(salvage.read_text(encoding="utf-8"), truncated)
+        rebuilt = json.loads((vault / "system" / "rotation.json").read_text(encoding="utf-8"))
+        self.assertIsInstance(rebuilt, dict)
+
+    def test_migrate_vault_cli_honors_vault_root_env(self):
+        # Merge-gate blocker (PR #82): --migrate-vault resolved to REPO_DIR
+        # regardless of LIFEHUG_VAULT_ROOT and reported false success while
+        # the target vault stayed broken.
+        vault = make_external_vault(self.tmp / "external-env")
+        _write_json(vault / "state" / "rotation.json", {})
+        args = update.argparse.Namespace(vault_root=None)
+        with mock.patch.dict(update.os.environ, {"LIFEHUG_VAULT_ROOT": str(vault)}):
+            rc = update.cmd_migrate_vault(args)
+        self.assertFalse(rc)
+        binds(vault, layout="external")
+
+    def test_migrate_vault_cli_vault_root_arg_beats_env(self):
+        vault = make_external_vault(self.tmp / "external-arg")
+        _write_json(vault / "state" / "rotation.json", {})
+        decoy = self.tmp / "decoy"
+        decoy.mkdir()
+        args = update.argparse.Namespace(vault_root=str(vault))
+        with mock.patch.dict(update.os.environ, {"LIFEHUG_VAULT_ROOT": str(decoy)}):
+            rc = update.cmd_migrate_vault(args)
+        self.assertFalse(rc)
+        binds(vault, layout="external")
+
+    def test_migrate_vault_cli_fails_loudly_not_falsely(self):
+        args = update.argparse.Namespace(vault_root=str(self.tmp / "does-not-exist"))
+        rc = update.cmd_migrate_vault(args)
+        self.assertEqual(rc, 1)
+
 
 class RunMigrationsWiringTests(TmpVaultCase):
     """update.py applies the TARGET version directly, so the v120 block has to


### PR DESCRIPTION
Test-only. The v130 PR body overclaimed that these adversarial tests existed; this makes it true: corrupt-JSON salvage-before-rebuild, --migrate-vault honoring LIFEHUG_VAULT_ROOT/--vault-root, and nonzero exit on a missing target. 22 passed.

🤖 Generated with Claude Fable 5 via Claude Code