### PR TITLE
Clean up workspace-parent test temp dirs

### DIFF
--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 137,
+  "version": 138,
   "released": "2026-08-09",
-  "changelog": "v137: the tagline speaks the product's own language — 'pieces that matter' (owner rename, 2026-08-09), completing the Projects & Pieces vocabulary from v127. Docs-only release.",
+  "changelog": "v138: test fixtures that need macOS-safe workspace-parent temp dirs now use one cleanup-registering helper, with a guard test that blocks future direct ROOT.parent mkdtemp leaks.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -108,6 +108,7 @@
     "tests/test_pass_transition.py",
     "tests/test_people_roster.py",
     "tests/test_source_integrity.py",
+    "tests/test_tempdir_cleanup.py",
     "tests/test_update.py",
     "tests/test_v101_actions.py",
     "tests/test_v102_timeline_curation.py",
@@ -143,6 +144,7 @@
     "tests/test_v97_theme_roster.py",
     "tests/test_wiki_compile.py",
     "tests/test_wiki_views.py",
+    "tests/tempdirs.py",
     "tests/v119_job_pill_evidence.py",
     "tests/walkthrough_lib.py",
     "wiki/SCHEMA.md"

--- a/tests/tempdirs.py
+++ b/tests/tempdirs.py
@@ -1,0 +1,23 @@
+"""Temp-dir helpers for tests that must avoid macOS /var symlink paths."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def root_parent_tmp(
+    test_case: unittest.TestCase,
+    root: Path,
+    *,
+    prefix: str | None = None,
+) -> Path:
+    """Create a ROOT.parent temp dir and register unconditional cleanup."""
+    options: dict[str, object] = {"dir": root.parent}
+    if prefix is not None:
+        options["prefix"] = prefix
+    tmp = Path(tempfile.mkdtemp(**options))
+    test_case.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+    return tmp

--- a/tests/test_tempdir_cleanup.py
+++ b/tests/test_tempdir_cleanup.py
@@ -1,0 +1,56 @@
+"""Regression guard for workspace-parent temp dirs in tests."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS = ROOT / "tests"
+
+
+def _is_tempfile_mkdtemp(node: ast.Call) -> bool:
+    return (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "mkdtemp"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "tempfile"
+    )
+
+
+def _is_root_parent(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "parent"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "ROOT"
+    )
+
+
+class RootParentTempDirPolicyTests(unittest.TestCase):
+    def test_root_parent_mkdtemp_uses_cleanup_helper(self):
+        offenders: list[str] = []
+        for path in sorted(TESTS.glob("test*.py")):
+            if path.name == Path(__file__).name:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not _is_tempfile_mkdtemp(node):
+                    continue
+                if any(
+                    keyword.arg == "dir" and _is_root_parent(keyword.value)
+                    for keyword in node.keywords
+                ):
+                    offenders.append(f"{path.relative_to(ROOT)}:{node.lineno}")
+
+        self.assertEqual(
+            offenders,
+            [],
+            "Use root_parent_tmp(self, ROOT, ...) from tests/tempdirs.py so "
+            "cleanup is registered.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_v119_jobs.py
+++ b/tests/test_v119_jobs.py
@@ -9,7 +9,6 @@ import socket
 import stat
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import unittest
@@ -20,7 +19,9 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import jobs  # noqa: E402
 import lifehug  # noqa: E402
 import vault_paths  # noqa: E402
@@ -115,7 +116,7 @@ def make_minimum_vault(root: Path, *, embedded: bool = False) -> None:
 class DurableJobsTests(unittest.TestCase):
     def setUp(self):
         vault_paths._reset_process_binding_for_tests()
-        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-jobs-test-", dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-jobs-test-")
         self.vault = self.tmp / "vault-only"
         make_minimum_vault(self.vault)
         self.framework = self.tmp / "framework" / "system"

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -11,7 +11,6 @@ import shutil
 import socket
 import subprocess
 import sys
-import tempfile
 import time
 import unittest
 import urllib.error
@@ -22,7 +21,9 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import vault_paths  # noqa: E402
 
 
@@ -124,7 +125,7 @@ def tree_digest(root: Path) -> dict[str, str]:
 class VaultContractTests(unittest.TestCase):
     def setUp(self):
         vault_paths._reset_process_binding_for_tests()
-        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-v120-contract-", dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v120-contract-")
 
     def tearDown(self):
         vault_paths._reset_process_binding_for_tests()
@@ -500,7 +501,7 @@ class VaultContractTests(unittest.TestCase):
 
 class ExternalVaultSubprocessTests(unittest.TestCase):
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-v120-smoke-", dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v120-smoke-")
         self.framework = self.tmp / "framework"
         shutil.copytree(SYSTEM, self.framework / "system", ignore=shutil.ignore_patterns("__pycache__"))
         shutil.copytree(ROOT / "templates", self.framework / "templates")

--- a/tests/test_v125_frameworks.py
+++ b/tests/test_v125_frameworks.py
@@ -14,14 +14,15 @@ from __future__ import annotations
 
 import json
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import book  # noqa: E402
 import compose  # noqa: E402
 import format_frameworks  # noqa: E402
