### PR TITLE
Add supervised no-kick job mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@ same canonical scripts. Queue administration is intentionally exposed through
 `system/jobs.py` (`worker`, `show`, `retry`, `purge`, and `cleanup`); canonical
 vault mutations remain commands of `system/lifehug.py`.
 
+Embedded hosts that create disposable vault workspaces can set
+`LIFEHUG_JOBS_NO_KICK=1`. In that mode, queued-and-waited mutations drain in
+the foreground instead of spawning the detached fallback worker, so the command
+returns only after Lifehug has stopped touching the checkout. Local companion
+behavior stays unchanged when the variable is unset.
+
 ```mermaid
 flowchart TB
     subgraph d["🌅 DAILY · free"]

--- a/system/jobs.py
+++ b/system/jobs.py
@@ -78,6 +78,7 @@ DRAIN_IDLE_SECONDS = max(0.05, float(os.environ.get("LIFEHUG_JOB_DRAIN_IDLE", "0
 DRAIN_LOCK_WAIT_SECONDS = max(0.05, float(os.environ.get("LIFEHUG_JOB_DRAIN_LOCK_WAIT", "1")))
 WAIT_TIMEOUT_SECONDS = max(1, int(os.environ.get("LIFEHUG_JOB_WAIT_TIMEOUT", "86400")))
 ORPHAN_GRACE_SECONDS = max(60, int(os.environ.get("LIFEHUG_JOB_ORPHAN_GRACE", "86400")))
+NO_KICK_ENV = "LIFEHUG_JOBS_NO_KICK"
 PAYLOAD_VERSION = 1
 RECORD_VERSION = 2
 
@@ -93,6 +94,11 @@ _FOCUS_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 
 def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def supervised_no_kick_enabled() -> bool:
+    """Return true when an embedded host forbids detached fallback workers."""
+    return os.environ.get(NO_KICK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _parse_time(value: str) -> datetime | None:
@@ -713,7 +719,11 @@ def enqueue(
             }
             _write_json(_record_path(job_id), record)
             created = True
-    if kick and (created or record["state"] in {"queued", "safely-retryable"}):
+    if (
+        kick
+        and not supervised_no_kick_enabled()
+        and (created or record["state"] in {"queued", "safely-retryable"})
+    ):
         _kick_worker()
     return record
 
@@ -1338,6 +1348,26 @@ def wait_for_job(job_id: str, *, timeout: float = WAIT_TIMEOUT_SECONDS) -> dict:
     raise TimeoutError("timed out waiting for job")
 
 
+def wait_for_job_supervised(job_id: str, *, timeout: float = WAIT_TIMEOUT_SECONDS) -> dict:
+    """Wait for one job while draining runnable work in this process."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = load_job(job_id)
+        if record is None:
+            raise ValueError("unknown job")
+        if record["state"] in TERMINAL_STATES:
+            return record
+        worker_once(wait_seconds=DRAIN_LOCK_WAIT_SECONDS)
+        time.sleep(min(POLL_SECONDS, 0.2))
+    raise TimeoutError("timed out waiting for job")
+
+
+def wait_for_job_embedded_safe(job_id: str, *, timeout: float = WAIT_TIMEOUT_SECONDS) -> dict:
+    if supervised_no_kick_enabled():
+        return wait_for_job_supervised(job_id, timeout=timeout)
+    return wait_for_job(job_id, timeout=timeout)
+
+
 def _cmd_enqueue(args: argparse.Namespace) -> int:
     if args.command not in {"daily", "weekly", "monthly", "compile-pending", "compile"}:
         print("error: use the typed application API for commands with inputs", file=sys.stderr)
@@ -1348,7 +1378,7 @@ def _cmd_enqueue(args: argparse.Namespace) -> int:
     if not args.wait:
         return 0
     try:
-        record = wait_for_job(record["id"])
+        record = wait_for_job_embedded_safe(record["id"])
     except TimeoutError:
         return 124
     return int(record.get("exit_code", 1)) if record["state"] == "failed" else 0
@@ -1366,7 +1396,7 @@ def _cmd_file_answer(args: argparse.Namespace) -> int:
     if not args.wait:
         return 0
     try:
-        record = wait_for_job(record["id"])
+        record = wait_for_job_embedded_safe(record["id"])
     except TimeoutError:
         return 124
     return int(record.get("exit_code", 1)) if record["state"] == "failed" else 0

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -127,7 +127,7 @@ def _queue_and_wait(command: str, payload: dict) -> int:
     try:
         record = jobs.enqueue(command, payload)
         print(f"Queued {command} job {record['id']}")
-        record = jobs.wait_for_job(record["id"])
+        record = jobs.wait_for_job_embedded_safe(record["id"])
     except (TimeoutError, ValueError) as exc:
         print(f"Error: local job could not complete ({exc})", file=sys.stderr)
         return 1

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 138,
+  "version": 139,
   "released": "2026-08-09",
-  "changelog": "v138: test fixtures that need macOS-safe workspace-parent temp dirs now use one cleanup-registering helper, with a guard test that blocks future direct ROOT.parent mkdtemp leaks.",
+  "changelog": "v139: embedded hosts can set LIFEHUG_JOBS_NO_KICK=1 so queued-and-waited mutations drain under the foreground process instead of spawning a detached fallback worker.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_v119_jobs.py
+++ b/tests/test_v119_jobs.py
@@ -203,6 +203,36 @@ class DurableJobsTests(unittest.TestCase):
         self.assertEqual(duplicate["id"], record["id"])
         kick.assert_called_once_with()
 
+    def test_no_kick_mode_drains_supervised_without_detached_worker(self):
+        with mock.patch.dict(os.environ, {"LIFEHUG_JOBS_NO_KICK": "1"}):
+            with mock.patch.object(jobs, "_kick_worker") as kick:
+                record = jobs.enqueue(
+                    "compile",
+                    {"no_ai": True},
+                    identity="supervised-no-kick",
+                    kick=True,
+                )
+                finished = jobs.wait_for_job_embedded_safe(record["id"], timeout=5)
+
+        kick.assert_not_called()
+        self.assertEqual(finished["state"], "succeeded")
+        self.assertIn(
+            "start",
+            (self.vault / "state" / "probe-events.log").read_text(encoding="utf-8"),
+        )
+
+    def test_lifehug_queue_wait_uses_embedded_safe_wait(self):
+        record = {"id": "a" * 20}
+        finished = {"id": record["id"], "state": "succeeded"}
+        with mock.patch.object(jobs, "configure"), \
+                mock.patch.object(jobs, "enqueue", return_value=record), \
+                mock.patch.object(
+                    jobs, "wait_for_job_embedded_safe", return_value=finished
+                ) as wait:
+            self.assertEqual(lifehug._queue_and_wait("compile", {"no_ai": True}), 0)
+
+        wait.assert_called_once_with(record["id"])
+
     def test_cold_start_identity_key_is_atomic_across_processes(self):
         cold_vault = self.tmp / "cold-vault"
         make_minimum_vault(cold_vault)


### PR DESCRIPTION
Closes #86\n\n## Summary\n- add LIFEHUG_JOBS_NO_KICK=1 to suppress detached fallback worker kicks\n- add embedded-safe waiting that drains runnable jobs in the foreground process\n- route lifehug.py queued mutations and jobs.py --wait through the embedded-safe wait path\n- document the env var and bump framework version to v139\n\n## Validation\n- PATH="/opt/homebrew/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/homebrew/bin:/Users/ea/.codex/tmp/arg0/codex-arg0i8MUqZ:/Users/ea/.bun/bin:/Applications/ChatGPT.app/Contents/Resources" /opt/homebrew/bin/python3.14 -m unittest tests.test_v119_jobs\n- /opt/homebrew/bin/python3.14 scripts/ci/check_version_bump.py --base origin/main --head HEAD\n- /opt/homebrew/bin/python3.14 scripts/ci/check_framework_files.py\n- git diff --check HEAD~1..HEAD