### PR TITLE
Conversation turn engine: post-answer chat turns with graceful fallback (contract)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,9 @@ Lifehug state files track delivery history, coverage, and the question queue. Du
 - `system/coverage.json` — per-category answer counts
 - `state/question_queue.json` — planned queue with sent/queued status
 - `state/source_manifest.json` — answer and source registry
-- `state/answer_acknowledgments.json` — metadata-only acknowledgment delivery/dedupe ledger
+- `state/answer_acknowledgments.json` — metadata-only acknowledgment delivery/dedupe ledger (the v153 fallback path)
+- `state/conversation_deliveries.json` — metadata-only conversation-turn delivery/dedupe ledger
+- `state/conversations/` — one document per conversation session (turns, extraction, close)
 - `system/question-bank.md` — checked-off questions
 
 ### Framework files (accept REMOTE on conflict)
@@ -241,7 +243,7 @@ When the user replies to a daily question (via any channel):
    - Pipe the answer through `python3 system/lifehug.py process-answer {question_id}`
    - Let `process-answer` compile the private wiki automatically unless there is a clear repair reason to pass `--no-compile-wiki`
    - Commit and push if requested or part of the configured daily workflow
-3. **Acknowledge warmly** — `process-answer` now does this automatically after the answer is durable and before any adaptive follow-up, using the shared `ai_provider` plus the canonical `answer-ack-prompt` tone contract. Do not send a second hand-written acknowledgment. Provider/generation/Telegram failure degrades to silence without failing capture or suppressing the follow-up; inspect metadata-only status with `python3 system/lifehug.py answer-ack-status`.
+3. **Answer with a conversation turn** — `process-answer` does this automatically once the answer is durable (v153, issue #116). It sends ONE message that receives what was said, pays it back, and cues the next question in the user's own words, per `interactions/conversation/prompt/behavior.md`; the cued follow-up is filed as a suffix-chain bank question (A14 → A14b) and rotation targets it. Do not send a second hand-written acknowledgment or a second question. Any definitive failure degrades in the same run to the previous pair — warm acknowledgment, then the separate adaptive follow-up — so this path is never silent and never worse than before. Inspect metadata-only status with `python3 system/lifehug.py conversation-status` (the fallback acknowledgment keeps its own `answer-ack-status`).
 
 ## Unprompted Story Ingest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ printf '%s\n' "$ANSWER_TEXT" | python3 system/lifehug.py process-answer {questio
 
 If follow-up questions are already known, pass `--followup "question text"` for each.
 
-The helper writes `answers/{question_id}.md` as a raw source record, registers it in `state/source_manifest.json`, marks the question answered, rebuilds coverage, updates rotation state, refreshes `README.md`, and compiles the private wiki. After the answer file (and a requested local commit) is durable, it builds the canonical `answer-ack-prompt` through the shared `ai_provider`, sends the warm acknowledgment on Telegram, and only then sends any adaptive follow-up. Model, provider, malformed-generation, and Telegram failures are best-effort: they never fail the saved answer or suppress the follow-up.
+The helper writes `answers/{question_id}.md` as a raw source record, registers it in `state/source_manifest.json`, marks the question answered, rebuilds coverage, updates rotation state, refreshes `README.md`, and compiles the private wiki. After the answer file (and a requested local commit) is durable, it runs ONE conversation turn (v153, issue #116): `system/conversation_delivery.py` assembles the turn through the `interactions/conversation/` behavior authority and the issue #115 builders, enforces the deterministic lints (one question, `cap.turn_chars`, banned phrases) before anything is sent, and delivers a single Telegram message that receives the answer, pays it back, and cues the next question in the user's own words. The cued follow-up is minted as a suffix-chain bank question and rotation targets it, so the next inbound files against it. Model, provider, malformed-generation, lint, and Telegram failures are best-effort AND never silent: each degrades in the same run to the previous behavior — the canonical `answer-ack-prompt` acknowledgment followed by the separate adaptive follow-up. A transport-ambiguous turn is the one exception: it is ledgered and surfaced rather than followed by an acknowledgment, because the turn may already have arrived.
 
 **Chat / phone path (durable filing, v82/v83/v121).** From a chat surface that must not block,
 dispatch the canonical wrapper, acknowledge immediately, and end the turn. The
@@ -260,7 +260,7 @@ printf '%s\n' "$ANSWER_TEXT" | nohup bash system/file_answer_bg.sh {question_id}
   --source "telegram-voice" >/tmp/lifehug-file-{question_id}.log 2>&1 &
 ```
 
-Set `TELEGRAM_CHAT_ID` (or legacy `LIFEHUG_CHAT_ID`) to steer the acknowledgment to the active chat; otherwise it goes to the configured `telegram_chat_id`/`group_chat_id`. Delivery metadata is stored under `state/answer_acknowledgments.json`, keyed by the durable `answer:{ID}` source id and containing no answer, prompt, or generated message text. Confirmed sends never repeat. A transport-ambiguous send stays visible in `doctor` / `answer-ack-status` and is not retried unless you first verify Telegram did not receive it:
+Set `TELEGRAM_CHAT_ID` (or legacy `LIFEHUG_CHAT_ID`) to steer the acknowledgment to the active chat; otherwise it goes to the configured `telegram_chat_id`/`group_chat_id`. Delivery metadata is stored under `state/conversation_deliveries.json` for turns (keyed `turn:{session_id}:{turn_index}`, plus `close:{session_id}` for closing takeaways) and under `state/answer_acknowledgments.json` for the fallback acknowledgment (keyed by the durable `answer:{ID}` source id). Neither contains answer, prompt, or generated message text. Confirmed sends never repeat. A transport-ambiguous send stays visible in `doctor` / `answer-ack-status` and is not retried unless you first verify Telegram did not receive it:
 
 ```bash
 python3 system/lifehug.py answer-ack-status A3
@@ -1145,7 +1145,11 @@ channel: "telegram"
 Optional AI-call tuning (v85): `ai_timeout_seconds` (default 600; env override
 `LIFEHUG_AI_TIMEOUT`) bounds each gateway/SDK call, and `classify_model` /
 `research_model` override the classifier/expander model defaults.
-`answer_ack_model` selects the warm acknowledgment model (default
+`conversation_model` selects the seated conversation-turn/closing model (default
+`claude-sonnet-5`); `router_model` (default `claude-haiku-4-5`) and
+`arc_plan_model` (falls back to `classify_model`) are read by the
+conversation interaction's later stages.
+`answer_ack_model` selects the fallback acknowledgment model (default
 `claude-sonnet-5`; a configured local provider still uses its own local model).
 
 Direct on-machine AI (v123): put `ai_provider: local`,
@@ -1344,14 +1348,15 @@ If the user wants to rollback: `python3 system/update.py --rollback`
 Lifehug tracks its version in `system/version.json`. Framework files (listed there) are maintained by the Lifehug project and can be updated automatically. User data files are never touched by updates:
 
 **Framework files** (updated automatically):
-- `CLAUDE.md`, `system/ai_provider.py`, `system/answer_ack.py`, `system/answer_ack_delivery.py`, `system/ask.py`, `system/artifact.py`, `system/compose.py`, `system/daily_question.sh`, `system/weekly_maintenance.sh`, `system/weekly_report.py`, `system/monthly_research.sh`, `system/gen_followups.py`, `system/ingest_story.py`, `system/jobs.py`, `system/lifehug.py`, `system/lifehug_core.py`, `system/mirror.py`, `system/process_answer.py`, `system/question_candidates.py`, `system/question_planner.py`, `system/rebuild_state.py`, `system/serve_wiki.py`, `system/source_integrity.py`, `system/source_contract.md`, `system/update.py`, `system/update_readme.py`, `system/version.json`, `system/wiki_compile.py`, `system/research.md`, `.gitignore`
+- `CLAUDE.md`, `system/ai_provider.py`, `system/answer_ack.py`, `system/answer_ack_delivery.py`, `system/ask.py`,
+  `system/conversation.py`, `system/conversation_delivery.py`, `system/conversation_lints.py`, `system/artifact.py`, `system/compose.py`, `system/daily_question.sh`, `system/weekly_maintenance.sh`, `system/weekly_report.py`, `system/monthly_research.sh`, `system/gen_followups.py`, `system/ingest_story.py`, `system/jobs.py`, `system/lifehug.py`, `system/lifehug_core.py`, `system/mirror.py`, `system/process_answer.py`, `system/question_candidates.py`, `system/question_planner.py`, `system/rebuild_state.py`, `system/serve_wiki.py`, `system/source_integrity.py`, `system/source_contract.md`, `system/update.py`, `system/update_readme.py`, `system/version.json`, `system/wiki_compile.py`, `system/research.md`, `.gitignore`
 - `templates/letter.md`, `templates/tweet.md`, `templates/instagram.md`, `templates/post.md`, `templates/chapter.md`
 - `skills/artifact/SKILL.md`, `skills/focus/SKILL.md`, `skills/compile/SKILL.md`
 
 **User data** (never touched):
 - `README.md`, `profile.yaml` (committed identity/prefs), `config.yaml` (gitignored secrets/overrides), `system/question-bank.md`, `system/rotation.json`, `system/coverage.json`, `system/schedule.json`
 - `answers/`, `outputs/`, `sources/`
-- `state/answer_acknowledgments.json`, `state/question_candidates.json`, `state/question_queue.json`, `state/planner_state.json`, `state/source_manifest.json`, `state/source_lint_findings.json`, `state/timeline_placements.json`
+- `state/answer_acknowledgments.json`, `state/conversation_deliveries.json`, `state/question_candidates.json`, `state/question_queue.json`, `state/planner_state.json`, `state/source_manifest.json`, `state/source_lint_findings.json`, `state/timeline_placements.json`
 
 ## Cross-Medium Parity
 

--- a/artifacts/walkthroughs/conversation-turn-engine/synthetic-transcript.md
+++ b/artifacts/walkthroughs/conversation-turn-engine/synthetic-transcript.md
@@ -1,0 +1,110 @@
+# Conversation turn engine — synthetic interaction evidence
+
+Deterministic transcript for issue #116 (PR #122). Synthetic names, synthetic
+memories, synthetic vault. No real Telegram bot, private vault, model
+endpoint, or API key was used or claimed — and nothing here reads from
+`~/Workspace/dave`.
+
+Every row names the subtest that proves it. Reproduce all of it with:
+
+```
+python3 -m unittest tests.test_conversation_delivery -v
+```
+
+The transcript is the human-readable projection of those assertions, not
+extra claims.
+
+## Before → after, in one glance
+
+| | The author answers "What did the farm smell like?" |
+|---|---|
+| **Before (v152)** | **Message 1:** "Thank you for sharing that. Diesel and cut hay make the memory feel close."<br>**Message 2:** "📖 Lifehug — since you're on a roll<br>B1: What's a decision you'd make differently?<br>(Totally optional — tomorrow's question comes either way)" |
+| **After (v153)** | **One message:** "Diesel and cut hay — and your grandfather's hands carrying both at once. Tell me about \"the north field\"." |
+
+The second message's question was picked by rotation and is about something
+else entirely. The turn's question is about what the author just said, in the
+author's own words, and it is filed as `A14a` in the bank so the next inbound
+answer lands on the right question.
+
+## 1. Confirmed chat — the happy path
+
+| # | Durable / system event | What the synthetic author sees | Proven by |
+|---:|---|---|---|
+| 1 | `answer:A14` is filed, registered, scored, and (when requested) committed locally | — | (inherited `finalize_answer_delivery` ordering) |
+| 2 | A chat session opens at the FIRST ANSWER (`conv-…`), the answer is recorded as a `user` turn | — | `test_confirmed_turn_is_one_message` |
+| 3 | Provider ready → turn generated → lints pass → ONE Telegram message sent → ledger `turn:{sid}:1 = confirmed` | "Diesel and cut hay — and your grandfather's hands carrying both at once. Tell me about \"the north field\"." | `test_confirmed_turn_is_one_message` |
+| 4 | The cued follow-up is minted as `A14a` (suffix chain, bank-visible), rotation retargets to it, coverage rebuilds | — | `test_confirmed_turn_is_one_message` |
+| 5 | Exchange 2: the author answers `A14a`; a second turn receives it and cues `A14b` | "The north field in August — he baled it himself. Tell me about \"the barn\"." | `test_third_exchange_exit_shape_and_cap` |
+| 6 | Exchange 3 is the exit-friendly door: the turn receives and pays out but asks NOTHING — stopping here is a good place to rest | "A baler kept alive with parts he made himself. That is a whole portrait of him in one sentence." | `test_third_exchange_exit_shape_and_cap` |
+| 7 | The author keeps going anyway; we keep receiving and never hard-stop, still without spending question initiative | "Listening for the belt — that is the kind of knowing you only get by standing next to someone." | `test_third_exchange_exit_shape_and_cap` |
+| 8 | Close (≥2 user turns → the session earned a takeaway): generated, linted, sent, ledgered under `close:{sid}` | "What stays with me is that his hands carried the work and the harvest at the same time. Thank you for putting me in that barn. Next time we can pick up the baler he kept alive." | `test_completed_chat_closing_takeaway` |
+| 9 | Close block records `reason`, `takeaway`, `takeaway_delivered`, `insight_receipts_count`, `filed`; engagement lands on each filed question's score record; candidate ideas file with `provenance: conversation` | — | `test_engagement_appended_to_answer_scores`, `test_candidate_ideas_filed_with_conversation_provenance` |
+
+A replay of the same answer performs neither a second model call nor a second
+send (`test_confirmed_replay_is_noop`). A closing that ends with a trailing
+question is never sent — behavior rule 8 (`test_closing_with_a_trailing_question_is_never_sent`).
+
+## 2. Fallback path — byte-shape identical to v152
+
+| # | Durable / system event | What the synthetic author sees | Proven by |
+|---:|---|---|---|
+| 1 | `answer:A14` is filed normally | — | — |
+| 2 | Provider reports not-ready (`agent-task` → `no_unattended_provider`, otherwise `provider_unavailable`); ledger records `skipped`; NO turn is sent | — | `test_provider_unavailable_falls_back_to_todays_behavior`, `test_keyless_provider_reports_no_unattended_provider` |
+| 3 | Same invocation degrades to v152: the canonical warm acknowledgment, told honestly that a follow-up is pending | "Thank you for sharing that. Diesel and cut hay make the memory feel close." | `test_provider_unavailable_falls_back_to_todays_behavior` |
+| 4 | Then the separate adaptive follow-up, with its original header/footer framing | "📖 Lifehug — since you're on a roll … (Totally optional — tomorrow's question comes either way)" | `test_provider_unavailable_falls_back_to_todays_behavior` |
+
+The same degradation covers a provider error (`test_provider_error_falls_back`),
+a definitive send rejection (`test_definitive_send_rejection_falls_back`), and
+every lint/parse rejection below. Never silence; never worse than v152.
+
+### Lint rejections that fall back
+
+| Rejected generation | Ledger | Sent? | Proven by |
+|---|---|---|---|
+| Two questions in one message | `failed / malformed_generation` | nothing | `test_lint_reject_falls_back[two_questions]` |
+| Over `cap.turn_chars` (1200, read from `evals/lints.yaml`) | `failed / malformed_generation` | nothing | `test_lint_reject_falls_back[overlong]` |
+| Banned phrase ("that must have been") | `failed / malformed_generation` | nothing | `test_lint_reject_falls_back[banned_phrase]` |
+| Unparseable output | `failed / malformed_generation` | nothing | `test_lint_reject_falls_back[unparseable]` |
+| A question asked when the cadence gates are spent (curfew / 3-a-day cap / pass transition) | `failed / malformed_generation` + `question_not_permitted` | nothing | `test_curfew_and_cap_gates_transfer` |
+
+Advisory findings (closed-question grammar, year questions) are counted in the
+ledger and do NOT block a send — a false positive there would silently
+downgrade a good turn (`test_advisory_lints_do_not_block_the_send`).
+
+## 3. Ambiguous path — no auto-retry, and no fallback ack
+
+| # | Durable / system event | What the synthetic author sees | Proven by |
+|---:|---|---|---|
+| 1 | The ledger records `ambiguous / send_in_progress` BEFORE the Telegram call (crash-safe replay position) | — | `test_pre_send_ambiguous_position_is_written_before_the_send` |
+| 2 | The Telegram response is lost | The turn may or may not be present | `test_ambiguous_never_auto_retried_and_no_fallback_ack` |
+| 3 | NO fallback acknowledgment runs — a second message would risk a duplicate voice for a turn that may already have arrived | Nothing further | `test_ambiguous_never_auto_retried_and_no_fallback_ack` |
+| 4 | No follow-up is minted; rotation is untouched | — | `test_ambiguous_never_auto_retried_and_no_fallback_ack` |
+| 5 | A later run reads `ambiguous_not_retried` and makes no model call | — | `test_ambiguous_never_auto_retried_and_no_fallback_ack` |
+
+`conversation-status <session_id>` keeps it visible with
+`operator_action: verify Telegram before retrying`. An operator who has
+checked Telegram runs
+`conversation-turn-retry <session_id> <turn_index> --confirm-not-sent`
+(`test_turn_retry_requires_confirmation_for_ambiguous`).
+
+## 4. Timeout path — a partial chat files silently
+
+| # | Durable / system event | What the synthetic author sees | Proven by |
+|---:|---|---|---|
+| 1 | One answer is filed and receives its turn; the author walks away mid-exchange | (the turn from step 3 of path 1) | `test_idle_timeout_files_partial_chat_silently` |
+| 2 | Two hours later (chat idle timeout from `interaction.yaml`, `knob.chat_idle_timeout_minutes: 120`) the lazy sweep closes the session | **Nothing. No closing message, no "you didn't finish", nothing.** | `test_idle_timeout_files_partial_chat_silently`, `test_idle_timeout_knobs_come_from_interaction_yaml` |
+| 3 | The close block is still written (`reason: idle_timeout`, `takeaway: ""`, `takeaway_delivered: false`, `filed: [A14]`) | — | `test_idle_timeout_files_partial_chat_silently` |
+| 4 | The answer stays durably filed with its richness score untouched | — | `test_idle_timeout_files_partial_chat_silently` |
+
+A zero-turn session closes the same silent way
+(`test_zero_turn_session_closes_silently`). The no-nag rule is
+owner-confirmed: whatever was answered is already filed per turn, so there is
+nothing to chase.
+
+## 5. Concurrency and privacy
+
+| Property | Behavior | Proven by |
+|---|---|---|
+| Single flight | A concurrent second entry for the same session mints no second turn and sends nothing at all — not even a fallback ack, because the winner's turn is the voice | `test_single_flight_mint` |
+| Metadata-only ledger and diagnostics | No answer, question, prompt, or generated text in `state/conversation_deliveries.json` or in learning-failure records — only session ids, turn indices, question ids, fixed reason codes, lint ids, timestamps, attempt counts | `test_metadata_only_ledger_and_diagnostics` |
+| Single source for the length cap | `system/conversation_delivery.py` contains no independent `1200`; the cap comes from `interactions/conversation/evals/lints.yaml` `cap.turn_chars` through the shared lint engine | `test_length_cap_is_sourced_from_lints_yaml_not_pinned_here` |

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -15,8 +15,15 @@
 # --- AI models ---
 # Pass-transition question generation:
 followup_model: "anthropic/claude-opus-4-6"
-# Warm 2–4 sentence answer acknowledgment (shared provider; default Sonnet):
+# Warm 2–4 sentence answer acknowledgment — the FALLBACK path since v153
+# (shared provider; default Sonnet):
 # answer_ack_model: "claude-sonnet-5"
+# Conversation turns + closing takeaways (the seated voice; sonnet-class):
+# conversation_model: "claude-sonnet-5"
+# Conversation intent router (cheap, haiku-class):
+# router_model: "claude-haiku-4-5"
+# Weekly conversation arc planning (falls back to classify_model):
+# arc_plan_model: "claude-sonnet-5"
 # Research neighborhood expansion (self-knowledge, gaps, topics):
 # research_model: "claude-opus-4-20250514"
 # Story/source classification:

--- a/docs/adr/0003-conversation-turn-engine.md
+++ b/docs/adr/0003-conversation-turn-engine.md
@@ -1,0 +1,84 @@
+# ADR 0003: Conversation turn engine replaces post-answer ack + follow-up
+
+Date: 2026-08-11
+Status: proposed
+
+## Context
+
+Answering a Lifehug question produced two disconnected messages. First a
+warm acknowledgment that is contractually forbidden from asking anything —
+`system/answer_ack.py` literally instructs "No questions back". Then, when
+the adaptive-cadence gates allowed it, a second message carrying a question
+picked by rotation from the bank: a different topic, a different voice, and
+a header ("📖 Lifehug — since you're on a roll") that announces itself as a
+prompt rather than a reply. The owner's words on issue lifehug#99 name the
+failure directly — follow-ups have to read as conversation. `system/
+research.md` §2e had already named the fix: "The fix is conversation, not
+cadence — immediate acknowledgment + one listening follow-up."
+
+Issue #114 shipped the behavior authority (`interactions/conversation/`) and
+issue #115 shipped the session store, the prompt builders, and the
+deterministic lint engine. Neither had a consumer: the post-answer pipeline
+still ran the old pair. This ADR records the decision made in the
+2026-08-11 owner-approved design session and implemented by issue #116 —
+the decision to move the live post-answer path onto that infrastructure,
+and the two guarantees that move is conditional on.
+
+## Decision
+
+`system/conversation_delivery.py` replaces the acknowledgment +
+separate-follow-up pair in `process_answer.run_post_answer_delivery` with a
+single **conversation turn**: one message that receives the answer, pays it
+out, and cues the next question in the user's own words, per
+`interactions/conversation/prompt/behavior.md`. Two properties of that
+replacement are binding, not incidental:
+
+1. **The fallback guarantee.** Any definitive failure — no seated provider,
+   a provider error, an unparseable or lint-rejected generation, a
+   definitive send rejection — degrades to today's exact behavior in the
+   same invocation: `acknowledge_answer(...)` followed by
+   `maybe_send_followup_question(...)`. The post-answer moment is never
+   silent and never worse than it was before this change. The single
+   exception is an *ambiguous* send: the turn may already have reached
+   Telegram, so a fallback acknowledgment would risk speaking twice in two
+   different voices; that case is ledgered and surfaced to the operator
+   instead.
+2. **The exactly-once ledger.** `state/conversation_deliveries.json` carries
+   the same state machine as `state/answer_acknowledgments.json`: the
+   conservative `ambiguous/send_in_progress` position is written *before*
+   the external effect, a confirmed entry replays as a no-op with no second
+   model call and no second send, and an ambiguous entry is never
+   auto-retried — retrying it requires an operator who has checked Telegram
+   (`conversation-turn-retry --confirm-not-sent`).
+
+Alternatives considered. *Keep the ack and make only the follow-up
+conversational*: rejected — the two-message shape is itself the defect the
+owner named; a related question in a second message still reads as a prompt,
+not a reply. *Retry generation on a lint failure*: rejected — a retry loop
+against a live user costs latency and can produce a worse second attempt;
+one attempt then fallback matches the acknowledgment layer's proven
+behavior. *Extract a shared delivery-ledger module now*: deliberately
+deferred — the recurring-defect doctrine's trigger is the second copy, and
+Wave-2 PR 4's story turn will call this module rather than copy it.
+
+## Consequences
+
+- **Binds:** every future change to the post-answer path must preserve both
+  guarantees above. Adding a new failure mode means adding it to the
+  fallback path, not letting it fall through to silence. Changing the ledger
+  means preserving pre-send ambiguity and the never-auto-retry rule.
+- **Binds:** `answer_ack.py` / `answer_ack_delivery.py` are live code, not
+  legacy. They are the fallback path and the keyless-mode path. The "No
+  questions back" instruction stays: it is correct for an acknowledgment
+  that is followed by a separate question.
+- **Binds:** the runtime lints are `system/conversation_lints.py` reading
+  `interactions/conversation/evals/lints.yaml`. The turn length cap is
+  `cap.turn_chars` from that file — no module may pin an independent copy of
+  that number.
+- **Forecloses:** a second acknowledgment alongside a turn. One message per
+  post-answer moment, whichever path produced it.
+- **Forecloses:** closing-message nagging. Sessions below two user turns
+  close silently; whatever was answered is already durably filed per turn.
+- **Delete-when:** if the keyless host-agent path ever becomes the only
+  supported runtime, the provider-readiness branch and its fallback collapse
+  into one path and this ADR should be revisited.

--- a/docs/pr-specs/116-conversation-turn-engine.md
+++ b/docs/pr-specs/116-conversation-turn-engine.md
@@ -1,0 +1,514 @@
+# Contract: conversation-turn-engine (issue #116)
+
+Wave 2, PR 3 of the Conversation Interaction build (owner-approved design,
+2026-08-11). This contract is self-contained: everything the implementer
+needs is in this file plus the repo at the commit this contract ships on.
+Serves issues #98 (the Conversation primitive) and #99 (owner's words:
+"follow-ups must read as conversation").
+
+## Why
+
+The post-answer moment is Lifehug's most important surface, and today it is
+two disconnected messages: a warm acknowledgment that is contractually
+forbidden from asking anything ("No questions back" —
+`system/answer_ack.py:79`), followed by an adaptive follow-up question picked
+by rotation that is usually UNRELATED to what the user just said ("📖 Lifehug
+— since you're on a roll"). The owner's stated pain: today's chained
+questions don't relate like a real conversation. `system/research.md` §2e
+already names the fix: "The fix is conversation, not cadence — immediate
+acknowledgment + one listening follow-up."
+
+This PR makes the post-answer pipeline run a **conversation turn**: one
+message that receives the answer, pays it out, and cues the next question —
+a short, coherent Chat (~3 exchanges) with a graceful exit and a closing
+takeaway — while degrading to today's exact behavior on any failure.
+
+## Dependencies (Wave 1) and the merged-code-wins rule
+
+This PR builds on the two Wave-1 PRs (the `interactions/` scaffold and the
+session store + builders). Their contracts were drafted in the same session
+as this one; issue numbers were not yet assigned when this contract was
+written. **The interfaces below are what this PR was planned against (design
+§5/§6). If the merged Wave-1 code differs in names or shapes, the merged
+code wins — re-verify these at implementation start and follow the merged
+interfaces; the behavior pinned in this contract is unchanged either way.**
+
+Expected from Wave 1:
+
+1. `interactions/conversation/` definition files (Wave-1 PR 1):
+   - `interaction.yaml` — lifecycle knobs this engine must read (not
+     hardcode): chat idle timeout (default ~2h), conversation idle timeout
+     (default ~30min), chat exchange target (default 3), max message length,
+     deposit-framing on/off.
+   - `prompt/identity.md`, `prompt/behavior.md`, `prompt/examples.md`,
+     `prompt/turn-instructions.md` — consumed via the Wave-1 builders, never
+     read ad hoc.
+   - `evals/lints.yaml` — the deterministic lint definitions; the runtime
+     lints in this PR must be the same checks (single source, imported or
+     loaded from this file — do not fork the list into code constants that
+     can drift).
+2. `system/conversation.py` (Wave-1 PR 2) — pure, no provider calls:
+   - Session store CRUD over `state/conversations/<session_id>.json`
+     (vault-contract-registered by Wave 1), including a compare-and-set
+     field for single-flight turn minting.
+   - `build_turn_prompt(...)` — per-turn prompt assembly per
+     `interactions/conversation/context/manifest.md` (stable blocks first,
+     turn instructions last).
+   - `build_closing_prompt(...)` — the closing-takeaway prompt.
+   - Session document schema (the shape this PR reads/writes):
+
+```json
+{"session_id":"…","mode":"chat|conversation","channel":"telegram|web|cli",
+ "interaction_version":"1.0.0","status":"open|idle|closed",
+ "arc":{"question_id":"A14","opening":"…","intents":["scene_sensory","who_else","meaning"]},
+ "turns":[{"role":"user|lifehug","text":"…","ts":"…","model":"provider/model",
+           "question_id":"A14"}],
+ "rolling_summary":"…",
+ "extracted":{"facts":[],"entities":[],"candidate_ideas":[],"mirror_responses":[]},
+ "close":{"reason":"done|idle_timeout|exit_taken","takeaway":"…",
+          "takeaway_delivered":true,"insight_receipts_count":0,"filed":["A14","A14b"]}}
+```
+
+## Binding facts (verified against the repo at this contract's commit)
+
+- `system/process_answer.py`:
+  - `run_post_answer_delivery(*, source_id, question_id, question_text,
+    question_category, answer_text)` (line ~409) — plans the adaptive
+    follow-up, calls `answer_ack_delivery.acknowledge_answer(...)`
+    (swallowing all failures), then `maybe_send_followup_question(...)`.
+    This is the function this PR rewires.
+  - `finalize_answer_delivery(...)` (line ~470) — the durability boundary:
+    commit → post-answer delivery → chapter offer → bookkeeping commit.
+    Its ordering guarantee (durable answer FIRST, conversational effects
+    second, all conversational failures swallowed) is inherited unchanged.
+  - `plan_adaptive_followup(answered_question_id)` — returns the planned
+    bank question or None (respects `adaptive_cadence` config, the 20:00
+    curfew, `awaiting_pass_transition`, and `ask.sends_today(rotation) >=
+    ask.max_sends_per_day()`).
+  - `maybe_send_followup_question(answered_question_id, planned_question)` —
+    sends `FOLLOWUP_HEADER` / question / `FOLLOWUP_FOOTER` and calls
+    `ask.mark_question_sent(rotation, id)` + `rebuild_coverage()`.
+  - `next_followup_id(md_text, source_id)` / `append_followups(question_id,
+    followups)` — the ONLY way to mint follow-up questions (suffix chain
+    A14 → A14b; appends to `system/question-bank.md`).
+- `system/answer_ack_delivery.py` — the pattern this PR generalizes:
+  - `acknowledge_answer(*, source_id, question_id, question_text,
+    question_category, answer_text, followup_pending, state_path=...,
+    allow_ambiguous_retry=False, prompt_builder=..., ai_call=None,
+    status_resolver=None, telegram_send=None) -> AcknowledgmentOutcome`.
+  - Ledger `state/answer_acknowledgments.json`; statuses
+    `confirmed/skipped/failed/ambiguous`; `ambiguous` is written with reason
+    `send_in_progress` BEFORE the Telegram call (crash-safe replay
+    position); confirmed replays return `already_confirmed` with no second
+    model call or send; ambiguous is never auto-retried
+    (`allow_ambiguous_retry` requires operator confirmation).
+  - `_valid_completion`: rejects non-string, empty, >`ACK_MAX_CHARS` (1200),
+    NUL bytes, leading ``` `{` `[`, and prompt-echo markers.
+  - `DEFAULT_ACK_MODEL = "claude-sonnet-5"`; model key `answer_ack_model`.
+  - Injectable collaborators for tests (`ai_call`, `telegram_send`,
+    `status_resolver`, `prompt_builder`, `state_path`) — this PR's engine
+    MUST expose the same injectability (precedent:
+    `tests/test_v121_answer_ack_delivery.py`).
+- `system/ai_provider.py`: `call_ai(prompt, model)`, `provider_status(model,
+  probe=False) -> ProviderStatus(provider, model, ready, detail)`, error
+  family `AIProviderError` / `AIConfigurationError` / `AIUnavailableError` /
+  `AIResponseError`; keyless mode surfaces as provider `agent-task`,
+  not-ready.
+- `system/lifehug_core.py`: `send_telegram_result(text) ->
+  TelegramSendResult` (statuses `confirmed` / `ambiguous` / `not_attempted`
+  / rejection), `load_config()`, `record_learning_failure(...)` (metadata
+  only — never answer/prompt/generated text), `STATE_DIR`, `read_json` /
+  `write_json`.
+- `system/lifehug.py`: command classification sets at lines ~60–88 —
+  `QUEUED_MUTATION_COMMANDS` / `READ_ONLY_COMMANDS` /
+  `DIRECT_MUTATION_COMMANDS`. Every new subcommand must be classified in
+  exactly one.
+- `system/jobs.py::COMMANDS` — NOT touched by this PR (the
+  `conversation-close` job kind and batching-default change are Wave-2
+  PR 6).
+- `system/quality_profile.py::append_score(...)` — appends per-answer
+  records to `state/answer_scores.json` (vault-contract key
+  `answer_scores`, tracked; `unknown_fields: allow` family). Engagement
+  fields are ADDED to these records; precedent for non-richness signals
+  living there already exists (insight/negative/i_rate).
+- `system/vault_contract.json` `data_paths`: Wave 1 registers
+  `conversations` (`state/conversations`, directory, tracked). THIS PR
+  registers `conversation_deliveries`
+  (`state/conversation_deliveries.json`, file, tracked, json, version 1) —
+  and mirrors it in `system/vault_paths.py` git-paths, same as
+  `answer_scores`.
+- Config keys today: `answer_ack_model` (default `claude-sonnet-5`),
+  `classify_model`, `followup_model`, `adaptive_cadence` — documented in
+  `config.yaml.example`.
+- Version/CI: every PR bumps `system/version.json` (version, released,
+  changelog, `framework_files` for new distributable files) — no exemption.
+  origin/main is at version 149 as this contract is written; Wave-1 and
+  sibling Wave-2 PRs land in owner-decided order, so pick the next free
+  number at implementation time, not now. CI is `python3 -m unittest
+  discover -s tests -p "test_*.py"` on Python 3.11 + 3.14, dependency-free
+  — no pip installs, stdlib only. This repo has NO ruff/pytest tooling;
+  do not introduce any.
+
+## New config keys (this PR)
+
+Documented in `config.yaml.example`, read via `load_config()`:
+
+- `conversation_model` — the seated turn/closing model. Default
+  `"claude-sonnet-5"` (sonnet-class, same default constant style as
+  `DEFAULT_ACK_MODEL`).
+- `router_model` — the cheap intent router. Default `"claude-haiku-4-5"`
+  (haiku-class). Defined here so the key set ships once; its consumer is
+  Wave-2 PR 4 (`lifehug.py route`).
+- `arc_plan_model` — weekly arc planning; resolution order
+  `arc_plan_model` → `classify_model` → provider default. Defined here;
+  consumer is Wave-2 PR 5.
+
+## The behavior this engine enforces (pasted; the implementer does not
+re-derive this from the design docs)
+
+The seated model's full behavior contract lives in
+`interactions/conversation/prompt/behavior.md` (Wave 1) and reaches the
+model through the Wave-1 prompt builders. What THIS module owns is the
+**turn-shape decisions and the deterministic enforcement**:
+
+1. **One message per turn.** Receipt + payout + cued follow-up are ONE
+   Telegram message, never two or three.
+2. **Turn anatomy** (chat exchanges 1–2, substantive answer): receipt that
+   quotes the user's own words exactly (never paraphrased facts) → register
+   (celebration/savoring for good news, cognitive-empathy for hard stories)
+   → at most ONE contribution the user didn't have → cued follow-up
+   invitation quoting the user's phrase. At most one question per message.
+3. **Question-free turns are legal and planned**: when the turn instructions
+   say to receive without asking (heavy register, user declined the last
+   door), the message ends after the receipt/contribution with no question.
+4. **Third exchange is exit-friendly**: phrased so stopping is graceful
+   ("that's a good place to rest" energy). The ~3-exchange target governs
+   OUR initiative only — if the user keeps going, keep receiving; never
+   hard-stop a continuing user.
+5. **Closing takeaway** (session close, when warranted): takeaway (not
+   recap — composes the user's words, never rewrites), specific
+   appreciation, continuity line, optional deposit-frame (knob from
+   `interaction.yaml`), named hook for next time — then STOP, no trailing
+   question.
+6. **No-nag rule** (owner-confirmed): zero-turn sessions and chats
+   abandoned mid-exchange close SILENTLY at idle timeout — whatever was
+   answered is already durably filed per-turn; no closing message, no
+   "you didn't finish", nothing.
+7. **Zero pressure, ever**: no guilt, streaks, length evaluation, repeated
+   asks of a declined question. A skip is signal: file it, move on warmly.
+
+**Runtime lints** (deterministic, enforced in `conversation_delivery` on
+every generated message BEFORE send; definitions sourced from
+`interactions/conversation/evals/lints.yaml`, not forked into code):
+
+- ≤ 1 question mark's worth of questions per message (one-question lint).
+- Length ≤ the interaction.yaml message cap (default 1200 chars, matching
+  `ACK_MAX_CHARS`).
+- Banned-phrase list (from lints.yaml; includes at minimum: "that must have
+  been", guilt/streak phrasing, "as an AI" / AI self-reference,
+  "you haven't told me much").
+- Structural sanity, same class as `_valid_completion`: non-empty string, no
+  NUL, no leading ``` `{` `[`, no prompt-echo markers.
+
+A lint failure is treated exactly like `malformed_generation`: ledger
+`failed`, then the fallback path below. Never send a message that fails a
+lint; never retry generation in a loop (one attempt, like the ack).
+
+## The turn engine (`system/conversation_delivery.py`)
+
+Orchestration only — prompts come from `conversation.py` builders, provider
+calls via `ai_provider.call_ai`, sends via `lifehug_core`
+`send_telegram_result`. Ledger and diagnostics carry METADATA ONLY (source
+ids, session ids, fixed reason codes, timestamps, attempt counts — never
+answer, prompt, or generated text), exactly like `answer_ack_delivery`.
+
+Entry point (called from `run_post_answer_delivery` in place of the
+ack-then-followup pair):
+
+```
+run_post_answer_turn(*, source_id, question_id, question_text,
+                     question_category, answer_text,
+                     planned_question,  # from plan_adaptive_followup, may be None
+                     state_path=..., ai_call=None, telegram_send=None,
+                     status_resolver=None) -> TurnOutcome
+```
+
+Flow:
+
+1. **Sweep**: lazily close idle-expired sessions (see Lifecycle) before
+   anything else.
+2. **Session**: find the open chat session whose pending question chain
+   contains `question_id` (root or suffix-chain member); if none, OPEN one
+   now — a chat session opens at first answer, not at delivery. Record the
+   user turn (`role: "user"`) in the session document. Arc card lookup by
+   `question_id`: in this PR arc cards do not exist yet — the engine MUST
+   run **arc-card-absent minimal behavior** (below) whenever
+   `session["arc"]` is missing/empty, which in this PR is always.
+3. **Single-flight**: mint the lifehug turn via the store's compare-and-set
+   before generation; a concurrent second entry for the same session mints
+   exactly one turn (the loser returns `skipped/turn_already_minted`).
+4. **Readiness**: `provider_status(conversation_model, probe=False)`; not
+   ready → ledger `skipped` (`no_unattended_provider` for agent-task, else
+   `provider_unavailable`) → FALLBACK path.
+5. **Decide turn shape** from the session (exchange count, register signals
+   in the turn instructions) per the behavior rules above:
+   - exchanges 1–2 → receipt+payout+cued follow-up (or question-free when
+     instructed);
+   - exchange 3 → exit-friendly phrasing;
+   - past the target with the user still going → keep receiving
+     (receipt+payout, question optional, never hard-stop).
+6. **Follow-up identity** (what the cued question IS, arc-card-absent):
+   - The cued follow-up is a SPONTANEOUS follow-up about this answer,
+     minted through `append_followups(question_id, [text])` /
+     `next_followup_id` (files as the A14 → A14b suffix chain — durable,
+     lineage-preserving, bank-visible). The model proposes the follow-up
+     text inside its structured turn output; the engine mints the id and
+     records it as the session's pending question.
+   - After a CONFIRMED send of a turn carrying a cued follow-up, update
+     rotation exactly as `ask.mark_question_sent(rotation, new_id)` does
+     (so `rotation.last_question_id` targets the follow-up and the host
+     agent files the next inbound against it) and call
+     `rebuild_coverage()` — cadence accounting (`sends_today`) still
+     counts this send; the 3/day cap keeps governing our initiative.
+   - `planned_question` (the bank/rotation pick) is NOT sent mid-session;
+     it stays for tomorrow. It exists in the signature because the
+     FALLBACK path needs it.
+   - Turn-shape gating: if `plan_adaptive_followup` returned None because
+     of the curfew/cap/pass-transition gates, the turn is question-free
+     (our initiative is spent) — the gates transfer, not disappear.
+7. **Generate**: `build_turn_prompt(...)` → `ai_call(prompt,
+   conversation_model)`. The turn output is structured (message text +
+   proposed follow-up text + question-free flag + extracted
+   facts/entities/candidate_ideas deltas); the exact JSON shape is pinned
+   by the Wave-1 builder contract — merged code wins.
+8. **Lint** (above). Failure → ledger `failed/malformed_generation` →
+   FALLBACK.
+9. **Send**: persist ledger `ambiguous/send_in_progress` BEFORE the
+   external effect, then `send_telegram_result(message)`; map results
+   exactly as the ack does (`confirmed`/`ambiguous`/`not_attempted`→
+   `skipped`/else `failed`). Record the lifehug turn in the session
+   document only on `confirmed`.
+10. **Ledger**: `state/conversation_deliveries.json`, same file shape as
+    the ack ledger (`{"version":1,"entries":{...}}`), entries keyed
+    `turn:{session_id}:{turn_index}` with fields `session_id`,
+    `turn_index`, `question_id`, `status`, `reason`, `attempts`,
+    `updated_at` (+`confirmed_at` / `operator_action` like the ack).
+    Exactly-once semantics copied verbatim: confirmed replays are no-ops;
+    ambiguous is NEVER auto-retried and requires operator confirmation to
+    retry.
+
+**FALLBACK (design §12 risk 1 — non-negotiable):** on ledger outcomes
+`skipped` (provider not ready) or `failed` (provider error, malformed/lint
+failure, definitive send rejection), the pipeline degrades to TODAY'S
+behavior in the same invocation: `acknowledge_answer(...)` with
+`followup_pending=planned_question is not None`, then
+`maybe_send_followup_question(question_id, planned_question)`. Never
+silence, never worse than today. **Exception:** an `ambiguous` turn send
+does NOT trigger the fallback ack (the turn may have reached Telegram; a
+fallback would risk a duplicate voice) — ledger it, surface it via status,
+stop. All failures remain swallowed relative to answer durability, exactly
+as `run_post_answer_delivery` swallows ack failures today.
+
+## Lifecycle, close, engagement capture
+
+- **Idle timeouts** (knobs from `interaction.yaml`; defaults chat ~2h,
+  conversation ~30min) count from the last turn. The arc card waiting with
+  a delivered question burns nothing — the session doesn't exist until the
+  first answer.
+- **Close triggers**: (a) turn-cap-reached + next answer never arrives →
+  idle timeout; (b) idle timeout generally; (c) exit taken (in this PR,
+  detectable only as silence after the exit-friendly third exchange —
+  router-based explicit exits arrive with PR 4). Closes run in the lazy
+  sweep (step 1 above) and via the CLI below. No daemon, no cron change in
+  this PR.
+- **Close behavior**: completed chats (the exchange target was reached and
+  the last lifehug turn wasn't left dangling mid-question) get the closing
+  takeaway message — generated via `build_closing_prompt` +
+  `conversation_model`, linted, sent and ledgered exactly like a turn
+  (entry key `close:{session_id}`). Zero-turn or abandoned-mid-chat
+  sessions close SILENTLY (no-nag rule). Either way the close block is
+  written: `reason`, `takeaway` (empty if silent), `takeaway_delivered`,
+  `insight_receipts_count` (count of receipt-citing insight contributions
+  delivered this session, taken from the structured turn outputs),
+  `filed` (question ids answered in-session).
+- **Partial chats are normal and file cleanly** (owner-confirmed): answers
+  are durable per-turn through `process-answer` as today; a timeout close
+  files whatever was answered; next day starts a fresh chat; nothing nags.
+- **Engagement capture at close** (decision-D cause instrumentation): for
+  each question id in `close.filed`, append to its existing
+  `state/answer_scores.json` record an `engagement` object:
+  `{"session_id", "session_turns", "continued_past_exit": bool,
+  "turn_length_trend": "expanding|flat|contracting", "close_reason"}`.
+  Never overwrite richness fields. Named consumers (doctrine): the arc
+  planner (Wave-2 PR 5, arc-topic/opener choice) and
+  `compute_profile()`'s engagement dimension (Wave-2 PR 6). Recorded now
+  so the nourishment dashboard can be built any time from recorded data.
+- **Extracted-field filing at close** (consumers named per doctrine):
+  `extracted.candidate_ideas` → candidate store via the
+  `question_candidates` append path with `"provenance": "conversation"`;
+  `extracted.entities` → filed as classification hints for the weekly
+  classify pass (write into the session close block AND the agent-tasks
+  hint surface the weekly pass already reads — follow the Wave-1 store
+  contract's filing helpers if it provides them). `extracted.facts` are
+  in-session only (rolling-summary re-assertion — the 39%-degradation
+  mitigation) and are NOT filed anywhere at close.
+  `extracted.mirror_responses` are RECORDED in the session document but
+  their consumer (`state/mirror_responses.json` + mirror inbound) is
+  Wave-2 PR 6 — do not build it here.
+- **Wiki/commit batching is NOT this PR**: in-session `process-answer`
+  keeps today's compile/commit behavior; the one-commit-per-close collapse
+  and the `conversation-close` job kind are Wave-2 PR 6.
+
+## CLI additions (`system/lifehug.py`)
+
+- `conversation-status [session_id]` — metadata-only session + delivery
+  ledger status (mirrors `answer-ack-status`). Classify in
+  `READ_ONLY_COMMANDS`.
+- `conversation-close --expired | <session_id>` — run the idle sweep, or
+  close one session now (operator door; also what a cron line could call).
+  Classify in `DIRECT_MUTATION_COMMANDS`.
+- `conversation-turn-retry <session_id> <turn_index> [--confirm-not-sent]`
+  — retry a definitively unsent turn; ambiguous requires the flag, exactly
+  like `answer-ack-retry`. Classify in `DIRECT_MUTATION_COMMANDS`.
+
+## Scope
+
+**In**: `system/conversation_delivery.py`; the `run_post_answer_delivery`
+rewire in `system/process_answer.py`; config keys + `config.yaml.example`
+docs; `state/conversation_deliveries.json` + vault-contract/vault-paths
+registration; the three CLI subcommands; engagement capture; close sweep;
+skill/SKILL.md + CLAUDE.md/AGENTS.md answer-processing steps updated to
+describe the turn (the ack step description changes — keep the "do not add
+a second acknowledgment" rule, now phrased for turns); tests + synthetic
+transcript evidence; `system/version.json` bump (changelog sized to user
+impact — this is a headline change); `framework_files` gains
+`system/conversation_delivery.py`.
+
+**Out (explicit non-goals)**:
+- No platform (lifehug-platform) changes — parity twin is tracked on the
+  platform side by the design's Wave 3.
+- No arc cards, no arc planner, no `timeline.compute_gaps` consumer
+  (Wave-2 PR 5). The engine ships arc-card-absent minimal behavior and
+  must keep working unchanged when PR 5 starts attaching cards.
+- No router, no story-path change, no deflection (Wave-2 PR 4 —
+  issue #117).
+- No `jobs.py` changes, no batching-default change, no mirror inbound, no
+  `compute_profile` engagement dimension (Wave-2 PR 6).
+- No viewer (`serve_wiki.py`) changes — Today-card copy changes ride a
+  later PR.
+- `answer_ack.py` / `answer_ack_delivery.py` are NOT deleted or reworded —
+  they are the live fallback and keyless path. The "No questions back"
+  line stays: it is correct for the fallback ack.
+- Keyless mode: the host agent remains the seated model per the Wave-1
+  skill contract; this PR's engine simply reports `skipped/
+  no_unattended_provider` and falls back, exactly like the ack today.
+
+## Implementation notes (seams, not steps)
+
+- `process_answer.py:409` `run_post_answer_delivery` — replace the
+  ack+followup pair with `run_post_answer_turn`, keeping the
+  plan-first structure (`plan_adaptive_followup` result passed in) and the
+  per-step exception swallowing + `record_learning_failure` metadata.
+- Copy the ledger/state-machine skeleton from `answer_ack_delivery.py`
+  (`_state`, `_write_outcome`, `_fixed_provider_reason`,
+  `_valid_completion`, the pre-send ambiguous write) rather than importing
+  its privates; the recurring-defect doctrine extraction of a shared
+  delivery-ledger module is deliberately deferred until a third copy
+  appears (twice is the trigger, and PR 4's story turn will reuse THIS
+  module, not copy it — build `conversation_delivery` so the story path
+  can call it).
+- Session store access only through the Wave-1 `conversation.py` CRUD —
+  never raw `read_json`/`write_json` against `state/conversations/`.
+- `datetime.now()` / clock access must be injectable or monkeypatchable
+  for the timeout tests (module-level `_now()` hook like `jobs.py`).
+- Telegram formatting: plain text like the ack; no header/footer branding
+  on turn messages (the "📖 Lifehug — since you're on a roll" framing
+  remains ONLY on the fallback path's separate follow-up message).
+
+## Test plan
+
+New `tests/test_conversation_delivery.py` (unittest, stdlib-only, injected
+fakes for `ai_call` / `telegram_send` / `status_resolver` / clock /
+`state_path`, synthetic vault via `tests/tempdirs.py` conventions —
+NEVER `~/Workspace/dave`), following `tests/test_v121_answer_ack_delivery.py`.
+Subtests (state-machine-shaped change → named explicitly, v130/v131
+precedent):
+
+- `test_confirmed_turn_is_one_message` — receipt+cued follow-up in one
+  send; follow-up minted via the suffix chain; rotation updated; ledger
+  `confirmed`.
+- `test_confirmed_replay_is_noop` — no second model call, no second send.
+- `test_ambiguous_never_auto_retried_and_no_fallback_ack` — pre-send
+  ambiguous position honored; fallback ack NOT fired.
+- `test_provider_unavailable_falls_back_to_todays_behavior` — ack sent with
+  `followup_pending` honest, separate follow-up message sent, ledger
+  `skipped`.
+- `test_lint_reject_falls_back` — two-question / overlong / banned-phrase
+  outputs each → `failed/malformed_generation` → fallback.
+- `test_question_free_turn` — no follow-up minted, no rotation change.
+- `test_third_exchange_exit_shape_and_cap` — cap governs initiative;
+  user-keeps-going path still receives.
+- `test_idle_timeout_files_partial_chat_silently` — no closing send for
+  abandoned-mid-chat; close block written; answers remain filed.
+- `test_completed_chat_closing_takeaway` — closing linted/ledgered
+  (`close:{session_id}`), `takeaway_delivered` true.
+- `test_engagement_appended_to_answer_scores` — engagement object on each
+  filed question's record; richness untouched.
+- `test_curfew_and_cap_gates_transfer` — planned-question None for gate
+  reasons → question-free turn.
+- `test_single_flight_mint` — concurrent second entry mints no second turn.
+- `test_metadata_only_ledger_and_diagnostics` — no answer/prompt/generated
+  text in ledger or learning-failure records.
+
+Plus: extend `tests/test_answer_ack.py`-adjacent coverage only if the
+`process_answer` rewire changes an existing assertion (the ack module
+itself is unchanged).
+
+Exact invocations (scoped locally; CI runs the full discover):
+
+```
+python3 -m unittest tests.test_conversation_delivery -v
+python3 -m unittest tests.test_v121_answer_ack_delivery tests.test_ingest_and_planner -v
+```
+
+## Launch-and-verify
+
+This PR does not touch `serve_wiki.py`, so no Playwright walkthrough is
+required. Evidence follows the `artifacts/walkthroughs/local-warm-answer-ack/
+synthetic-transcript.md` precedent (issue #52 / PR #67):
+
+1. Commit `artifacts/walkthroughs/conversation-turn-engine/
+   synthetic-transcript.md` — a deterministic, synthetic-data transcript
+   (no real vault, bot, or key claimed) with one table per path:
+   confirmed chat (answer → ONE receipt+payout+cued-follow-up message →
+   second exchange → exit-friendly third → closing takeaway), fallback
+   path (provider down → today's ack + separate follow-up, byte-shape
+   identical to the current behavior), ambiguous path (no auto-retry, no
+   fallback ack), and timeout path (partial chat files silently). Each
+   table row names the subtest above that proves it.
+2. The reviewer reproduces from scratch with:
+   `python3 -m unittest tests.test_conversation_delivery -v` (all subtests
+   green) — the transcript is the human-readable projection of those
+   assertions, not extra claims.
+3. PR comment embeds the transcript (SHA-pinned blob URL) per the evidence
+   convention.
+
+## Definition of done
+
+- [ ] Code + tests pass locally (`python3 -m unittest discover -s tests`)
+- [ ] `system/version.json` bumped (version, released, changelog,
+      `framework_files` += `system/conversation_delivery.py`)
+- [ ] `system/vault_contract.json` + `system/vault_paths.py` register
+      `conversation_deliveries`
+- [ ] AGENTS.md / CLAUDE.md / skill/SKILL.md answer-processing steps
+      updated (turn replaces ack+follow-up; fallback documented; "do not
+      add a second acknowledgment" preserved for turns)
+- [ ] ADR: this PR implements decisions already ratified by the owner
+      (2026-08-11 design session); add
+      `docs/adr/` entry "Conversation turn engine replaces post-answer
+      ack+follow-up" (Context/Decision/Consequences) pinning the fallback
+      guarantee and the exactly-once ledger as binding — future work must
+      honor both
+- [ ] Issue #116 commented with verification results
+- [ ] Synthetic-transcript evidence committed and embedded in a PR comment
+      (SHA-pinned blob URL)

--- a/docs/pr-specs/116-conversation-turn-engine.md
+++ b/docs/pr-specs/116-conversation-turn-engine.md
@@ -160,8 +160,9 @@ Documented in `config.yaml.example`, read via `load_config()`:
   (haiku-class). Defined here so the key set ships once; its consumer is
   Wave-2 PR 4 (`lifehug.py route`).
 - `arc_plan_model` — weekly arc planning; resolution order
-  `arc_plan_model` → `classify_model` → provider default. Defined here;
-  consumer is Wave-2 PR 5.
+  `arc_plan_model` → `classify_model` → `classify_story.DEFAULT_MODEL`
+  (`"claude-sonnet-5"`) as the terminal fallback (matching #118). Defined
+  here; consumer is Wave-2 PR 5.
 
 ## The behavior this engine enforces (pasted; the implementer does not
 re-derive this from the design docs)
@@ -202,8 +203,10 @@ every generated message BEFORE send; definitions sourced from
 `interactions/conversation/evals/lints.yaml`, not forked into code):
 
 - ≤ 1 question mark's worth of questions per message (one-question lint).
-- Length ≤ the interaction.yaml message cap (default 1200 chars, matching
-  `ACK_MAX_CHARS`).
+- Length ≤ the turn-length cap sourced from the shared lint config
+  `evals/lints.yaml` key `cap.turn_chars` (value 1200, matching
+  `ACK_MAX_CHARS`) — read from that one file; this module does NOT pin an
+  independent 1200 constant.
 - Banned-phrase list (from lints.yaml; includes at minimum: "that must have
   been", guilt/streak phrasing, "as an AI" / AI self-reference,
   "you haven't told me much").
@@ -321,13 +324,18 @@ as `run_post_answer_delivery` swallows ack failures today.
   router-based explicit exits arrive with PR 4). Closes run in the lazy
   sweep (step 1 above) and via the CLI below. No daemon, no cron change in
   this PR.
-- **Close behavior**: completed chats (the exchange target was reached and
-  the last lifehug turn wasn't left dangling mid-question) get the closing
-  takeaway message — generated via `build_closing_prompt` +
+- **Close behavior**: the closing-takeaway criterion is the deterministic
+  cross-runtime rule (platform #414 confirms the same rule): a template/
+  model close message is sent only when the session has **≥2 user turns**;
+  zero-turn or single-answer chats close SILENTLY (no nag), regardless of
+  whether an exchange target was nominally reached. Sessions meeting the
+  ≥2-user-turns bar get the closing takeaway message — generated via
+  `build_closing_prompt` +
   `conversation_model`, linted, sent and ledgered exactly like a turn
-  (entry key `close:{session_id}`). Zero-turn or abandoned-mid-chat
-  sessions close SILENTLY (no-nag rule). Either way the close block is
-  written: `reason`, `takeaway` (empty if silent), `takeaway_delivered`,
+  (entry key `close:{session_id}`). Sessions below the ≥2-user-turns bar
+  (zero-turn or abandoned-mid-chat) close SILENTLY (no-nag rule). Either
+  way the close block is written: `reason`, `takeaway` (empty if silent),
+  `takeaway_delivered`,
   `insight_receipts_count` (count of receipt-citing insight contributions
   delivered this session, taken from the structured turn outputs),
   `filed` (question ids answered in-session).
@@ -336,13 +344,20 @@ as `run_post_answer_delivery` swallows ack failures today.
   files whatever was answered; next day starts a fresh chat; nothing nags.
 - **Engagement capture at close** (decision-D cause instrumentation): for
   each question id in `close.filed`, append to its existing
-  `state/answer_scores.json` record an `engagement` object:
-  `{"session_id", "session_turns", "continued_past_exit": bool,
-  "turn_length_trend": "expanding|flat|contracting", "close_reason"}`.
-  Never overwrite richness fields. Named consumers (doctrine): the arc
-  planner (Wave-2 PR 5, arc-topic/opener choice) and
-  `compute_profile()`'s engagement dimension (Wave-2 PR 6). Recorded now
-  so the nourishment dashboard can be built any time from recorded data.
+  `state/answer_scores.json` record an `engagement` object using #119's
+  AUTHORITATIVE field names for the shared fields:
+  `{"session_id", "session_turns", "continuation_past_exit": bool,
+  "turn_length_trajectory": "expanding|flat|contracting", "close_reason"}`
+  (NOT `continued_past_exit`/`turn_length_trend` — #119 defines the
+  canonical names for the fields shared across producers; `session_id`,
+  `session_turns`, and `close_reason` are extra fields this PR contributes
+  freely). Leave room for #119's `time_to_answer_hours` and
+  `unprompted_inbound` fields, which are computed elsewhere and are not
+  this PR's responsibility to populate. Never overwrite richness fields.
+  Named consumers (doctrine): the arc planner (Wave-2 PR 5, arc-topic/
+  opener choice) and `compute_profile()`'s engagement dimension (Wave-2
+  PR 6). Recorded now so the nourishment dashboard can be built any time
+  from recorded data.
 - **Extracted-field filing at close** (consumers named per doctrine):
   `extracted.candidate_ideas` → candidate store via the
   `question_candidates` append path with `"provenance": "conversation"`;
@@ -366,7 +381,11 @@ as `run_post_answer_delivery` swallows ack failures today.
   `READ_ONLY_COMMANDS`.
 - `conversation-close --expired | <session_id>` — run the idle sweep, or
   close one session now (operator door; also what a cron line could call).
-  Classify in `DIRECT_MUTATION_COMMANDS`.
+  Classify in `DIRECT_MUTATION_COMMANDS`. This PR's `conversation-close`
+  work UPGRADES #115's minimal subcommand IN PLACE (same name — this is
+  not a new/rival subcommand) and this PR OWNS the `--expired` sweep flag
+  on it. #119's jobs builder calls this exact subcommand/flag to enqueue
+  the sweep — do not introduce a separate `conversation-sweep` command.
 - `conversation-turn-retry <session_id> <turn_index> [--confirm-not-sent]`
   — retry a definitively unsent turn; ambiguous requires the flag, exactly
   like `answer-ack-retry`. Classify in `DIRECT_MUTATION_COMMANDS`.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -106,10 +106,11 @@ printf '%s\n' "$ANSWER_TEXT" | python3 system/lifehug.py process-answer <ID> \
   --followup "What did the room look like in that moment?"
 ```
 
-5. After the answer is durable, `process-answer` sends the canonical warm Telegram acknowledgment through the shared AI provider, then any adaptive follow-up. Do not add a second acknowledgment. A provider or send failure never changes answer success and never suppresses the follow-up.
-6. Confirmed acknowledgments dedupe by `answer:{ID}`. Check `answer-ack-status`; retry a definitive failure with `answer-ack-retry`. Never retry an ambiguous send until Telegram has been checked, then pass `--confirm-not-sent`.
-7. `process-answer` compiles the wiki automatically by default. Use `--no-compile-wiki` only for tests or emergency repairs.
-8. Commit only when the user asks, or when operating an explicit daily/cron workflow.
+5. After the answer is durable, `process-answer` sends ONE conversation turn (v153): a single Telegram message that receives the answer, pays it back, and cues the next question in the user's own words. Do not add a second acknowledgment or a second question — one message per answer, whatever the path produced it. Any definitive failure (no provider, generation error, lint rejection, send rejection) degrades in the same run to the previous behavior: the warm acknowledgment followed by a separate adaptive follow-up. Nothing here ever changes answer success.
+6. Turn delivery dedupes by `turn:{session_id}:{turn_index}`. Check `conversation-status`; retry a definitive failure with `conversation-turn-retry <session_id> <turn_index>`. Never retry an ambiguous send until Telegram has been checked, then pass `--confirm-not-sent`. The fallback acknowledgment keeps its own `answer:{ID}` ledger — `answer-ack-status` / `answer-ack-retry` are unchanged.
+7. Chats close themselves: `conversation-close --expired` runs the idle sweep. A chat with at least two of the user's turns gets a closing takeaway; a partial one closes SILENTLY — never nag someone for stopping.
+8. `process-answer` compiles the wiki automatically by default. Use `--no-compile-wiki` only for tests or emergency repairs.
+9. Commit only when the user asks, or when operating an explicit daily/cron workflow.
 
 Never manually edit `coverage.json` or `rotation.json` unless repairing a failed script run with a clear reason.
 

--- a/system/conversation.py
+++ b/system/conversation.py
@@ -346,6 +346,65 @@ def close_session(
     return doc
 
 
+#: The four extraction buckets a turn may contribute to (schema-pinned).
+EXTRACTED_BUCKETS = ("facts", "entities", "candidate_ideas", "mirror_responses")
+
+
+def merge_session_extraction(
+    session_id: str,
+    *,
+    rolling_summary: str | None = None,
+    extracted: dict | None = None,
+    vault_root: str | Path | None = None,
+) -> dict:
+    """Merge one turn's extraction deltas into an OPEN session document.
+
+    Wave 1 shipped turn-append and close only; issue #116's engine needs the
+    ``extracted``/``rolling_summary`` half of the schema to actually persist,
+    because the close step files ``extracted.candidate_ideas`` into the
+    candidate store and records ``extracted.entities`` on the close block.
+    Keeping that write here (rather than in the engine) preserves the
+    contract rule that ``state/conversations/`` is only ever touched through
+    this module's CRUD.
+
+    Deltas are appended, de-duplicated conservatively (exact repeats of a
+    JSON-serializable item are dropped), and unknown buckets are ignored.
+    """
+    root = _resolve_root(vault_root)
+    doc = load_session(session_id, vault_root=root)
+    if doc.get("status") == "closed":
+        raise SessionClosedError(f"session {session_id} is closed")
+    if rolling_summary is not None:
+        if not isinstance(rolling_summary, str):
+            raise ValueError("rolling_summary must be a string")
+        doc["rolling_summary"] = rolling_summary
+    if extracted:
+        if not isinstance(extracted, dict):
+            raise ValueError("extracted must be an object")
+        current = doc.get("extracted")
+        if not isinstance(current, dict):
+            current = {}
+        for bucket in EXTRACTED_BUCKETS:
+            existing = current.get(bucket)
+            if not isinstance(existing, list):
+                existing = []
+            additions = extracted.get(bucket)
+            if not isinstance(additions, list):
+                current[bucket] = existing
+                continue
+            seen = {json.dumps(item, sort_keys=True) for item in existing}
+            for item in additions:
+                key = json.dumps(item, sort_keys=True)
+                if key in seen:
+                    continue
+                seen.add(key)
+                existing.append(item)
+            current[bucket] = existing
+        doc["extracted"] = current
+    _write_json_at(_conversations_dir(root) / f"{session_id}.json", doc, vault_root=root)
+    return doc
+
+
 # --------------------------------------------------------------------------
 # Arc-card helpers (storage only)
 #

--- a/system/conversation_delivery.py
+++ b/system/conversation_delivery.py
@@ -1,0 +1,1580 @@
+#!/usr/bin/env python3
+"""Lifehug — the conversation turn engine (issue #116, Wave 2 PR 3).
+
+The post-answer moment used to be two disconnected messages: a warm
+acknowledgment that is contractually forbidden from asking anything
+(``answer_ack.py``) followed by a rotation-picked follow-up question that is
+usually unrelated to what the user just said. This module makes that moment
+ONE conversation turn: a single message that receives the answer, pays it
+out, and cues the next question — and it degrades to exactly today's
+behavior on any definitive failure.
+
+This module is ORCHESTRATION only:
+
+* prompts come from ``conversation.build_turn_prompt`` /
+  ``conversation.build_closing_prompt`` (issue #115) — never assembled here;
+* the behavior authority is ``interactions/conversation/`` — never restated
+  in code;
+* the deterministic lints come from ``conversation_lints`` (issue #115),
+  whose config authority is ``interactions/conversation/evals/lints.yaml`` —
+  never forked into constants here (recurring-defect doctrine);
+* provider calls go through ``ai_provider.call_ai``; sends through
+  ``lifehug_core.send_telegram_result``;
+* session documents are touched ONLY through ``conversation``'s CRUD.
+
+State (``state/conversation_deliveries.json``) and diagnostics carry
+METADATA ONLY — session ids, turn indices, question ids, fixed reason codes,
+lint ids, timestamps, attempt counts. Never an answer, a prompt, or
+generated text. Same file shape and same exactly-once state machine as
+``answer_ack_delivery`` (``{"version": 1, "entries": {...}}``): a confirmed
+entry replays as a no-op, and an ambiguous entry is NEVER auto-retried.
+
+Fallback guarantee (design §12 risk 1, binding): when the turn is skipped
+for provider readiness or fails (provider error, unparseable/lint-rejected
+generation, definitive send rejection), the same invocation degrades to
+today's behavior — ``acknowledge_answer(...)`` then
+``maybe_send_followup_question(...)``. Never silence, never worse than
+today. The ONE exception is an ambiguous turn send: the turn may have
+reached Telegram, so a fallback ack would risk a duplicate voice — it is
+ledgered and surfaced, and nothing else is sent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable
+
+import conversation
+import conversation_lints
+from ai_provider import (
+    AIConfigurationError,
+    AIProviderError,
+    AIResponseError,
+    AIUnavailableError,
+    call_ai,
+    provider_status,
+)
+from lifehug_core import (
+    ANSWER_SCORES_FILE,
+    CONVERSATION_DELIVERIES_FILE,
+    TelegramSendResult,
+    load_config,
+    now_utc,
+    read_json,
+    record_learning_failure,
+    send_telegram_result,
+    write_json,
+)
+
+DELIVERY_STATE_FILE = CONVERSATION_DELIVERIES_FILE
+
+#: Vault root for this module's session writes. ``None`` means "the
+#: process-bound vault" (``conversation``'s own default). It is a module
+#: attribute rather than a call-time-only argument so that a caller which
+#: cannot thread arguments through — ``process_answer.run_post_answer_delivery``
+#: and its tests — can still point the engine at a synthetic vault.
+VAULT_ROOT: str | Path | None = None
+
+#: Seated turn/closing model. Sonnet-class, same default-constant style as
+#: answer_ack_delivery.DEFAULT_ACK_MODEL.
+DEFAULT_CONVERSATION_MODEL = "claude-sonnet-5"
+#: Cheap intent router (haiku-class). Key shipped here so the config surface
+#: lands once; its consumer is Wave-2 PR 4 (`lifehug.py route`).
+DEFAULT_ROUTER_MODEL = "claude-haiku-4-5"
+
+STATUS_CONFIRMED = "confirmed"
+STATUS_SKIPPED = "skipped"
+STATUS_FAILED = "failed"
+STATUS_AMBIGUOUS = "ambiguous"
+
+#: Skip reasons that still degrade to today's behavior. Every other skip
+#: reason means another writer is already handling this moment (single
+#: flight) — sending an ack there would duplicate the voice.
+FALLBACK_SKIP_REASONS = frozenset({"no_unattended_provider", "provider_unavailable"})
+
+#: The lint ids that BLOCK a send at runtime (contract, "Runtime lints"):
+#: one-question, banned phrases, length cap. Every other lint the shared
+#: engine reports (question grammar, year questions, receipt-before-question)
+#: is advisory — counted in the ledger, never a send-blocker, because a
+#: false positive there would silently downgrade a good turn to the ack.
+RUNTIME_BLOCKING_LINTS = ("one_question_per_turn", "banned_phrases", "length_caps")
+
+#: Prompt-echo markers — the same class of structural check as
+#: answer_ack_delivery._valid_completion, adapted to this prompt's blocks.
+_ECHO_MARKERS = (
+    "## turn_instructions",
+    "## identity",
+    "## behavior",
+    "hard length cap for this message",
+    "lifehug — closing takeaway",
+)
+
+_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.IGNORECASE)
+_SESSION_TS_RE = re.compile(r"^conv-(\d{8})-(\d{6})-[0-9a-f]{6}$")
+#: A14 -> A14, A14b -> A14 (the suffix chain's root).
+_CHAIN_ROOT_RE = re.compile(r"^([A-Z]\d+)[a-z]*$")
+
+
+class TurnEngineError(Exception):
+    """Base error for turn-engine operations (never raised into capture)."""
+
+
+@dataclass(frozen=True)
+class TurnOutcome:
+    """Metadata-only result of one turn attempt."""
+
+    session_id: str
+    turn_index: int
+    status: str
+    reason: str
+    attempted: bool
+    fallback_used: bool = False
+    followup_id: str | None = None
+    question_free: bool = True
+    lint_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TurnShape:
+    """The engine's deterministic turn-shape decision for this exchange."""
+
+    position: str
+    question_allowed: bool
+    user_turns: int
+    target_exchanges: int
+
+
+# --------------------------------------------------------------------------
+# Clock (module-level hook so timeout tests never sleep — jobs.py precedent)
+# --------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        moment = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)
+
+
+def _session_opened_at(session_id: str) -> datetime | None:
+    """Zero-turn sessions have no turn timestamps — the id carries the UTC clock."""
+    match = _SESSION_TS_RE.match(session_id or "")
+    if not match:
+        return None
+    try:
+        return datetime.strptime(
+            f"{match.group(1)}{match.group(2)}", "%Y%m%d%H%M%S"
+        ).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------
+# Ledger — same shape and state machine as state/answer_acknowledgments.json
+# --------------------------------------------------------------------------
+
+
+def _state(path: Path) -> dict:
+    data = read_json(path, default={}) or {}
+    if not isinstance(data, dict) or not isinstance(data.get("entries", {}), dict):
+        return {"version": 1, "entries": {}}
+    data.setdefault("version", 1)
+    data.setdefault("entries", {})
+    return data
+
+
+def turn_key(session_id: str, turn_index: int) -> str:
+    return f"turn:{session_id}:{turn_index}"
+
+
+def close_key(session_id: str) -> str:
+    return f"close:{session_id}"
+
+
+def _write_outcome(
+    path: Path,
+    key: str,
+    *,
+    session_id: str,
+    turn_index: int,
+    question_id: str,
+    status: str,
+    reason: str,
+    attempts: int,
+    lint_ids: tuple[str, ...] | list[str] = (),
+    advisory_lints: int = 0,
+) -> None:
+    data = _state(path)
+    entry = {
+        "session_id": session_id,
+        "turn_index": turn_index,
+        "question_id": question_id,
+        "status": status,
+        "reason": reason,
+        "attempts": attempts,
+        "updated_at": now_utc(),
+    }
+    if lint_ids:
+        entry["lint_ids"] = sorted(set(lint_ids))
+    if advisory_lints:
+        entry["advisory_lints"] = advisory_lints
+    if status == STATUS_CONFIRMED:
+        entry["confirmed_at"] = entry["updated_at"]
+    if status == STATUS_AMBIGUOUS:
+        entry["operator_action"] = "verify Telegram before retrying"
+    data["entries"][key] = entry
+    write_json(path, data)
+
+
+def _fixed_provider_reason(exc: BaseException) -> str:
+    if isinstance(exc, AIConfigurationError):
+        return "provider_configuration_error"
+    if isinstance(exc, AIResponseError):
+        return "provider_malformed_response"
+    if isinstance(exc, AIUnavailableError):
+        return "provider_unavailable"
+    return "generation_failed"
+
+
+def _diagnostic(operation: str, reason: str, session_id: str) -> None:
+    """Fixed metadata only — never exception text, never model text."""
+    record_learning_failure(
+        "conversation_delivery",
+        operation,
+        reason,
+        context={"session_id": session_id},
+    )
+
+
+# --------------------------------------------------------------------------
+# Generation contract: parsing + linting
+# --------------------------------------------------------------------------
+
+
+def _output_contract_block(shape: TurnShape) -> str:
+    """The engine's structured-output appendix to the Wave-1 turn prompt.
+
+    The merged Wave-1 builder assembles behavior + context + filled turn
+    instructions; it does not (and should not) pin a machine-readable output
+    shape, because the same definition files also drive the keyless
+    host-agent path where a human-readable message is the whole product.
+    The ENGINE needs structure (the proposed follow-up text, the
+    question-free flag, and the extraction deltas), so it appends this
+    orchestration-owned block last — after the turn instructions, which the
+    manifest requires to be the final behavior block.
+    """
+    if shape.question_allowed:
+        question_rule = (
+            "Ask AT MOST ONE question, and it must be a cued invitation that "
+            "quotes the user's own phrase. Put that same question's text in "
+            "\"followup_question\"."
+        )
+    elif shape.position == "third_exchange_exit_friendly":
+        question_rule = (
+            "Ask NO question. This is the exit-friendly turn: make stopping "
+            "here feel like a good place to rest. Set \"followup_question\" "
+            "to null and \"question_free\" to true."
+        )
+    else:
+        question_rule = (
+            "Ask NO question — keep receiving. Set \"followup_question\" to "
+            "null and \"question_free\" to true."
+        )
+    return (
+        "\n\n## OUTPUT FORMAT (runtime contract — reply with JSON only)\n\n"
+        "Reply with a single JSON object and nothing else:\n\n"
+        "{\n"
+        '  "message": "the one Telegram message, plain text",\n'
+        '  "followup_question": "the question you asked, verbatim, or null",\n'
+        '  "question_free": true | false,\n'
+        '  "rolling_summary": "a short running summary of this session",\n'
+        '  "insight_receipts": 0,\n'
+        '  "extracted": {"facts": [], "entities": [], "candidate_ideas": [], '
+        '"mirror_responses": []}\n'
+        "}\n\n"
+        f"- {question_rule}\n"
+        '- "insight_receipts" counts the contributions in this message that '
+        "cite a provenance id from the record block.\n"
+        "- Everything in \"message\" is sent to the user verbatim; nothing else is.\n"
+    )
+
+
+def _strip_fences(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = _FENCE_RE.sub("", stripped).strip()
+    return stripped
+
+
+def _valid_message(raw: object) -> str | None:
+    """Structural sanity, same class as answer_ack_delivery._valid_completion."""
+    if not isinstance(raw, str):
+        return None
+    message = raw.strip()
+    if not message or "\x00" in message:
+        return None
+    if message.startswith(("```", "{", "[")):
+        return None
+    lowered = message.lower()
+    if any(marker in lowered for marker in _ECHO_MARKERS):
+        return None
+    return message
+
+
+def parse_turn_output(raw: object) -> dict | None:
+    """Parse the structured turn output; None when it is unusable.
+
+    Tolerates a ```json fence around the object (a common provider habit)
+    but nothing looser — a turn we cannot read is a malformed generation,
+    and malformed generations fall back rather than guess.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        data = json.loads(_strip_fences(raw))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    message = _valid_message(data.get("message"))
+    if message is None:
+        return None
+    followup = data.get("followup_question")
+    followup_text = followup.strip() if isinstance(followup, str) else ""
+    extracted = data.get("extracted")
+    summary = data.get("rolling_summary")
+    receipts = data.get("insight_receipts")
+    return {
+        "message": message,
+        "followup_question": followup_text or None,
+        "question_free": bool(data.get("question_free", not followup_text)),
+        "rolling_summary": summary.strip() if isinstance(summary, str) else None,
+        "insight_receipts": int(receipts) if isinstance(receipts, int) else 0,
+        "extracted": extracted if isinstance(extracted, dict) else {},
+    }
+
+
+def _question_sentences(text: str) -> list[str]:
+    """Question sentences per the shared lint engine's own heuristics.
+
+    Imported from conversation_lints rather than re-implemented: the
+    echoed-question stripping rule (a quoted span containing '?' is the
+    USER's question, not ours) is exactly the subtlety a forked copy would
+    get wrong.
+    """
+    stripped = conversation_lints._strip_echoed_questions(text)
+    return [s for s in conversation_lints._split_sentences(stripped) if conversation_lints._is_question(s)]
+
+
+def lint_outgoing(
+    message: str,
+    *,
+    question_allowed: bool,
+    is_reply_to_substantive: bool = True,
+    config: dict | None = None,
+) -> tuple[list[str], int]:
+    """Return (blocking lint ids, advisory finding count) for one message.
+
+    The checks themselves live in ``conversation_lints`` (single authority,
+    config from ``evals/lints.yaml`` — including the ``cap.turn_chars``
+    length cap, which this module deliberately does NOT pin independently).
+    """
+    findings = conversation_lints.lint_turn(
+        message, is_reply_to_substantive=is_reply_to_substantive, config=config
+    )
+    blocking = [f["lint"] for f in findings if f.get("lint") in RUNTIME_BLOCKING_LINTS]
+    advisory = len(findings) - len(blocking)
+    if not question_allowed and _question_sentences(message):
+        # The engine's own deterministic enforcement: a question-free turn
+        # that asks anyway would spend initiative the gates already spent.
+        blocking.append("question_not_permitted")
+    return blocking, advisory
+
+
+# --------------------------------------------------------------------------
+# Turn shape
+# --------------------------------------------------------------------------
+
+
+def _manifest() -> dict:
+    try:
+        return conversation.load_interaction_manifest()
+    except (OSError, ValueError):
+        return {}
+
+
+def _knob(manifest: dict, key: str, default: int) -> int:
+    value = manifest.get(key)
+    return value if isinstance(value, int) else default
+
+
+def _count_user_turns(session: dict) -> int:
+    return sum(1 for turn in (session.get("turns") or []) if turn.get("role") == "user")
+
+
+def decide_turn_shape(
+    session: dict,
+    *,
+    manifest: dict,
+    planned_question: object | None,
+) -> TurnShape:
+    """Deterministic turn shape from session state + the cadence gates.
+
+    Exchange 1..target-1 carry our initiative (a cued follow-up). The
+    target-th exchange is the exit-friendly door: it receives and pays out
+    but asks nothing, so stopping there reads as "a good place to rest"
+    rather than a dropped question. Past the target we keep receiving for as
+    long as the user keeps going — the target governs OUR initiative only,
+    never the user's.
+
+    When ``plan_adaptive_followup`` returned None (curfew, 3/day cap, pass
+    transition, cadence off), the gates transfer to the turn: the turn is
+    question-free. The gates move, they do not disappear.
+    """
+    user_turns = _count_user_turns(session)
+    target = _knob(manifest, "knob.chat_target_exchanges", 3)
+    if user_turns <= 1:
+        position = "opening"
+    elif user_turns < target:
+        position = "mid_arc"
+    elif user_turns == target:
+        position = "third_exchange_exit_friendly"
+    else:
+        position = "past_target"
+    question_allowed = planned_question is not None and user_turns < target
+    return TurnShape(position, question_allowed, user_turns, target)
+
+
+# --------------------------------------------------------------------------
+# Session selection
+# --------------------------------------------------------------------------
+
+
+def _chain_root(question_id: str) -> str:
+    match = _CHAIN_ROOT_RE.match(question_id or "")
+    return match.group(1) if match else (question_id or "")
+
+
+def _session_question_ids(session: dict) -> set[str]:
+    ids = set()
+    arc = session.get("arc") or {}
+    if isinstance(arc, dict) and arc.get("question_id"):
+        ids.add(str(arc["question_id"]))
+    for turn in session.get("turns") or []:
+        if turn.get("question_id"):
+            ids.add(str(turn["question_id"]))
+    pending = session.get("pending_question_id")
+    if pending:
+        ids.add(str(pending))
+    return ids
+
+
+def find_open_session_for_question(
+    question_id: str,
+    *,
+    vault_root: str | Path | None = None,
+) -> dict | None:
+    """The open chat session whose question chain contains ``question_id``."""
+    root = _chain_root(question_id)
+    newest = None
+    for summary in conversation.list_sessions(status="open", vault_root=vault_root):
+        session_id = summary.get("session_id")
+        if not session_id:
+            continue
+        try:
+            doc = conversation.load_session(session_id, vault_root=vault_root)
+        except (OSError, ValueError):
+            continue
+        if any(_chain_root(qid) == root for qid in _session_question_ids(doc)):
+            newest = doc if newest is None else newest
+    return newest
+
+
+def _append_turn_resilient(
+    session_id: str,
+    turn: dict,
+    *,
+    expected_turns: int,
+    vault_root: str | Path | None = None,
+    attempts: int = 3,
+) -> dict:
+    """CAS-append, re-reading the count on conflict.
+
+    Used ONLY after a confirmed send: at that point the message exists in
+    the user's Telegram, so losing the record to a concurrent writer would
+    be worse than replaying the compare-and-set against the fresh count.
+    The pre-generation user-turn append deliberately does NOT use this — a
+    conflict there is the single-flight signal.
+    """
+    count = expected_turns
+    last: Exception | None = None
+    for _ in range(max(1, attempts)):
+        try:
+            return conversation.append_turn(
+                session_id, turn, expected_turns=count, vault_root=vault_root
+            )
+        except conversation.TurnConflictError as exc:
+            last = exc
+            fresh = conversation.load_session(session_id, vault_root=vault_root)
+            count = len(fresh.get("turns") or [])
+    raise last if last else TurnEngineError("append failed")
+
+
+def _locate_user_turn(session: dict, question_id: str, answer_text: str) -> int | None:
+    """Index of an already-recorded user turn for this exact answer, if any.
+
+    Replay detection: ``run_post_answer_turn`` is called from the durable
+    side of ``process-answer``, so a re-run of the same answer must not
+    append a second user turn (and must not send a second message). The
+    ledger still owns exactly-once for the SEND; this owns exactly-once for
+    the session document.
+    """
+    text = (answer_text or "").strip()
+    for index, turn in enumerate(session.get("turns") or []):
+        if turn.get("role") != "user":
+            continue
+        if str(turn.get("question_id") or "") != question_id:
+            continue
+        if (turn.get("text") or "").strip() == text:
+            return index
+    return None
+
+
+def _resolve_model(config: dict, key: str, default: str) -> str:
+    return str(config.get(key) or default)
+
+
+def _safe_config() -> dict:
+    try:
+        cfg = load_config()
+    except Exception:  # noqa: BLE001 — a malformed local config never risks capture
+        return {}
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def arc_plan_model(config: dict | None = None) -> str:
+    """arc_plan_model -> classify_model -> classify_story.DEFAULT_MODEL.
+
+    Shipped here so the key set lands once (contract, "New config keys");
+    the consumer is Wave-2 PR 5. The terminal fallback is imported from the
+    classification authority rather than re-pinned as a literal.
+    """
+    cfg = config if isinstance(config, dict) else _safe_config()
+    from classify_story import DEFAULT_MODEL  # noqa: PLC0415
+
+    return str(cfg.get("arc_plan_model") or cfg.get("classify_model") or DEFAULT_MODEL)
+
+
+def router_model(config: dict | None = None) -> str:
+    cfg = config if isinstance(config, dict) else _safe_config()
+    return _resolve_model(cfg, "router_model", DEFAULT_ROUTER_MODEL)
+
+
+def conversation_model(config: dict | None = None) -> str:
+    cfg = config if isinstance(config, dict) else _safe_config()
+    return _resolve_model(cfg, "conversation_model", DEFAULT_CONVERSATION_MODEL)
+
+
+def _default_fallback(
+    *,
+    source_id: str,
+    question_id: str,
+    question_text: str,
+    question_category: str,
+    answer_text: str,
+    planned_question: object | None,
+) -> None:
+    """Today's exact behavior: the warm ack, then the separate follow-up.
+
+    Both steps swallow their own failures — this path exists precisely
+    because something already went wrong, and answer durability always wins.
+    """
+    try:
+        from answer_ack_delivery import acknowledge_answer  # noqa: PLC0415
+
+        outcome = acknowledge_answer(
+            source_id=source_id,
+            question_id=question_id,
+            question_text=question_text,
+            question_category=question_category,
+            answer_text=answer_text,
+            followup_pending=planned_question is not None,
+        )
+        print(
+            f"✓ Answer acknowledgment (turn fallback): {outcome.status} "
+            f"({outcome.reason}; {source_id})"
+        )
+    except Exception:  # noqa: BLE001
+        _diagnostic("fallback_acknowledgment", "internal_error", source_id)
+    try:
+        from process_answer import maybe_send_followup_question  # noqa: PLC0415
+
+        maybe_send_followup_question(question_id, planned_question)
+    except Exception:  # noqa: BLE001
+        _diagnostic("fallback_followup", "internal_error", source_id)
+
+
+def run_post_answer_turn(
+    *,
+    source_id: str,
+    question_id: str,
+    question_text: str,
+    question_category: str,
+    answer_text: str,
+    planned_question: object | None = None,
+    state_path: Path | None = None,
+    vault_root: str | Path | None = None,
+    channel: str = "telegram",
+    pinned_session_id: str | None = None,
+    allow_ambiguous_retry: bool = False,
+    sweep: bool = True,
+    ai_call: Callable[[str, str], str] | None = None,
+    telegram_send: Callable[[str], TelegramSendResult] | None = None,
+    status_resolver: Callable[..., object] | None = None,
+    prompt_builder: Callable[[dict], str] | None = None,
+    followup_minter: Callable[[str, list[str]], list[tuple[str, str]]] | None = None,
+    rotation_updater: Callable[[str], None] | None = None,
+    fallback: Callable[..., None] | None = None,
+) -> TurnOutcome:
+    """Run ONE conversation turn for a durable answer, or degrade to today.
+
+    Called from ``process_answer.run_post_answer_delivery`` in place of the
+    acknowledgment + separate-follow-up pair. Every failure mode either
+    sends the fallback pair or (ambiguous only) stops after ledgering —
+    nothing here can raise into the caller's durability path.
+    """
+    state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
+    vault_root = vault_root if vault_root is not None else VAULT_ROOT
+    manifest = _manifest()
+    if sweep:
+        try:
+            close_expired_sessions(
+                vault_root=vault_root,
+                state_path=state_path,
+                ai_call=ai_call,
+                telegram_send=telegram_send,
+                status_resolver=status_resolver,
+            )
+        except Exception:  # noqa: BLE001 — a stuck sweep never blocks this turn
+            _diagnostic("idle_sweep", "sweep_failed", source_id)
+
+    if pinned_session_id:
+        session = conversation.load_session(pinned_session_id, vault_root=vault_root)
+    else:
+        session = find_open_session_for_question(question_id, vault_root=vault_root)
+    if session is None:
+        # A chat session opens at the FIRST ANSWER, not at delivery: an arc
+        # card waiting with a delivered question burns no idle clock.
+        session = conversation.open_session("chat", channel, vault_root=vault_root)
+    session_id = str(session["session_id"])
+
+    existing_index = _locate_user_turn(session, question_id, answer_text)
+    if existing_index is None:
+        user_turn = {
+            "role": "user",
+            "text": answer_text,
+            "channel": channel,
+            "question_id": question_id,
+        }
+        try:
+            session = conversation.append_turn(
+                session_id,
+                user_turn,
+                expected_turns=len(session.get("turns") or []),
+                vault_root=vault_root,
+            )
+        except (conversation.TurnConflictError, conversation.SessionClosedError):
+            # Single flight: a concurrent entry for this session already
+            # minted the turn. The loser sends nothing — no turn, and no
+            # fallback ack either (the winner's message is the voice).
+            return TurnOutcome(session_id, -1, STATUS_SKIPPED, "turn_already_minted", False)
+        existing_index = len(session.get("turns") or []) - 1
+
+    turn_index = existing_index + 1
+    key = turn_key(session_id, turn_index)
+    entries = _state(state_path)["entries"]
+    previous = entries.get(key, {})
+    previous_status = previous.get("status")
+    if previous_status == STATUS_CONFIRMED:
+        return TurnOutcome(session_id, turn_index, STATUS_CONFIRMED, "already_confirmed", False)
+    if previous_status == STATUS_AMBIGUOUS and not allow_ambiguous_retry:
+        return TurnOutcome(session_id, turn_index, STATUS_AMBIGUOUS, "ambiguous_not_retried", False)
+    attempts = int(previous.get("attempts", 0) or 0) + 1
+
+    fallback_call = fallback or _default_fallback
+
+    def _degrade(status: str, reason: str, *, lint_ids: tuple[str, ...] = ()) -> TurnOutcome:
+        _write_outcome(
+            state_path,
+            key,
+            session_id=session_id,
+            turn_index=turn_index,
+            question_id=question_id,
+            status=status,
+            reason=reason,
+            attempts=attempts,
+            lint_ids=lint_ids,
+        )
+        degrades = status == STATUS_FAILED or reason in FALLBACK_SKIP_REASONS
+        if degrades:
+            fallback_call(
+                source_id=source_id,
+                question_id=question_id,
+                question_text=question_text,
+                question_category=question_category,
+                answer_text=answer_text,
+                planned_question=planned_question,
+            )
+        return TurnOutcome(
+            session_id, turn_index, status, reason, True, fallback_used=degrades, lint_ids=lint_ids
+        )
+
+    config = _safe_config()
+    model = conversation_model(config)
+    resolve_status = status_resolver or provider_status
+    selected = resolve_status(model, probe=False)
+    if not getattr(selected, "ready", False):
+        reason = (
+            "no_unattended_provider"
+            if getattr(selected, "provider", "") == "agent-task"
+            else "provider_unavailable"
+        )
+        return _degrade(STATUS_SKIPPED, reason)
+
+    shape = decide_turn_shape(session, manifest=manifest, planned_question=planned_question)
+    builder = prompt_builder or conversation.build_turn_prompt
+    try:
+        prompt = builder({"session": session}) + _output_contract_block(shape)
+        generated = (ai_call or call_ai)(prompt, model)
+    except AIProviderError as exc:
+        reason = _fixed_provider_reason(exc)
+        _diagnostic("generation", reason, session_id)
+        return _degrade(STATUS_FAILED, reason)
+    except Exception:  # noqa: BLE001 — answer durability always wins
+        _diagnostic("generation", "generation_failed", session_id)
+        return _degrade(STATUS_FAILED, "generation_failed")
+
+    parsed = parse_turn_output(generated)
+    if parsed is None:
+        _diagnostic("generation", "malformed_generation", session_id)
+        return _degrade(STATUS_FAILED, "malformed_generation")
+
+    message = parsed["message"]
+    question_allowed = shape.question_allowed and not parsed["question_free"]
+    blocking, advisory = lint_outgoing(
+        message,
+        question_allowed=question_allowed,
+        config=_lints_config(),
+    )
+    if blocking:
+        _diagnostic("lint", "malformed_generation", session_id)
+        return _degrade(STATUS_FAILED, "malformed_generation", lint_ids=tuple(blocking))
+
+    # Conservative replay position BEFORE the external effect.
+    _write_outcome(
+        state_path,
+        key,
+        session_id=session_id,
+        turn_index=turn_index,
+        question_id=question_id,
+        status=STATUS_AMBIGUOUS,
+        reason="send_in_progress",
+        attempts=attempts,
+        advisory_lints=advisory,
+    )
+    send_result = (telegram_send or send_telegram_result)(message)
+    if send_result.status == "confirmed":
+        status, reason = STATUS_CONFIRMED, "telegram_confirmed"
+    elif send_result.status == "ambiguous":
+        status, reason = STATUS_AMBIGUOUS, send_result.reason
+    elif send_result.status == "not_attempted":
+        status, reason = STATUS_SKIPPED, send_result.reason
+    else:
+        status, reason = STATUS_FAILED, send_result.reason
+
+    if status != STATUS_CONFIRMED:
+        _write_outcome(
+            state_path,
+            key,
+            session_id=session_id,
+            turn_index=turn_index,
+            question_id=question_id,
+            status=status,
+            reason=reason,
+            attempts=attempts,
+            advisory_lints=advisory,
+        )
+        _diagnostic("telegram_send", reason, session_id)
+        if status == STATUS_AMBIGUOUS:
+            # The turn may have reached Telegram. A fallback ack here would
+            # risk a duplicate voice — ledger it and stop (contract exception).
+            return TurnOutcome(session_id, turn_index, status, reason, True)
+        fallback_call(
+            source_id=source_id,
+            question_id=question_id,
+            question_text=question_text,
+            question_category=question_category,
+            answer_text=answer_text,
+            planned_question=planned_question,
+        )
+        return TurnOutcome(session_id, turn_index, status, reason, True, fallback_used=True)
+
+    followup_id = None
+    if question_allowed and parsed["followup_question"]:
+        followup_id = _mint_followup(
+            question_id,
+            parsed["followup_question"],
+            minter=followup_minter,
+            rotation_updater=rotation_updater,
+            session_id=session_id,
+        )
+
+    lifehug_turn = {
+        "role": "lifehug",
+        "text": message,
+        "channel": channel,
+        "model": model,
+        "question_id": followup_id or question_id,
+    }
+    try:
+        _append_turn_resilient(
+            session_id, lifehug_turn, expected_turns=turn_index, vault_root=vault_root
+        )
+        conversation.merge_session_extraction(
+            session_id,
+            rolling_summary=parsed["rolling_summary"],
+            extracted=parsed["extracted"],
+            vault_root=vault_root,
+        )
+    except Exception:  # noqa: BLE001 — the message is already delivered
+        _diagnostic("session_record", "session_write_failed", session_id)
+
+    _write_outcome(
+        state_path,
+        key,
+        session_id=session_id,
+        turn_index=turn_index,
+        question_id=followup_id or question_id,
+        status=STATUS_CONFIRMED,
+        reason="telegram_confirmed",
+        attempts=attempts,
+        advisory_lints=advisory,
+    )
+    if parsed["insight_receipts"]:
+        _record_insight_receipts(state_path, key, parsed["insight_receipts"])
+    return TurnOutcome(
+        session_id,
+        turn_index,
+        STATUS_CONFIRMED,
+        "telegram_confirmed",
+        True,
+        followup_id=followup_id,
+        question_free=followup_id is None,
+    )
+
+
+def _lints_config() -> dict | None:
+    try:
+        return conversation_lints.load_lints_config()
+    except (OSError, ValueError):
+        return None
+
+
+def _record_insight_receipts(state_path: Path, key: str, count: int) -> None:
+    """Metadata-only receipt count, read back by the close step."""
+    data = _state(state_path)
+    entry = data["entries"].get(key)
+    if isinstance(entry, dict):
+        entry["insight_receipts"] = int(count)
+        write_json(state_path, data)
+
+
+def _mint_followup(
+    question_id: str,
+    followup_text: str,
+    *,
+    minter: Callable[[str, list[str]], list[tuple[str, str]]] | None,
+    rotation_updater: Callable[[str], None] | None,
+    session_id: str,
+) -> str | None:
+    """File the cued follow-up as an A14 -> A14b suffix-chain bank question.
+
+    Minting happens only AFTER a confirmed send: a question the user never
+    received must not appear in their bank. Rotation then targets the new id
+    exactly as ``ask.mark_question_sent`` does, so the host agent files the
+    next inbound against it — and cadence accounting still counts this send,
+    keeping the 3/day cap governing our initiative.
+    """
+    try:
+        if minter is None:
+            from process_answer import append_followups  # noqa: PLC0415
+
+            minter = append_followups
+        added = minter(question_id, [followup_text])
+    except Exception:  # noqa: BLE001
+        _diagnostic("followup_mint", "mint_failed", session_id)
+        return None
+    if not added:
+        return None
+    new_id = str(added[0][0])
+    try:
+        if rotation_updater is None:
+            rotation_updater = _default_rotation_update
+        rotation_updater(new_id)
+    except Exception:  # noqa: BLE001
+        _diagnostic("rotation_update", "rotation_update_failed", session_id)
+    return new_id
+
+
+def _default_rotation_update(question_id: str) -> None:
+    import ask  # noqa: PLC0415
+    from lifehug_core import ROTATION_FILE, rebuild_coverage  # noqa: PLC0415
+
+    rotation = read_json(ROTATION_FILE, default={}) or {}
+    ask.mark_question_sent(rotation, question_id)
+    rebuild_coverage()
+
+
+# --------------------------------------------------------------------------
+# Lifecycle: idle sweep, close, engagement capture, extracted filing
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CloseOutcome:
+    """Metadata-only result of closing one session."""
+
+    session_id: str
+    reason: str
+    silent: bool
+    takeaway_delivered: bool
+    status: str
+    detail: str
+    filed: tuple[str, ...] = ()
+    user_turns: int = 0
+
+
+def _last_activity(session: dict) -> datetime | None:
+    turns = session.get("turns") or []
+    if turns:
+        moment = _parse_ts(turns[-1].get("ts"))
+        if moment is not None:
+            return moment
+    return _session_opened_at(str(session.get("session_id") or ""))
+
+
+def idle_timeout_minutes(session: dict, manifest: dict) -> int:
+    """Per-mode idle timeout from interaction.yaml (chat ~2h, conversation ~30m)."""
+    if session.get("mode") == "conversation":
+        return _knob(manifest, "knob.conversation_idle_timeout_minutes", 30)
+    return _knob(manifest, "knob.chat_idle_timeout_minutes", 120)
+
+
+def is_idle_expired(session: dict, *, manifest: dict, now: datetime | None = None) -> bool:
+    moment = _last_activity(session)
+    if moment is None:
+        return False
+    reference = now or _now()
+    return reference - moment >= timedelta(minutes=idle_timeout_minutes(session, manifest))
+
+
+def _filed_question_ids(session: dict) -> tuple[str, ...]:
+    filed: list[str] = []
+    for turn in session.get("turns") or []:
+        if turn.get("role") != "user":
+            continue
+        qid = turn.get("question_id")
+        if qid and str(qid) not in filed:
+            filed.append(str(qid))
+    return tuple(filed)
+
+
+def _session_insight_receipts(state_path: Path, session_id: str) -> int:
+    prefix = f"turn:{session_id}:"
+    total = 0
+    for key, entry in _state(state_path)["entries"].items():
+        if key.startswith(prefix) and isinstance(entry, dict):
+            total += int(entry.get("insight_receipts", 0) or 0)
+    return total
+
+
+def turn_length_trajectory(session: dict) -> str:
+    """expanding | flat | contracting over this session's user turns."""
+    lengths = [
+        len((turn.get("text") or "").strip())
+        for turn in session.get("turns") or []
+        if turn.get("role") == "user"
+    ]
+    if len(lengths) < 2:
+        return "flat"
+    midpoint = len(lengths) // 2
+    first = lengths[:midpoint] or lengths[:1]
+    second = lengths[-midpoint:] or lengths[-1:]
+    early = sum(first) / len(first)
+    late = sum(second) / len(second)
+    if early <= 0:
+        return "flat"
+    ratio = late / early
+    if ratio >= 1.2:
+        return "expanding"
+    if ratio <= 0.8:
+        return "contracting"
+    return "flat"
+
+
+def append_engagement(
+    session: dict,
+    *,
+    close_reason: str,
+    manifest: dict,
+    scores_path: Path | None = None,
+) -> list[str]:
+    """Append the engagement object to each filed question's answer_scores record.
+
+    Field names for the SHARED fields are #119's authority
+    (``continuation_past_exit``, ``turn_length_trajectory``); ``session_id``,
+    ``session_turns`` and ``close_reason`` are this PR's own contributions.
+    ``time_to_answer_hours`` and ``unprompted_inbound`` are computed
+    elsewhere (#119) and are deliberately left absent rather than guessed.
+    Richness fields are never touched.
+    """
+    filed = _filed_question_ids(session)
+    if not filed:
+        return []
+    scores_path = scores_path if scores_path is not None else ANSWER_SCORES_FILE
+    data = read_json(scores_path, default=None)
+    if not isinstance(data, dict) or not isinstance(data.get("scores"), list):
+        return []
+    user_turns = _count_user_turns(session)
+    target = _knob(manifest, "knob.chat_target_exchanges", 3)
+    engagement = {
+        "session_id": str(session.get("session_id") or ""),
+        "session_turns": len(session.get("turns") or []),
+        "continuation_past_exit": user_turns > target,
+        "turn_length_trajectory": turn_length_trajectory(session),
+        "close_reason": close_reason,
+    }
+    touched: list[str] = []
+    for record in data["scores"]:
+        if not isinstance(record, dict):
+            continue
+        if str(record.get("question_id") or "") in filed:
+            record["engagement"] = dict(engagement)
+            touched.append(str(record["question_id"]))
+    if touched:
+        data["last_updated"] = now_utc()
+        write_json(scores_path, data)
+    return touched
+
+
+def file_candidate_ideas(
+    session: dict,
+    *,
+    candidates_path: Path | None = None,
+) -> list[str]:
+    """File extracted.candidate_ideas into the candidate store, provenance conversation."""
+    extracted = session.get("extracted") or {}
+    ideas = extracted.get("candidate_ideas") if isinstance(extracted, dict) else None
+    if not isinstance(ideas, list) or not ideas:
+        return []
+    import question_candidates  # noqa: PLC0415
+
+    path = candidates_path or question_candidates.QUESTION_CANDIDATES_FILE
+    store = question_candidates.load_store(path)
+    existing = {
+        question_candidates.normalize_question(str(c.get("text", "")))
+        for c in store.get("candidates", [])
+        if isinstance(c, dict)
+    }
+    session_id = str(session.get("session_id") or "")
+    created = now_utc()
+    added: list[str] = []
+    for index, idea in enumerate(ideas, 1):
+        text = idea.get("text") if isinstance(idea, dict) else idea
+        if not isinstance(text, str) or not text.strip():
+            continue
+        clean = text.strip()
+        if question_candidates.normalize_question(clean) in existing:
+            continue
+        existing.add(question_candidates.normalize_question(clean))
+        cid = f"cand-{session_id}-{index}"
+        store.setdefault("candidates", []).append({
+            "id": cid,
+            "text": clean,
+            "source_path": None,
+            "target_page": None,
+            "kind": "conversation",
+            "priority": 0.5,
+            "reason": "Proposed inside a Lifehug conversation",
+            "status": "candidate",
+            "story_function": None,
+            "created_at": created,
+            "provenance": "conversation",
+        })
+        added.append(cid)
+    if added:
+        question_candidates.save_store(store, path)
+    return added
+
+
+def _entity_hints(session: dict) -> list[str]:
+    extracted = session.get("extracted") or {}
+    entities = extracted.get("entities") if isinstance(extracted, dict) else None
+    if not isinstance(entities, list):
+        return []
+    hints: list[str] = []
+    for entity in entities:
+        name = entity.get("name") if isinstance(entity, dict) else entity
+        if isinstance(name, str) and name.strip() and name.strip() not in hints:
+            hints.append(name.strip())
+    return hints
+
+
+def close_session_now(
+    session_id: str,
+    *,
+    reason: str = "done",
+    state_path: Path | None = None,
+    vault_root: str | Path | None = None,
+    scores_path: Path | None = None,
+    candidates_path: Path | None = None,
+    channel: str = "telegram",
+    ai_call: Callable[[str, str], str] | None = None,
+    telegram_send: Callable[[str], TelegramSendResult] | None = None,
+    status_resolver: Callable[..., object] | None = None,
+    prompt_builder: Callable[[dict], str] | None = None,
+    manifest: dict | None = None,
+) -> CloseOutcome:
+    """Close one session: closing takeaway when warranted, silence otherwise.
+
+    The closing-takeaway criterion is the deterministic cross-runtime rule
+    (platform #414 confirms the same rule): a close message goes out only
+    when the session has at least TWO user turns. Zero-turn sessions and
+    chats abandoned mid-exchange close SILENTLY — whatever was answered is
+    already durably filed per turn, so a "you didn't finish" nudge would be
+    pressure with no content. No-nag is owner-confirmed.
+    """
+    state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
+    vault_root = vault_root if vault_root is not None else VAULT_ROOT
+    scores_path = scores_path if scores_path is not None else ANSWER_SCORES_FILE
+    manifest = manifest if manifest is not None else _manifest()
+    session = conversation.load_session(session_id, vault_root=vault_root)
+    filed = _filed_question_ids(session)
+    user_turns = _count_user_turns(session)
+    receipts = _session_insight_receipts(state_path, session_id)
+    takeaway = ""
+    delivered = False
+    status, detail = STATUS_SKIPPED, "no_close_message"
+
+    if user_turns >= 2:
+        status, detail, takeaway = _deliver_closing(
+            session,
+            state_path=state_path,
+            channel=channel,
+            ai_call=ai_call,
+            telegram_send=telegram_send,
+            status_resolver=status_resolver,
+            prompt_builder=prompt_builder,
+            vault_root=vault_root,
+        )
+        delivered = status == STATUS_CONFIRMED
+    else:
+        detail = "silent_no_nag"
+
+    close = {
+        "reason": reason,
+        "takeaway": takeaway if delivered else "",
+        "takeaway_delivered": delivered,
+        "insight_receipts_count": receipts,
+        "filed": list(filed),
+    }
+    hints = _entity_hints(session)
+    if hints:
+        # Classification hints for the weekly pass. The pass has no
+        # dedicated hint surface today (verified against classify_story.py /
+        # state/agent_tasks), so the close block IS the surface; wiring the
+        # weekly consumer belongs to whoever owns that pass.
+        close["entity_hints"] = hints
+    closed = conversation.close_session(session_id, close, vault_root=vault_root)
+
+    try:
+        append_engagement(
+            closed, close_reason=reason, manifest=manifest, scores_path=scores_path
+        )
+    except Exception:  # noqa: BLE001 — instrumentation never blocks a close
+        _diagnostic("engagement_capture", "engagement_write_failed", session_id)
+    try:
+        file_candidate_ideas(closed, candidates_path=candidates_path)
+    except Exception:  # noqa: BLE001
+        _diagnostic("candidate_filing", "candidate_write_failed", session_id)
+
+    return CloseOutcome(
+        session_id,
+        reason,
+        silent=not delivered,
+        takeaway_delivered=delivered,
+        status=status,
+        detail=detail,
+        filed=filed,
+        user_turns=user_turns,
+    )
+
+
+def _deliver_closing(
+    session: dict,
+    *,
+    state_path: Path,
+    channel: str,
+    ai_call: Callable[[str, str], str] | None,
+    telegram_send: Callable[[str], TelegramSendResult] | None,
+    status_resolver: Callable[..., object] | None,
+    prompt_builder: Callable[[dict], str] | None,
+    vault_root: str | Path | None,
+) -> tuple[str, str, str]:
+    """Generate/lint/send the closing takeaway; ledger it under close:{id}.
+
+    A failed close is SILENT, never a fallback ack: the ack is the
+    post-answer voice, and every answer in this session already got one turn
+    or one ack of its own. Returning (status, detail, takeaway).
+    """
+    session_id = str(session["session_id"])
+    key = close_key(session_id)
+    entries = _state(state_path)["entries"]
+    previous = entries.get(key, {})
+    if previous.get("status") == STATUS_CONFIRMED:
+        return STATUS_CONFIRMED, "already_confirmed", str(previous.get("takeaway", ""))
+    if previous.get("status") == STATUS_AMBIGUOUS:
+        return STATUS_AMBIGUOUS, "ambiguous_not_retried", ""
+    attempts = int(previous.get("attempts", 0) or 0) + 1
+    turn_index = len(session.get("turns") or [])
+
+    def ledger(status: str, reason: str, lint_ids: tuple[str, ...] = ()) -> None:
+        _write_outcome(
+            state_path,
+            key,
+            session_id=session_id,
+            turn_index=turn_index,
+            question_id="",
+            status=status,
+            reason=reason,
+            attempts=attempts,
+            lint_ids=lint_ids,
+        )
+
+    model = conversation_model()
+    resolve_status = status_resolver or provider_status
+    selected = resolve_status(model, probe=False)
+    if not getattr(selected, "ready", False):
+        reason = (
+            "no_unattended_provider"
+            if getattr(selected, "provider", "") == "agent-task"
+            else "provider_unavailable"
+        )
+        ledger(STATUS_SKIPPED, reason)
+        return STATUS_SKIPPED, reason, ""
+
+    builder = prompt_builder or conversation.build_closing_prompt
+    try:
+        prompt = builder({"session": session}) + _closing_output_contract()
+        generated = (ai_call or call_ai)(prompt, model)
+    except AIProviderError as exc:
+        reason = _fixed_provider_reason(exc)
+        ledger(STATUS_FAILED, reason)
+        _diagnostic("closing_generation", reason, session_id)
+        return STATUS_FAILED, reason, ""
+    except Exception:  # noqa: BLE001
+        ledger(STATUS_FAILED, "generation_failed")
+        _diagnostic("closing_generation", "generation_failed", session_id)
+        return STATUS_FAILED, "generation_failed", ""
+
+    parsed = parse_turn_output(generated)
+    message = parsed["message"] if parsed else _valid_message(generated)
+    if message is None:
+        ledger(STATUS_FAILED, "malformed_generation")
+        _diagnostic("closing_generation", "malformed_generation", session_id)
+        return STATUS_FAILED, "malformed_generation", ""
+    # Behavior rule 8: a close ends on the peak and STOPS — no trailing
+    # question. That makes every closing message question-free by contract.
+    blocking, _advisory = lint_outgoing(
+        message, question_allowed=False, config=_lints_config()
+    )
+    if blocking:
+        ledger(STATUS_FAILED, "malformed_generation", tuple(blocking))
+        _diagnostic("closing_lint", "malformed_generation", session_id)
+        return STATUS_FAILED, "malformed_generation", ""
+
+    ledger(STATUS_AMBIGUOUS, "send_in_progress")
+    send_result = (telegram_send or send_telegram_result)(message)
+    if send_result.status == "confirmed":
+        ledger(STATUS_CONFIRMED, "telegram_confirmed")
+        try:
+            _append_turn_resilient(
+                session_id,
+                {
+                    "role": "lifehug",
+                    "text": message,
+                    "channel": channel,
+                    "model": model,
+                },
+                expected_turns=turn_index,
+                vault_root=vault_root,
+            )
+        except Exception:  # noqa: BLE001 — already delivered
+            _diagnostic("session_record", "session_write_failed", session_id)
+        return STATUS_CONFIRMED, "telegram_confirmed", message
+    if send_result.status == "ambiguous":
+        ledger(STATUS_AMBIGUOUS, send_result.reason)
+        _diagnostic("closing_send", send_result.reason, session_id)
+        return STATUS_AMBIGUOUS, send_result.reason, ""
+    status = STATUS_SKIPPED if send_result.status == "not_attempted" else STATUS_FAILED
+    ledger(status, send_result.reason)
+    _diagnostic("closing_send", send_result.reason, session_id)
+    return status, send_result.reason, ""
+
+
+def _closing_output_contract() -> str:
+    return (
+        "\n\nReply with a single JSON object and nothing else:\n"
+        '{"message": "the closing message, plain text", "question_free": true}\n'
+        "The closing message ends on the peak and STOPS — no trailing question.\n"
+    )
+
+
+def close_expired_sessions(
+    *,
+    now: datetime | None = None,
+    vault_root: str | Path | None = None,
+    state_path: Path | None = None,
+    scores_path: Path | None = None,
+    candidates_path: Path | None = None,
+    ai_call: Callable[[str, str], str] | None = None,
+    telegram_send: Callable[[str], TelegramSendResult] | None = None,
+    status_resolver: Callable[..., object] | None = None,
+    prompt_builder: Callable[[dict], str] | None = None,
+) -> list[CloseOutcome]:
+    """Lazy sweep: close every open session past its idle timeout.
+
+    No daemon and no cron change in this PR — the sweep runs at the top of
+    every post-answer turn and on demand via ``conversation-close --expired``
+    (the same subcommand #119's jobs builder enqueues).
+    """
+    state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
+    vault_root = vault_root if vault_root is not None else VAULT_ROOT
+    scores_path = scores_path if scores_path is not None else ANSWER_SCORES_FILE
+    manifest = _manifest()
+    reference = now or _now()
+    outcomes: list[CloseOutcome] = []
+    for summary in conversation.list_sessions(status="open", vault_root=vault_root):
+        session_id = summary.get("session_id")
+        if not session_id:
+            continue
+        try:
+            session = conversation.load_session(session_id, vault_root=vault_root)
+        except (OSError, ValueError):
+            continue
+        if not is_idle_expired(session, manifest=manifest, now=reference):
+            continue
+        try:
+            outcomes.append(
+                close_session_now(
+                    session_id,
+                    reason="idle_timeout",
+                    state_path=state_path,
+                    vault_root=vault_root,
+                    scores_path=scores_path,
+                    candidates_path=candidates_path,
+                    ai_call=ai_call,
+                    telegram_send=telegram_send,
+                    status_resolver=status_resolver,
+                    prompt_builder=prompt_builder,
+                    manifest=manifest,
+                )
+            )
+        except Exception:  # noqa: BLE001 — one bad session never stalls the sweep
+            _diagnostic("idle_sweep", "close_failed", str(session_id))
+    return outcomes
+
+
+def retry_turn(
+    session_id: str,
+    turn_index: int,
+    *,
+    confirm_not_sent: bool = False,
+    state_path: Path | None = None,
+    vault_root: str | Path | None = None,
+    ai_call: Callable[[str, str], str] | None = None,
+    telegram_send: Callable[[str], TelegramSendResult] | None = None,
+    status_resolver: Callable[..., object] | None = None,
+) -> TurnOutcome:
+    """Operator door: retry a definitively unsent turn.
+
+    Ambiguous entries need ``--confirm-not-sent`` (operator verified
+    Telegram), exactly like ``answer-ack-retry``. A retried turn is always
+    question-free: the operator is recovering a lost receipt, not spending
+    fresh question initiative.
+    """
+    state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
+    vault_root = vault_root if vault_root is not None else VAULT_ROOT
+    session = conversation.load_session(session_id, vault_root=vault_root)
+    turns = session.get("turns") or []
+    user_index = turn_index - 1
+    if user_index < 0 or user_index >= len(turns) or turns[user_index].get("role") != "user":
+        raise ValueError(f"no user turn at index {user_index} in {session_id}")
+    user_turn = turns[user_index]
+    question_id = str(user_turn.get("question_id") or "")
+    return run_post_answer_turn(
+        source_id=f"answer:{question_id}" if question_id else session_id,
+        question_id=question_id,
+        question_text="",
+        question_category="",
+        answer_text=str(user_turn.get("text") or ""),
+        planned_question=None,
+        state_path=state_path,
+        vault_root=vault_root,
+        pinned_session_id=session_id,
+        allow_ambiguous_retry=confirm_not_sent,
+        sweep=False,
+        ai_call=ai_call,
+        telegram_send=telegram_send,
+        status_resolver=status_resolver,
+        fallback=lambda **_kwargs: None,
+    )
+
+
+# --------------------------------------------------------------------------
+# CLI — conversation-status / conversation-close / conversation-turn-retry
+# --------------------------------------------------------------------------
+
+
+def print_status(session_id: str | None, *, full: bool = False, state_path: Path | None = None) -> int:
+    """Session summary + delivery-ledger status (metadata only by default)."""
+    state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
+    entries = _state(state_path)["entries"]
+    if session_id:
+        try:
+            doc = conversation.load_session(session_id)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error: {exc}")
+            return 1
+        turns = doc.get("turns") or []
+        print(f"{doc['session_id']}: {doc.get('status')} ({doc.get('mode')}/{doc.get('channel')})")
+        print(f"turns: {len(turns)}")
+        close = doc.get("close") or {}
+        if close:
+            print(
+                f"close: {close.get('reason')} (takeaway_delivered="
+                f"{bool(close.get('takeaway_delivered'))}; "
+                f"insight_receipts={close.get('insight_receipts_count', 0)}; "
+                f"filed={','.join(close.get('filed') or []) or '-'})"
+            )
+        if full:
+            for turn in turns:
+                print(f"  {turn.get('role')} [{turn.get('ts')}]: {turn.get('text')}")
+        entries = {k: v for k, v in entries.items() if v.get("session_id") == session_id}
+    else:
+        for summary in conversation.list_sessions():
+            print(
+                f"{summary['session_id']}: {summary['status']} "
+                f"({summary['mode']}/{summary['channel']}; turns={summary['turn_count']})"
+            )
+    if not entries:
+        print("No conversation delivery metadata found.")
+        return 0
+    print("delivery ledger:")
+    for key, entry in sorted(entries.items()):
+        print(
+            f"  {key}: {entry.get('status', 'unknown')} "
+            f"({entry.get('reason', 'unknown')}; attempts={entry.get('attempts', 0)})"
+        )
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    return print_status(args.session_id, full=args.full)
+
+
+def cmd_close(args: argparse.Namespace) -> int:
+    if args.expired:
+        outcomes = close_expired_sessions()
+        if not outcomes:
+            print("No expired conversation sessions.")
+            return 0
+        for outcome in outcomes:
+            print(
+                f"{outcome.session_id}: closed ({outcome.reason}; "
+                f"{'silent' if outcome.silent else 'takeaway sent'}; {outcome.detail})"
+            )
+        return 0
+    if not args.session_id:
+        print("Error: pass a session id or --expired")
+        return 1
+    try:
+        outcome = close_session_now(args.session_id, reason=args.reason)
+    except (FileNotFoundError, ValueError, conversation.ConversationError) as exc:
+        print(f"Error: {exc}")
+        return 1
+    print(
+        f"{outcome.session_id}: closed ({outcome.reason}; "
+        f"{'silent' if outcome.silent else 'takeaway sent'}; {outcome.detail})"
+    )
+    return 0
+
+
+def cmd_turn_retry(args: argparse.Namespace) -> int:
+    try:
+        outcome = retry_turn(
+            args.session_id, args.turn_index, confirm_not_sent=args.confirm_not_sent
+        )
+    except (FileNotFoundError, ValueError, conversation.ConversationError) as exc:
+        print(f"Error: {exc}")
+        return 1
+    print(f"{outcome.session_id} turn {outcome.turn_index}: {outcome.status} ({outcome.reason})")
+    return 0 if outcome.status == STATUS_CONFIRMED else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Conversation turn delivery: status, close/sweep, and retry"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("status", help="Session + delivery-ledger status (metadata only)")
+    p.add_argument("session_id", nargs="?")
+    p.add_argument("--full", action="store_true", help="Also print turn text (private content)")
+    p.set_defaults(func=cmd_status)
+
+    p = sub.add_parser("close", help="Close one session now, or sweep every expired one")
+    p.add_argument("session_id", nargs="?")
+    p.add_argument("--expired", action="store_true", help="Close every idle-expired session")
+    p.add_argument("--reason", default="done", choices=sorted(conversation.VALID_CLOSE_REASONS))
+    p.set_defaults(func=cmd_close)
+
+    p = sub.add_parser("turn-retry", help="Retry a definitively unsent turn")
+    p.add_argument("session_id")
+    p.add_argument("turn_index", type=int)
+    p.add_argument(
+        "--confirm-not-sent",
+        action="store_true",
+        help="Retry an ambiguous send only after verifying Telegram did not receive it",
+    )
+    p.set_defaults(func=cmd_turn_retry)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -81,6 +81,10 @@ DIRECT_MUTATION_COMMANDS = frozenset({
     # store's own three mutators. No jobs.py command kind yet (Wave 2) — they
     # take the writer lock directly like the rest of this family.
     "conversation-close", "conversation-open", "conversation-record-turn",
+    # New in issue #116 (Wave 2 PR 3): the operator retry door for a turn
+    # whose send definitively failed. conversation-close is unchanged here —
+    # it was already classified; #116 only upgraded what it does.
+    "conversation-turn-retry",
     "correct-source", "entity-roster", "fix", "focus-add",
     "focus-approve", "focus-dismiss", "focus-finish", "focus-new", "focus-set",
     "ingest", "ingest-story", "mirror-compile", "perennial-add", "perennials",
@@ -831,12 +835,16 @@ def cmd_conversation_open(args: argparse.Namespace) -> int:
 
 
 def cmd_conversation_status(args: argparse.Namespace) -> int:
+    # v153 (issue #116): upgraded IN PLACE to the turn engine's status, which
+    # prints the same session summary PLUS the delivery ledger (mirrors
+    # answer-ack-status). conversation.py's own `status` stays available for
+    # store-only inspection.
     flags = ["status"]
     if args.session_id:
         flags.append(args.session_id)
     if args.full:
         flags.append("--full")
-    return run_python("conversation.py", flags)
+    return run_python("conversation_delivery.py", flags)
 
 
 def cmd_conversation_record_turn(args: argparse.Namespace) -> int:
@@ -851,7 +859,23 @@ def cmd_conversation_record_turn(args: argparse.Namespace) -> int:
 
 
 def cmd_conversation_close(args: argparse.Namespace) -> int:
-    return run_python("conversation.py", ["close", args.session_id, "--reason", args.reason])
+    # v153 (issue #116): the same subcommand now closes for real — closing
+    # takeaway when the session earned one, silence when it did not — and
+    # owns the --expired idle sweep that #119's jobs builder enqueues.
+    flags = ["close"]
+    if args.expired:
+        flags.append("--expired")
+    else:
+        flags.append(args.session_id)
+    flags += ["--reason", args.reason]
+    return run_python("conversation_delivery.py", flags)
+
+
+def cmd_conversation_turn_retry(args: argparse.Namespace) -> int:
+    flags = ["turn-retry", args.session_id, str(args.turn_index)]
+    if args.confirm_not_sent:
+        flags.append("--confirm-not-sent")
+    return run_python("conversation_delivery.py", flags)
 
 
 def cmd_conversation_turn_prompt(_args: argparse.Namespace) -> int:
@@ -1880,10 +1904,20 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--expected-turns", required=True, type=int)
     p.set_defaults(func=cmd_conversation_record_turn)
 
-    p = sub.add_parser("conversation-close", help="Store a conversation close only; takeaway on stdin optional")
-    p.add_argument("session_id")
-    p.add_argument("--reason", required=True, choices=["done", "idle_timeout", "exit_taken"])
+    p = sub.add_parser("conversation-close",
+                       help="Close one conversation session now, or sweep every idle-expired one")
+    p.add_argument("session_id", nargs="?")
+    p.add_argument("--expired", action="store_true",
+                   help="Close every session past its idle timeout (the sweep)")
+    p.add_argument("--reason", default="done", choices=["done", "idle_timeout", "exit_taken"])
     p.set_defaults(func=cmd_conversation_close)
+
+    p = sub.add_parser("conversation-turn-retry", help="Retry a definitively unsent conversation turn")
+    p.add_argument("session_id")
+    p.add_argument("turn_index", type=int)
+    p.add_argument("--confirm-not-sent", action="store_true",
+                   help="Retry an ambiguous send only after checking that Telegram did not receive it")
+    p.set_defaults(func=cmd_conversation_turn_retry)
 
     p = sub.add_parser("conversation-turn-prompt", help="stdin JSON -> the conversation turn prompt")
     p.set_defaults(func=cmd_conversation_turn_prompt)

--- a/system/lifehug_core.py
+++ b/system/lifehug_core.py
@@ -187,6 +187,7 @@ COMPILE_NEEDED_FILE = _data("compile_needed")
 ARC_CARDS_FILE = _data("arc_cards")
 CONVERSATIONS_DIR = _data("conversations")
 MIRROR_RESPONSES_FILE = _data("mirror_responses")
+CONVERSATION_DELIVERIES_FILE = _data("conversation_deliveries")
 
 TEMPLATES_DIR = framework_path("templates", framework_system_dir=SYSTEM_DIR)
 MISSION_FILE = framework_path("mission", framework_system_dir=SYSTEM_DIR)

--- a/system/process_answer.py
+++ b/system/process_answer.py
@@ -414,10 +414,21 @@ def run_post_answer_delivery(
     question_category: str,
     answer_text: str,
 ):
-    """After durability: acknowledgment attempt, then adaptive follow-up.
+    """After durability: ONE conversation turn, or today's ack + follow-up.
 
-    Every acknowledgment failure is swallowed before the follow-up step.  No
-    diagnostic receives answer, prompt, or generated message text.
+    v153 (issue #116): the acknowledgment-then-separate-follow-up pair became
+    a single conversation turn — receipt, payout, and a cued follow-up in one
+    message, per ``interactions/conversation/prompt/behavior.md``. The
+    planning step is unchanged and still runs FIRST, because the turn engine
+    needs the cadence gates' verdict (curfew, 3/day cap, pass transition):
+    when planning returns None our question initiative is spent, and the turn
+    is question-free rather than skipped.
+
+    The engine degrades to today's exact behavior — ``acknowledge_answer``
+    then ``maybe_send_followup_question`` — on any definitive failure, so
+    this path is never silent and never worse than before. Every failure is
+    swallowed relative to answer durability, and no diagnostic receives
+    answer, prompt, or generated message text.
     """
     planned_question = None
     try:
@@ -430,6 +441,59 @@ def run_post_answer_delivery(
             context={"source_id": source_id},
         )
 
+    outcome = None
+    try:
+        from conversation_delivery import run_post_answer_turn  # noqa: PLC0415
+
+        outcome = run_post_answer_turn(
+            source_id=source_id,
+            question_id=question_id,
+            question_text=question_text,
+            question_category=question_category,
+            answer_text=answer_text,
+            planned_question=planned_question,
+        )
+        print(
+            f"✓ Conversation turn: {outcome.status} "
+            f"({outcome.reason}; {source_id})"
+        )
+    except Exception as exc:  # noqa: BLE001 — the turn is never capture
+        record_learning_failure(
+            "process_answer",
+            "conversation_turn",
+            type(exc).__name__,
+            context={"source_id": source_id},
+        )
+        print(f"  (conversation turn skipped: internal_error; {source_id})")
+        # The engine owns its own fallback; an exception BEFORE it could run
+        # leaves the user with nothing, so run today's behavior here.
+        _run_legacy_post_answer_delivery(
+            source_id=source_id,
+            question_id=question_id,
+            question_text=question_text,
+            question_category=question_category,
+            answer_text=answer_text,
+            planned_question=planned_question,
+        )
+    return outcome
+
+
+def _run_legacy_post_answer_delivery(
+    *,
+    source_id: str,
+    question_id: str,
+    question_text: str,
+    question_category: str,
+    answer_text: str,
+    planned_question,
+):
+    """Pre-v153 behavior: warm acknowledgment, then the separate follow-up.
+
+    Kept as a named function (not dead code): it is the last-resort path when
+    the turn engine cannot even be imported or raises before its own fallback
+    fires. ``answer_ack``'s "No questions back" rule is correct HERE — this
+    message is an acknowledgment, and the follow-up is a separate message.
+    """
     outcome = None
     try:
         from answer_ack_delivery import acknowledge_answer  # noqa: PLC0415

--- a/system/vault_contract.json
+++ b/system/vault_contract.json
@@ -2,9 +2,9 @@
   "contract_version": 1,
   "identity": {
     "framework": "lifehug/lifehug",
-    "framework_version": 150,
-    "revision": "vault-contract-v2",
-    "content_digest": "sha256:b5c2c3362d4f4f8b71735a2a4e2f48e23b61ea77ee66e7939702142ee4691d76"
+    "framework_version": 153,
+    "revision": "vault-contract-v3",
+    "content_digest": "sha256:82b98f8d5f3fc91a5a1f330c67e2c0d5eae2a216f2e1f82aed10d40efa96bb33"
   },
   "special_file_policy": {
     "regular_files": "allow",
@@ -138,6 +138,13 @@
     },
     "mirror_responses": {
       "path": "state/mirror_responses.json",
+      "kind": "file",
+      "required": false,
+      "tracked": true,
+      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+    },
+    "conversation_deliveries": {
+      "path": "state/conversation_deliveries.json",
       "kind": "file",
       "required": false,
       "tracked": true,

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 152,
+  "version": 153,
   "released": "2026-08-11",
-  "changelog": "v150: the Conversation Interaction's durable session store lands (issue #115, Wave 1 PR 2 of 2) \u2014 vault-contract v2 registers arc_cards, conversations, and mirror_responses data paths plus the interactions framework path; system/conversation.py adds session CRUD (open/load/list/append-turn-CAS/close), deterministic context assembly, and four pure prompt builders (turn/router/arc/closing); system/conversation_lints.py adds the deterministic lint engine (one-question-per-turn, banned phrases, question-grammar audit, length caps, receipt-before-question, year-question detection); eight new conversation-* lifehug.py subcommands expose all of it. Infrastructure only \u2014 no live-flow behavior change; nothing here is reachable except through the new subcommands and imports.",
+  "changelog": "v153: the post-answer moment becomes a CONVERSATION (issue #116, Wave 2 PR 3). Answering a question no longer produces two disconnected messages \u2014 a warm acknowledgment that cannot ask anything, followed by a rotation-picked question about something else. It now produces ONE message that receives what you said, pays it back with something you didn't have, and cues the next question in your own words: a short chat (~3 exchanges) that ends gracefully and, when it earned one, closes with a takeaway. Partial chats file cleanly and close silently \u2014 no nagging, ever. system/conversation_delivery.py orchestrates the turn through the issue #115 builders and the interactions/conversation/ behavior authority, enforcing the deterministic lints (one question, length cap, banned phrases) before anything is sent; state/conversation_deliveries.json makes delivery exactly-once (confirmed replays are no-ops, ambiguous is never auto-retried); and ANY definitive failure degrades to the previous acknowledgment + follow-up pair in the same run, so this is never silent and never worse than before. New config keys conversation_model / router_model / arc_plan_model; conversation-status and conversation-close upgraded in place (--expired runs the idle sweep) plus the new conversation-turn-retry operator door; engagement signal is recorded on each answered question at close.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -185,6 +185,8 @@
     "tests/walkthrough_lib.py",
     "wiki/SCHEMA.md",
     "system/conversation.py",
-    "system/conversation_lints.py"
+    "system/conversation_lints.py",
+    "system/conversation_delivery.py",
+    "tests/test_conversation_delivery.py"
   ]
 }

--- a/tests/test_answer_ack.py
+++ b/tests/test_answer_ack.py
@@ -10,6 +10,9 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
+
+from tempdirs import root_parent_tmp  # noqa: E402
 
 
 def load_answer_ack():
@@ -150,6 +153,7 @@ class AnswerAcknowledgmentDeliveryTests(unittest.TestCase):
 
     def setUp(self):
         import answer_ack_delivery
+        import conversation_delivery
         import process_answer
 
         self.delivery = answer_ack_delivery
@@ -157,6 +161,24 @@ class AnswerAcknowledgmentDeliveryTests(unittest.TestCase):
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         self.state_path = Path(tmp.name) / "answer_acknowledgments.json"
+        # v153: run_post_answer_delivery now runs a conversation turn first
+        # (which falls back to the ack pair asserted below). Point the engine
+        # at a synthetic vault — ROOT.parent, because vault_paths refuses to
+        # traverse macOS's /var symlink — so these tests never write session
+        # documents or a delivery ledger into the real vault.
+        vault = root_parent_tmp(self, ROOT, prefix="lifehug-v153-ack-") / "vault"
+        vault.mkdir()
+        for patch in (
+            mock.patch.object(conversation_delivery, "VAULT_ROOT", vault),
+            mock.patch.object(
+                conversation_delivery,
+                "DELIVERY_STATE_FILE",
+                vault / "state" / "conversation_deliveries.json",
+            ),
+            mock.patch.object(conversation_delivery, "record_learning_failure"),
+        ):
+            patch.start()
+            self.addCleanup(patch.stop)
 
     def test_ack_is_best_effort_and_never_confirmed_without_a_telegram_target(self):
         """Ported from test_ack_skips_model_call_without_telegram_target.

--- a/tests/test_conversation_delivery.py
+++ b/tests/test_conversation_delivery.py
@@ -1,0 +1,671 @@
+"""v153 / issue #116 — the conversation turn engine.
+
+Wave 2 PR 3 of the Conversation Interaction build. The post-answer moment
+becomes ONE conversation turn (receipt + payout + cued follow-up), with an
+exactly-once delivery ledger and a non-negotiable fallback to today's
+acknowledgment + separate-follow-up pair.
+
+Every collaborator is injected (``ai_call`` / ``telegram_send`` /
+``status_resolver`` / clock / ``state_path`` / ``vault_root`` /
+``followup_minter`` / ``rotation_updater`` / ``fallback``); the vault is a
+synthetic temp tree built through tests/tempdirs.py. Synthetic data only —
+NEVER ~/Workspace/dave.
+
+Subtest names are the contract's own list (state-machine-shaped change →
+named explicitly, v130/v131 precedent).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSTEM = ROOT / "system"
+sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
+
+from tempdirs import root_parent_tmp  # noqa: E402
+import conversation  # noqa: E402
+import conversation_delivery as engine  # noqa: E402
+import lifehug_core as core  # noqa: E402
+from ai_provider import AIUnavailableError, ProviderStatus  # noqa: E402
+
+QUESTION_ID = "A14"
+QUESTION = "What did the farm smell like?"
+ANSWER = "Diesel and cut hay, mostly. My grandfather's hands always smelled like both."
+SECOND_ANSWER = "The hay came from the north field, and he baled it himself every August."
+THIRD_ANSWER = "He kept the baler running with parts he machined in the barn."
+TURN_MESSAGE = (
+    "Diesel and cut hay — and your grandfather's hands carrying both at once. "
+    'Tell me about "the north field".'
+)
+FOLLOWUP_TEXT = 'Tell me about "the north field".'
+CLOSING_MESSAGE = (
+    "What stays with me is that his hands carried the work and the harvest at "
+    "the same time. Thank you for putting me in that barn. Next time we can "
+    "pick up the baler he kept alive."
+)
+
+
+def ready_status(*_args, **_kwargs):
+    return ProviderStatus("local-openai", "synthetic-model", True, "synthetic")
+
+
+def keyless_status(*_args, **_kwargs):
+    return ProviderStatus("agent-task", "synthetic-model", False, "synthetic")
+
+
+def down_status(*_args, **_kwargs):
+    return ProviderStatus("anthropic", "synthetic-model", False, "synthetic")
+
+
+def confirmed_send(_message):
+    return core.TelegramSendResult("confirmed", "telegram_confirmed", 1, 1)
+
+
+def ambiguous_send(_message):
+    return core.TelegramSendResult("ambiguous", "telegram_transport_ambiguous", 0, 1)
+
+
+def rejected_send(_message):
+    return core.TelegramSendResult("rejected", "telegram_api_rejected", 0, 1)
+
+
+def turn_json(message=TURN_MESSAGE, followup=FOLLOWUP_TEXT, **extra):
+    payload = {
+        "message": message,
+        "followup_question": followup,
+        "question_free": followup is None,
+        "rolling_summary": "The farm's smells; grandfather's hands.",
+        "insight_receipts": 1,
+        "extracted": {
+            "facts": ["the farm ran on diesel"],
+            "entities": [{"name": "grandfather"}],
+            "candidate_ideas": [{"text": "What did he machine in that barn?"}],
+            "mirror_responses": [],
+        },
+    }
+    payload.update(extra)
+    return json.dumps(payload)
+
+
+class EngineTestCase(unittest.TestCase):
+    """Synthetic vault + injected collaborators shared by every subtest."""
+
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v153-turn-")
+        self.vault = self.tmp / "vault"
+        self.vault.mkdir()
+        self.state_path = self.tmp / "conversation_deliveries.json"
+        self.scores_path = self.tmp / "answer_scores.json"
+        self.candidates_path = self.tmp / "question_candidates.json"
+        self.sent: list[str] = []
+        self.prompts: list[str] = []
+        self.fallbacks: list[dict] = []
+        self.minted: list[tuple[str, str]] = []
+        self.rotation: list[str] = []
+        diagnostics = mock.patch.object(engine, "record_learning_failure")
+        self.diagnostic = diagnostics.start()
+        self.addCleanup(diagnostics.stop)
+
+    # -- injected collaborators -------------------------------------------
+
+    def _ai(self, response=None, error=None):
+        def call(prompt, _model):
+            self.prompts.append(prompt)
+            if error is not None:
+                raise error
+            return response if response is not None else turn_json()
+
+        return call
+
+    def _send(self, transport=confirmed_send):
+        def send(message):
+            self.sent.append(message)
+            return transport(message)
+
+        return send
+
+    def _fallback(self, **kwargs):
+        self.fallbacks.append(kwargs)
+
+    def _minter(self, question_id, followups):
+        new_id = f"{question_id}{chr(ord('a') + len(self.minted))}"
+        self.minted.append((new_id, followups[0]))
+        return [(new_id, followups[0])]
+
+    def _rotation_updater(self, question_id):
+        self.rotation.append(question_id)
+
+    def run_turn(self, answer_text=ANSWER, question_id=QUESTION_ID, **overrides):
+        kwargs = {
+            "source_id": f"answer:{question_id}",
+            "question_id": question_id,
+            "question_text": QUESTION,
+            "question_category": "A",
+            "answer_text": answer_text,
+            "planned_question": {"id": "B1", "category": "B", "text": "What came next?"},
+            "state_path": self.state_path,
+            "vault_root": self.vault,
+            "sweep": False,
+            "status_resolver": ready_status,
+            "ai_call": self._ai(),
+            "telegram_send": self._send(),
+            "prompt_builder": lambda payload: "SYNTHETIC TURN PROMPT",
+            "followup_minter": self._minter,
+            "rotation_updater": self._rotation_updater,
+            "fallback": self._fallback,
+        }
+        kwargs.update(overrides)
+        return engine.run_post_answer_turn(**kwargs)
+
+    def entries(self):
+        return json.loads(self.state_path.read_text(encoding="utf-8"))["entries"]
+
+    def only_session(self):
+        sessions = conversation.list_sessions(vault_root=self.vault)
+        self.assertEqual(len(sessions), 1, sessions)
+        return conversation.load_session(sessions[0]["session_id"], vault_root=self.vault)
+
+    def seed_score(self, question_id, richness=0.75):
+        data = json.loads(self.scores_path.read_text(encoding="utf-8")) if self.scores_path.exists() \
+            else {"version": 1, "scores": []}
+        data["scores"].append({
+            "question_id": question_id,
+            "answered_at": "2026-08-11",
+            "category": "A",
+            "story_function": "scene",
+            "focus": None,
+            "signals": {"words": 42},
+            "richness_score": richness,
+        })
+        self.scores_path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class ConfirmedTurnTests(EngineTestCase):
+    def test_confirmed_turn_is_one_message(self):
+        outcome = self.run_turn()
+
+        self.assertEqual(self.sent, [TURN_MESSAGE])  # ONE message, not two
+        self.assertEqual((outcome.status, outcome.reason), ("confirmed", "telegram_confirmed"))
+        self.assertEqual(self.fallbacks, [])
+        # Follow-up minted through the A14 -> A14a suffix chain, rotation retargeted.
+        self.assertEqual(self.minted, [("A14a", FOLLOWUP_TEXT)])
+        self.assertEqual(self.rotation, ["A14a"])
+        self.assertEqual(outcome.followup_id, "A14a")
+
+        session = self.only_session()
+        roles = [turn["role"] for turn in session["turns"]]
+        self.assertEqual(roles, ["user", "lifehug"])
+        self.assertEqual(session["turns"][1]["question_id"], "A14a")
+        self.assertEqual(session["extracted"]["candidate_ideas"],
+                         [{"text": "What did he machine in that barn?"}])
+        entry = self.entries()[engine.turn_key(session["session_id"], 1)]
+        self.assertEqual((entry["status"], entry["reason"]), ("confirmed", "telegram_confirmed"))
+        self.assertEqual(entry["attempts"], 1)
+
+    def test_confirmed_replay_is_noop(self):
+        first = self.run_turn()
+        ai = mock.Mock(side_effect=AssertionError("duplicate generation"))
+        telegram = mock.Mock(side_effect=AssertionError("duplicate send"))
+        second = self.run_turn(ai_call=ai, telegram_send=telegram)
+
+        self.assertEqual(first.status, "confirmed")
+        self.assertEqual((second.status, second.reason, second.attempted),
+                         ("confirmed", "already_confirmed", False))
+        ai.assert_not_called()
+        telegram.assert_not_called()
+        self.assertEqual(len(self.only_session()["turns"]), 2)
+
+
+class AmbiguousTests(EngineTestCase):
+    def test_ambiguous_never_auto_retried_and_no_fallback_ack(self):
+        first = self.run_turn(telegram_send=self._send(ambiguous_send))
+        self.assertEqual(first.status, "ambiguous")
+        # The turn may have reached Telegram — a fallback ack would risk a
+        # duplicate voice, so nothing else goes out.
+        self.assertEqual(self.fallbacks, [])
+        self.assertEqual(self.minted, [])
+
+        session = self.only_session()
+        entry = self.entries()[engine.turn_key(session["session_id"], 1)]
+        self.assertEqual(entry["operator_action"], "verify Telegram before retrying")
+
+        ai = mock.Mock(side_effect=AssertionError("blind retry"))
+        second = self.run_turn(ai_call=ai)
+        self.assertEqual((second.status, second.reason, second.attempted),
+                         ("ambiguous", "ambiguous_not_retried", False))
+        ai.assert_not_called()
+        self.assertEqual(self.fallbacks, [])
+
+    def test_pre_send_ambiguous_position_is_written_before_the_send(self):
+        observed = {}
+
+        def send(message):
+            observed["entries"] = json.loads(self.state_path.read_text())["entries"]
+            return confirmed_send(message)
+
+        self.run_turn(telegram_send=send)
+        entry = next(iter(observed["entries"].values()))
+        self.assertEqual((entry["status"], entry["reason"]), ("ambiguous", "send_in_progress"))
+
+
+class FallbackTests(EngineTestCase):
+    def test_provider_unavailable_falls_back_to_todays_behavior(self):
+        telegram = mock.Mock(side_effect=AssertionError("no turn may be sent"))
+        outcome = self.run_turn(status_resolver=down_status, telegram_send=telegram)
+
+        self.assertEqual((outcome.status, outcome.reason), ("skipped", "provider_unavailable"))
+        self.assertTrue(outcome.fallback_used)
+        self.assertEqual(len(self.fallbacks), 1)
+        # The ack is told honestly whether a follow-up is pending, and the
+        # planned bank question is handed to the separate follow-up message.
+        self.assertEqual(self.fallbacks[0]["planned_question"], {"id": "B1", "category": "B",
+                                                                 "text": "What came next?"})
+        self.assertEqual(self.fallbacks[0]["question_id"], QUESTION_ID)
+        telegram.assert_not_called()
+
+    def test_keyless_provider_reports_no_unattended_provider(self):
+        outcome = self.run_turn(status_resolver=keyless_status)
+        self.assertEqual((outcome.status, outcome.reason), ("skipped", "no_unattended_provider"))
+        self.assertTrue(outcome.fallback_used)
+
+    def test_provider_error_falls_back(self):
+        outcome = self.run_turn(ai_call=self._ai(error=AIUnavailableError("synthetic")))
+        self.assertEqual((outcome.status, outcome.reason), ("failed", "provider_unavailable"))
+        self.assertEqual(len(self.fallbacks), 1)
+
+    def test_definitive_send_rejection_falls_back(self):
+        outcome = self.run_turn(telegram_send=self._send(rejected_send))
+        self.assertEqual(outcome.status, "failed")
+        self.assertTrue(outcome.fallback_used)
+        self.assertEqual(len(self.fallbacks), 1)
+        # No follow-up is minted for a message the user never received.
+        self.assertEqual(self.minted, [])
+
+    def test_lint_reject_falls_back(self):
+        cases = {
+            "two_questions": turn_json(
+                message="Diesel and hay. What was the field like? And who baled it?"
+            ),
+            "overlong": turn_json(message="x" * 4000),
+            "banned_phrase": turn_json(
+                message='That must have been hard. Tell me about "the north field".'
+            ),
+            "unparseable": "I am not JSON at all.",
+        }
+        for label, generated in cases.items():
+            with self.subTest(case=label):
+                self.setUp()  # a fresh synthetic vault per case
+                outcome = self.run_turn(ai_call=self._ai(response=generated))
+                self.assertEqual((outcome.status, outcome.reason),
+                                 ("failed", "malformed_generation"))
+                self.assertEqual(self.sent, [])
+                self.assertEqual(len(self.fallbacks), 1)
+
+
+class TurnShapeTests(EngineTestCase):
+    def _continue_session(self, answers):
+        """Drive N sequential answers through the engine in one session."""
+        outcomes = []
+        for index, answer in enumerate(answers):
+            outcomes.append(self.run_turn(answer_text=answer, question_id=QUESTION_ID))
+        return outcomes
+
+    def test_question_free_turn(self):
+        outcome = self.run_turn(ai_call=self._ai(response=turn_json(
+            message="Diesel and cut hay. I can smell that barn from here.",
+            followup=None,
+        )))
+        self.assertEqual(outcome.status, "confirmed")
+        self.assertTrue(outcome.question_free)
+        self.assertEqual(self.minted, [])       # nothing minted
+        self.assertEqual(self.rotation, [])     # rotation untouched
+
+    def test_curfew_and_cap_gates_transfer(self):
+        # plan_adaptive_followup returned None (curfew / 3-a-day cap / pass
+        # transition): our initiative is spent, so the turn is question-free
+        # and a model that asks anyway is rejected rather than sent.
+        outcome = self.run_turn(
+            planned_question=None,
+            ai_call=self._ai(response=turn_json(
+                message="Diesel and cut hay. What was the north field like?",
+                followup="What was the north field like?",
+            )),
+        )
+        self.assertEqual((outcome.status, outcome.reason), ("failed", "malformed_generation"))
+        self.assertIn("question_not_permitted", outcome.lint_ids)
+        self.assertEqual(self.sent, [])
+
+        self.setUp()
+        outcome = self.run_turn(
+            planned_question=None,
+            ai_call=self._ai(response=turn_json(message="Diesel and cut hay — I can smell it.",
+                                                followup=None)),
+        )
+        self.assertEqual(outcome.status, "confirmed")
+        self.assertEqual(self.minted, [])
+
+    def test_third_exchange_exit_shape_and_cap(self):
+        first = self.run_turn(answer_text=ANSWER)
+        second = self.run_turn(answer_text=SECOND_ANSWER)
+        self.assertEqual([o.status for o in (first, second)], ["confirmed", "confirmed"])
+        self.assertEqual(len(self.minted), 2)  # exchanges 1 and 2 carry initiative
+
+        # Exchange 3 is the exit-friendly door: it receives and pays out, but
+        # asks nothing — stopping there has to feel like a good place to rest.
+        # (The shape is decided with the incoming answer already recorded, so
+        # it is keyed on the user-turn count including this exchange's.)
+        manifest = engine._manifest()
+        def shape_for(user_turns):
+            return engine.decide_turn_shape(
+                {"mode": "chat", "turns": [{"role": "user", "text": "x"}] * user_turns},
+                manifest=manifest,
+                planned_question={"id": "B1"},
+            )
+
+        self.assertEqual(shape_for(1).position, "opening")
+        self.assertEqual(shape_for(2).position, "mid_arc")
+        self.assertTrue(shape_for(2).question_allowed)
+        self.assertEqual(shape_for(3).position, "third_exchange_exit_friendly")
+        self.assertFalse(shape_for(3).question_allowed)
+        self.assertEqual(shape_for(4).position, "past_target")
+        self.assertFalse(shape_for(4).question_allowed)
+
+        third = self.run_turn(
+            answer_text=THIRD_ANSWER,
+            ai_call=self._ai(response=turn_json(
+                message="A baler kept alive with parts he made himself. That is a whole "
+                        "portrait of him in one sentence.",
+                followup=None,
+            )),
+        )
+        self.assertEqual(third.status, "confirmed")
+        self.assertEqual(len(self.minted), 2)  # no new initiative spent
+
+        # And past the target the user keeps going: we keep receiving, never
+        # hard-stopping, still without spending question initiative.
+        fourth = self.run_turn(
+            answer_text="He taught me to listen for when the belt slipped.",
+            ai_call=self._ai(response=turn_json(
+                message="Listening for the belt — that is the kind of knowing you only "
+                        "get by standing next to someone.",
+                followup=None,
+            )),
+        )
+        self.assertEqual(fourth.status, "confirmed")
+        self.assertEqual(len(self.only_session()["turns"]), 8)
+
+
+class SingleFlightTests(EngineTestCase):
+    def test_single_flight_mint(self):
+        first = self.run_turn()
+        session_id = self.only_session()["session_id"]
+
+        # A concurrent second entry arrives with the same session already
+        # advanced: the store's compare-and-set rejects it, and the loser
+        # sends nothing at all (not even a fallback ack — the winner's turn
+        # is the voice).
+        original = conversation.append_turn
+
+        def conflicting_append(*args, **kwargs):
+            raise conversation.TurnConflictError("a concurrent writer won")
+
+        with mock.patch.object(conversation, "append_turn", conflicting_append):
+            second = self.run_turn(answer_text=SECOND_ANSWER)
+
+        self.assertEqual(first.status, "confirmed")
+        self.assertEqual((second.status, second.reason), ("skipped", "turn_already_minted"))
+        self.assertFalse(second.fallback_used)
+        self.assertEqual(self.fallbacks, [])
+        self.assertEqual(self.sent, [TURN_MESSAGE])
+        self.assertIs(conversation.append_turn, original)
+        self.assertEqual(len(conversation.load_session(session_id,
+                                                       vault_root=self.vault)["turns"]), 2)
+
+
+class CloseTests(EngineTestCase):
+    def _fixed_clock(self, moment):
+        patch = mock.patch.object(engine, "_now", lambda: moment)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def test_idle_timeout_files_partial_chat_silently(self):
+        self.seed_score(QUESTION_ID)
+        self.run_turn()  # one answer, then the user walks away mid-chat
+        session_id = self.only_session()["session_id"]
+        telegram = mock.Mock(side_effect=AssertionError("no-nag: nothing may be sent"))
+        ai = mock.Mock(side_effect=AssertionError("no closing generation"))
+
+        later = datetime.now(timezone.utc) + timedelta(hours=5)
+        outcomes = engine.close_expired_sessions(
+            now=later,
+            vault_root=self.vault,
+            state_path=self.state_path,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            ai_call=ai,
+            telegram_send=telegram,
+            status_resolver=ready_status,
+        )
+
+        self.assertEqual([o.session_id for o in outcomes], [session_id])
+        self.assertTrue(outcomes[0].silent)
+        telegram.assert_not_called()
+        ai.assert_not_called()
+
+        session = conversation.load_session(session_id, vault_root=self.vault)
+        self.assertEqual(session["status"], "closed")
+        self.assertEqual(session["close"]["reason"], "idle_timeout")
+        self.assertFalse(session["close"]["takeaway_delivered"])
+        self.assertEqual(session["close"]["takeaway"], "")
+        self.assertEqual(session["close"]["filed"], [QUESTION_ID])
+        # The answer itself stays filed — durability is per turn, not per close.
+        scores = json.loads(self.scores_path.read_text())["scores"]
+        self.assertEqual(scores[0]["richness_score"], 0.75)
+
+    def test_completed_chat_closing_takeaway(self):
+        self.run_turn(answer_text=ANSWER)
+        self.run_turn(answer_text=SECOND_ANSWER)
+        session_id = self.only_session()["session_id"]
+
+        outcome = engine.close_session_now(
+            session_id,
+            reason="done",
+            state_path=self.state_path,
+            vault_root=self.vault,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            ai_call=lambda _prompt, _model: json.dumps({"message": CLOSING_MESSAGE}),
+            telegram_send=self._send(),
+            prompt_builder=lambda payload: "SYNTHETIC CLOSING PROMPT",
+        )
+
+        self.assertTrue(outcome.takeaway_delivered)
+        self.assertEqual(self.sent[-1], CLOSING_MESSAGE)
+        session = conversation.load_session(session_id, vault_root=self.vault)
+        self.assertTrue(session["close"]["takeaway_delivered"])
+        self.assertEqual(session["close"]["takeaway"], CLOSING_MESSAGE)
+        self.assertEqual(session["close"]["insight_receipts_count"], 2)
+        entry = self.entries()[engine.close_key(session_id)]
+        self.assertEqual((entry["status"], entry["reason"]), ("confirmed", "telegram_confirmed"))
+
+    def test_closing_with_a_trailing_question_is_never_sent(self):
+        self.run_turn(answer_text=ANSWER)
+        self.run_turn(answer_text=SECOND_ANSWER)
+        session_id = self.only_session()["session_id"]
+        before = len(self.sent)
+
+        outcome = engine.close_session_now(
+            session_id,
+            state_path=self.state_path,
+            vault_root=self.vault,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            ai_call=lambda _p, _m: json.dumps(
+                {"message": "Thank you for that. What should we talk about next time?"}
+            ),
+            telegram_send=self._send(),
+            prompt_builder=lambda payload: "SYNTHETIC CLOSING PROMPT",
+        )
+        self.assertFalse(outcome.takeaway_delivered)
+        self.assertEqual(len(self.sent), before)  # behavior rule 8: no trailing question
+
+    def test_engagement_appended_to_answer_scores(self):
+        self.seed_score(QUESTION_ID)
+        self.seed_score("A14a")
+        self.run_turn(answer_text=ANSWER)
+        self.run_turn(answer_text=SECOND_ANSWER, question_id="A14a")
+        session_id = self.only_session()["session_id"]
+
+        engine.close_session_now(
+            session_id,
+            reason="done",
+            state_path=self.state_path,
+            vault_root=self.vault,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            ai_call=lambda _p, _m: json.dumps({"message": CLOSING_MESSAGE}),
+            telegram_send=self._send(),
+            prompt_builder=lambda payload: "SYNTHETIC CLOSING PROMPT",
+        )
+
+        scores = {s["question_id"]: s for s in json.loads(self.scores_path.read_text())["scores"]}
+        for question_id in (QUESTION_ID, "A14a"):
+            engagement = scores[question_id]["engagement"]
+            # #119's authoritative names for the shared fields.
+            self.assertEqual(
+                sorted(engagement),
+                ["close_reason", "continuation_past_exit", "session_id", "session_turns",
+                 "turn_length_trajectory"],
+            )
+            self.assertEqual(engagement["session_id"], session_id)
+            self.assertEqual(engagement["close_reason"], "done")
+            self.assertFalse(engagement["continuation_past_exit"])
+            self.assertIn(engagement["turn_length_trajectory"],
+                          {"expanding", "flat", "contracting"})
+            # Richness is never overwritten.
+            self.assertEqual(scores[question_id]["richness_score"], 0.75)
+            self.assertEqual(scores[question_id]["signals"], {"words": 42})
+
+    def test_candidate_ideas_filed_with_conversation_provenance(self):
+        self.run_turn(answer_text=ANSWER)
+        self.run_turn(answer_text=SECOND_ANSWER)
+        session_id = self.only_session()["session_id"]
+        engine.close_session_now(
+            session_id,
+            state_path=self.state_path,
+            vault_root=self.vault,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            ai_call=lambda _p, _m: json.dumps({"message": CLOSING_MESSAGE}),
+            telegram_send=self._send(),
+            prompt_builder=lambda payload: "SYNTHETIC CLOSING PROMPT",
+        )
+        candidates = json.loads(self.candidates_path.read_text())["candidates"]
+        self.assertEqual(len(candidates), 1)  # de-duplicated across both turns
+        self.assertEqual(candidates[0]["provenance"], "conversation")
+        self.assertEqual(candidates[0]["text"], "What did he machine in that barn?")
+
+    def test_zero_turn_session_closes_silently(self):
+        session = conversation.open_session("chat", "telegram", vault_root=self.vault)
+        telegram = mock.Mock(side_effect=AssertionError("no-nag"))
+        outcome = engine.close_session_now(
+            session["session_id"],
+            reason="idle_timeout",
+            state_path=self.state_path,
+            vault_root=self.vault,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            telegram_send=telegram,
+        )
+        self.assertTrue(outcome.silent)
+        self.assertEqual(outcome.detail, "silent_no_nag")
+        telegram.assert_not_called()
+
+    def test_idle_timeout_knobs_come_from_interaction_yaml(self):
+        manifest = engine._manifest()
+        chat = {"mode": "chat", "session_id": "conv-20260811-120000-abcdef", "turns": []}
+        talk = {"mode": "conversation", "session_id": "conv-20260811-120000-abcdef", "turns": []}
+        self.assertEqual(engine.idle_timeout_minutes(chat, manifest), 120)
+        self.assertEqual(engine.idle_timeout_minutes(talk, manifest), 30)
+        opened = datetime(2026, 8, 11, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertFalse(engine.is_idle_expired(chat, manifest=manifest,
+                                                now=opened + timedelta(minutes=119)))
+        self.assertTrue(engine.is_idle_expired(chat, manifest=manifest,
+                                               now=opened + timedelta(minutes=121)))
+
+
+class PrivacyTests(EngineTestCase):
+    def test_metadata_only_ledger_and_diagnostics(self):
+        diagnostics = []
+        self.diagnostic.side_effect = lambda *a, **k: diagnostics.append((a, k))
+        self.run_turn(ai_call=self._ai(error=AIUnavailableError(ANSWER)))
+        self.run_turn(answer_text=SECOND_ANSWER)
+
+        serialized = json.dumps(diagnostics) + self.state_path.read_text(encoding="utf-8")
+        for private in (ANSWER, SECOND_ANSWER, QUESTION, TURN_MESSAGE, FOLLOWUP_TEXT,
+                        "SYNTHETIC TURN PROMPT"):
+            self.assertNotIn(private, serialized)
+        self.assertIn(QUESTION_ID, serialized)
+
+
+class RuntimeLintSourceTests(EngineTestCase):
+    def test_length_cap_is_sourced_from_lints_yaml_not_pinned_here(self):
+        source = (SYSTEM / "conversation_delivery.py").read_text(encoding="utf-8")
+        self.assertNotIn("1200", source)
+        config = engine._lints_config()
+        self.assertEqual(config["cap.turn_chars"], 1200)
+        blocking, _ = engine.lint_outgoing("x" * 1201, question_allowed=False, config=config)
+        self.assertIn("length_caps", blocking)
+
+    def test_advisory_lints_do_not_block_the_send(self):
+        # A closed (yes/no) question is a question_grammar_audit finding —
+        # advisory, so the turn still goes out and the count is ledgered.
+        outcome = self.run_turn(ai_call=self._ai(response=turn_json(
+            message='Diesel and cut hay. Was "the north field" the one by the road?',
+        )))
+        self.assertEqual(outcome.status, "confirmed")
+        entry = self.entries()[engine.turn_key(self.only_session()["session_id"], 1)]
+        self.assertGreaterEqual(entry["advisory_lints"], 1)
+
+
+class RetryTests(EngineTestCase):
+    def test_turn_retry_requires_confirmation_for_ambiguous(self):
+        self.run_turn(telegram_send=self._send(ambiguous_send))
+        session_id = self.only_session()["session_id"]
+
+        blocked = engine.retry_turn(
+            session_id, 1,
+            state_path=self.state_path, vault_root=self.vault,
+            status_resolver=ready_status,
+            ai_call=mock.Mock(side_effect=AssertionError("blind retry")),
+            telegram_send=mock.Mock(side_effect=AssertionError("blind retry")),
+        )
+        self.assertEqual((blocked.status, blocked.reason), ("ambiguous", "ambiguous_not_retried"))
+
+        retried = engine.retry_turn(
+            session_id, 1,
+            confirm_not_sent=True,
+            state_path=self.state_path, vault_root=self.vault,
+            status_resolver=ready_status,
+            ai_call=self._ai(response=turn_json(message="Diesel and cut hay, still with me.",
+                                                followup=None)),
+            telegram_send=self._send(),
+        )
+        self.assertEqual(retried.status, "confirmed")
+        self.assertEqual(self.fallbacks, [])  # an operator retry never sends an ack
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -52,6 +52,7 @@ EXPECTED_DATA_PATHS = {
     "focus_recommendations",
     "import_sources",
     "jobs",
+    "conversation_deliveries",
     "learning_failures",
     "legacy_focus_recommendations",
     "manual_sources",
@@ -188,7 +189,7 @@ class VaultContractTests(unittest.TestCase):
         self.assertEqual(vault_paths.FRAMEWORK_PATHS, exported["framework_paths"])
         self.assertEqual(list(exported["data_paths"]), sorted(exported["data_paths"]))
         self.assertEqual(list(exported["framework_paths"]), sorted(exported["framework_paths"]))
-        self.assertEqual(exported["identity"]["framework_version"], 150)
+        self.assertEqual(exported["identity"]["framework_version"], 153)
         self.assertEqual(
             exported["identity"]["content_digest"],
             vault_paths._contract_digest(exported),

--- a/tests/test_v121_answer_ack_delivery.py
+++ b/tests/test_v121_answer_ack_delivery.py
@@ -14,8 +14,11 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import root_parent_tmp  # noqa: E402
 import answer_ack  # noqa: E402
+import conversation_delivery as turn_engine  # noqa: E402
 import answer_ack_delivery as delivery  # noqa: E402
 import lifehug_core as core  # noqa: E402
 import process_answer  # noqa: E402
@@ -170,6 +173,34 @@ class DeliveryContractTests(unittest.TestCase):
 
 
 class OrderingTests(unittest.TestCase):
+    """The post-answer ordering contract, now via the v153 turn engine.
+
+    Issue #116 replaced the ack + separate-follow-up pair with ONE
+    conversation turn that degrades to exactly this pair when no provider is
+    seated — which is the case in these tests. The assertions below are
+    therefore unchanged; only the isolation is new: the engine writes a
+    session document and a delivery ledger, so both are pointed at a
+    synthetic vault (never the developer's real one, never ~/Workspace/dave).
+    """
+
+    def setUp(self):
+        # ROOT.parent, never tempfile's default: on macOS /var is a symlink
+        # and vault_paths refuses to traverse symlinks (tests/tempdirs.py).
+        vault = root_parent_tmp(self, ROOT, prefix="lifehug-v153-ordering-") / "vault"
+        vault.mkdir()
+        for patch in (
+            mock.patch.object(turn_engine, "VAULT_ROOT", vault),
+            mock.patch.object(
+                turn_engine, "DELIVERY_STATE_FILE", vault / "state" / "conversation_deliveries.json"
+            ),
+            # The engine keeps its own diagnostic channel; without this the
+            # synthetic failures below would append to the real vault's
+            # learning-failures log.
+            mock.patch.object(turn_engine, "record_learning_failure"),
+        ):
+            patch.start()
+            self.addCleanup(patch.stop)
+
     def test_commit_then_ack_then_followup_exact_order(self):
         events = []
         followup = {"id": "B1", "category": "B", "text": "What came next?"}
@@ -261,6 +292,21 @@ class OrderingTests(unittest.TestCase):
 
 
 class ProcessAnswerIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        vault = root_parent_tmp(self, ROOT, prefix="lifehug-v153-integration-") / "vault"
+        vault.mkdir()
+        for patch in (
+            mock.patch.object(turn_engine, "VAULT_ROOT", vault),
+            mock.patch.object(
+                turn_engine,
+                "DELIVERY_STATE_FILE",
+                vault / "state" / "conversation_deliveries.json",
+            ),
+            mock.patch.object(turn_engine, "record_learning_failure"),
+        ):
+            patch.start()
+            self.addCleanup(patch.stop)
+
     def test_main_has_durable_file_and_first_commit_before_acknowledgment(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_v150_conversation_store.py
+++ b/tests/test_v150_conversation_store.py
@@ -545,15 +545,25 @@ class LintTests(unittest.TestCase):
 
 
 class NoBehaviorChangeGuardTests(unittest.TestCase):
-    """Subtest 6: no module under system/ other than lifehug.py and the two
-    new modules references a `conversation` import — proves this PR is
-    reachable only through the new conversation-* subcommands and direct
-    imports of the new modules themselves.
+    """Subtest 6: the conversation store/lints have exactly ONE live consumer.
+
+    v150 (issue #115) shipped this module pair as infrastructure with no
+    consumer at all. v153 (issue #116) gave it exactly one:
+    ``conversation_delivery`` — the turn engine — which ``process_answer``
+    reaches lazily. The guard's purpose is unchanged: keep the store and the
+    lint engine from acquiring ad-hoc callers that would fork the assembly
+    order or the lint list. Any NEW name appearing here is a review question,
+    not a test to relax.
     """
 
     def test_no_other_module_imports_conversation_or_conversation_lints(self):
         pattern = re.compile(r'^\s*(?:from|import)\s+conversation(?:_lints)?\b', re.MULTILINE)
-        exempt = {"lifehug.py", "conversation.py", "conversation_lints.py"}
+        exempt = {
+            "lifehug.py",
+            "conversation.py",
+            "conversation_lints.py",
+            "conversation_delivery.py",  # v153: the one sanctioned consumer
+        }
         offenders = []
         for path in sorted(SYSTEM.glob("*.py")):
             if path.name in exempt:


### PR DESCRIPTION
**Contract stage — implementation to follow on this branch.**

Closes #116. Wave 2, PR 3 of the Conversation Interaction build (owner-approved design, 2026-08-11). This PR currently carries only the implementation contract: `docs/pr-specs/116-conversation-turn-engine.md`.

What the contract pins:

- `system/conversation_delivery.py`: post-answer conversation turns — receipt + payout + cued follow-up in ONE message, question-free turns when the behavior contract says, exit-friendly third exchange, closing takeaway, silent no-nag closes for partial chats.
- `process_answer.py::run_post_answer_delivery` rewired from ack + separate adaptive follow-up to the turn engine, with a non-negotiable FALLBACK to today's exact ack+follow-up behavior on any provider/lint/send failure — never silence, never worse than today.
- Exactly-once delivery ledger (`state/conversation_deliveries.json`) copied from `answer_ack_delivery` semantics: confirmed/skipped/failed/ambiguous, ambiguous never auto-retried.
- Config keys `conversation_model` / `router_model` / `arc_plan_model`; engagement capture at close into `state/answer_scores.json`; `conversation-status` / `conversation-close` / `conversation-turn-retry` CLI.
- Depends on the Wave-1 scaffold + session store/builders (merged-code-wins clause in the contract). Arc cards are PR 5 — this engine ships arc-card-absent minimal behavior. No platform changes.

Note: `system/version.json` is deliberately not bumped at contract stage (the version-bump CI context will go green with the implementation commit; sibling wave PRs land in owner-decided order).

🤖 Generated with Claude Fable 5 via Claude Code

https://claude.ai/code/session_0116gPPwxxMvJ1CdyqwjJQFc