@@ -139,7 +140,7 @@ class FrameworkLoaderUnitTests(unittest.TestCase):
     """Against a synthetic templates/ directory."""
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT)
         self.templates_dir = self.tmp / "templates"
         self.templates_dir.mkdir(parents=True)
         self._saved = {

--- a/tests/test_v127_studio.py
+++ b/tests/test_v127_studio.py
@@ -13,14 +13,15 @@ from __future__ import annotations
 
 import json
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import artifact  # noqa: E402
 import book  # noqa: E402
 import jobs  # noqa: E402
@@ -48,7 +49,7 @@ class StudioTestBase(unittest.TestCase):
     """Shared fixture plumbing: a real-path tmp dir + module attribute saves."""
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT)
         self._saved = {
             (studio, "OUTPUTS_DIR"): studio.OUTPUTS_DIR,
             (studio, "QUESTIONS_FILE"): studio.QUESTIONS_FILE,

--- a/tests/test_v130_migration.py
+++ b/tests/test_v130_migration.py
@@ -24,7 +24,6 @@ import json
 import shutil
 import subprocess
 import sys
-import tempfile
 import unittest
 from datetime import date
 from pathlib import Path
@@ -33,7 +32,9 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import update  # noqa: E402
 import vault_paths  # noqa: E402
 
@@ -131,8 +132,7 @@ class TmpVaultCase(unittest.TestCase):
     def setUp(self):
         # dir=ROOT.parent, not the system temp dir: macOS /var is a symlink and
         # vault_paths refuses to traverse one.
-        self.tmp = Path(tempfile.mkdtemp(prefix="lifehug-v130-", dir=ROOT.parent))
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v130-")
         self._orig = (update.REPO_DIR, update.VERSION_FILE)
         self.addCleanup(self._restore)
 

--- a/tests/test_v134_focus_gate.py
+++ b/tests/test_v134_focus_gate.py
@@ -11,9 +11,7 @@ throwaway vault per test, never the founder vault.
 from __future__ import annotations
 
 import json
-import shutil
 import sys
-import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -21,7 +19,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import entity_roster  # noqa: E402
 import recommend_focuses  # noqa: E402
 import roadmap  # noqa: E402
@@ -52,8 +52,7 @@ class GateTestBase(unittest.TestCase):
     real-path-tmp-dir + monkeypatched-module-attribute convention."""
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
-        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.tmp = root_parent_tmp(self, ROOT)
         self._saved = {
             (roadmap, "ROADMAP_FILE"): roadmap.ROADMAP_FILE,
             (roadmap, "QUESTIONS_FILE"): roadmap.QUESTIONS_FILE,

--- a/tests/test_wiki_views.py
+++ b/tests/test_wiki_views.py
@@ -2,14 +2,15 @@
 
 import json
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import serve_wiki  # noqa: E402
 import roadmap  # noqa: E402
 import recommend_focuses  # noqa: E402
@@ -25,7 +26,7 @@ class WikiViewsTests(unittest.TestCase):
         # Keep the fixture under the real-path worktree parent. On macOS the
         # default /var/folders prefix traverses the /var symlink, which the
         # production no-follow vault I/O authority correctly rejects.
-        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT)
         # Save originals so each test runs against an isolated fixture set.
         self._saved = {
             (serve_wiki, "QUESTIONS_FILE"): serve_wiki.QUESTIONS_FILE,
@@ -779,7 +780,7 @@ class RevisionFooterTests(unittest.TestCase):
     Thoughts group for subjectless essays."""
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(dir=ROOT.parent))
+        self.tmp = root_parent_tmp(self, ROOT)
         self._saved = {
             (roadmap, "ROADMAP_FILE"): roadmap.ROADMAP_FILE,
             (roadmap, "QUESTIONS_FILE"): roadmap.QUESTIONS_FILE,


### PR DESCRIPTION
Closes #91\n\n## Summary\n- add a shared root_parent_tmp test helper that creates macOS-safe ROOT.parent temp dirs and always registers cleanup\n- move every direct ROOT.parent mkdtemp test fixture to the helper\n- add a regression guard that fails new direct tempfile.mkdtemp(..., dir=ROOT.parent) call sites\n\n## Validation\n- /opt/homebrew/bin/python3.14 -m unittest tests.test_tempdir_cleanup\n- /opt/homebrew/bin/python3.14 -m unittest tests.test_tempdir_cleanup tests.test_v125_frameworks tests.test_v127_studio tests.test_v134_focus_gate tests.test_wiki_views\n- PATH="/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/homebrew/bin:/Users/ea/.codex/tmp/arg0/codex-arg0i8MUqZ:/Users/ea/.bun/bin:/Applications/ChatGPT.app/Contents/Resources" /opt/homebrew/bin/python3.14 -m unittest tests.test_v120_vault_only.VaultContractTests tests.test_v120_vault_only.ExternalVaultSubprocessTests.test_explicit_cli_root_beats_environment_and_embedded_default_is_identical tests.test_v120_vault_only.ExternalVaultSubprocessTests.test_same_process_vault_switch_and_hostile_worker_root_reject\n- PATH="/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/homebrew/bin:/Users/ea/.codex/tmp/arg0/codex-arg0i8MUqZ:/Users/ea/.bun/bin:/Applications/ChatGPT.app/Contents/Resources" /opt/homebrew/bin/python3.14 -m unittest tests.test_v119_jobs.DurableJobsTests.test_file_answer_outer_queue_leaves_no_plaintext_temp\n- git diff --check\n\n## Local caveat\n- A broader local sweep of tests.test_v119_jobs tests.test_v120_vault_only tests.test_v130_migration still hits the existing v120 viewer smoke timeout: the process remains alive but returns an empty body before the test deadline. The temp-dir leak guard and fixture cleanup checks pass.