### PR TITLE
Contract: the arc planner — weekly arc cards, timeline-gap consumer, daily attach (#118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,13 @@ After setup, create a cron job for daily question delivery. The cron task should
 2. Let that script pick, send, pin when supported, and mark sent only after delivery succeeds
 3. Avoid custom state mutation outside the script
 
+The delivered message body is the day's pre-planned arc card when one is live
+(v154, issue #118): after the id parse, the script reads `lifehug.py arc-card
+<QID> --daily-text` — a pure file read, no AI on the daily path — and uses the
+card's framing plus the question when it prints something, today's format when
+it prints nothing (reengagement picks, an expired queue, an uncarded question).
+The `[QID]` marker is unchanged in either case.
+
 Real runs of the daily, weekly, and monthly scripts enqueue into the durable
 single-writer worker under `state/jobs/`; dry-runs remain direct and
 non-mutating. On macOS, install the persistent worker plus canonical schedules
@@ -286,7 +293,9 @@ python3 system/lifehug.py weekly-maintenance
 LIFEHUG_WEEKLY_DRY_RUN=1 system/weekly_maintenance.sh
 ```
 
-The weekly Loop segment compiles offline, lints sources, applies safe source fixes only when lint finds them, classifies capped new sources, updates the quality profile, auto-promotes candidates under caps, writes the next planned queue, scans gaps in dry-run mode, reports progress, and autocommits real changes.
+The weekly Loop segment compiles offline, lints sources, applies safe source fixes only when lint finds them, classifies capped new sources, updates the quality profile, auto-promotes candidates under caps, writes the next planned queue, **plans one arc card per queued question**, scans gaps in dry-run mode, reports progress, and autocommits real changes.
+
+**Arc cards (v154, issue #118).** Directly after the queue is written, `lifehug.py arc-plan` plans one card per queued question — an opening framing quoted from the author's own record plus 2–4 typed follow-up intents (unfilled five-slot scene probes, neighborhood siblings, timeline gaps phrased as landmark anchors, studio format slots, a Mirror "sit with" line on self-arc questions, demonstrated-knowledge summaries). Deterministic cards are always computed first, so a model failure, invalid output, or a keyless machine never costs the week its plan; keyless runs additionally emit the prompt to `state/agent_tasks/arcs/` for `arc-plan --from-response`. Cards live in `state/arc_cards.json` and expire with the queue. **This shell step is the parity spec for the platform's `arc_plan` step** — a cap or gate the platform needs must appear here first.
 
 Both loops run on any machine (v92/v123). Check `python3 system/lifehug.py ai-status` first: a ready direct local model, gateway, or keyed provider runs fully unattended; unavailable providers use agent-task mode — follow `skills/maintenance/SKILL.md` (pre-complete AI work via `--emit-prompts`/`--emit-task`/`--from-response` before the run; a keyless cron emits its AI work to `state/agent_tasks/` instead of failing). The direct local route is fail-closed: it never sends source material to another provider when its configured endpoint is offline or rejected. Local and OpenClaw loopback transports bypass proxies and refuse redirects; their errors expose metadata only. The Anthropic SDK is optional; if absent, status stays keyless instead of exiting.
 
@@ -297,7 +306,7 @@ python3 system/lifehug.py monthly-research
 LIFEHUG_MONTHLY_DRY_RUN=1 system/monthly_research.sh
 ```
 
-The monthly Loop segment compiles, detects gaps, opens a small capped set of new research neighborhoods, refreshes the self-knowledge arc if needed, recommends Focuses, reports progress, and autocommits real changes.
+The monthly Loop segment compiles, detects gaps, opens a small capped set of new research neighborhoods, refreshes the self-knowledge arc if needed, recommends Focuses, **offers at most one conversation thread** from a neighborhood that has record to open from and somewhere left to go (never repeated within a quarter — v154), reports progress, and autocommits real changes.
 
 Review candidate questions before they enter the daily flow:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ Help the user configure a daily cron job or scheduled task that:
 3. Runs `system/daily_question.sh`, which picks the question, sends it, and marks it delivered only after success
 4. If an update is available, mentions it briefly after the question
 
+**Daily message composition (v154, issue #118).** After the question id is parsed, the script asks for the day's pre-planned arc card (`lifehug.py arc-card <QID> --daily-text`). This is a PURE FILE READ — the daily path stays AI-free. When a live card with an opening exists, the message body becomes the card's framing (one sentence quoted from the author's own record) followed by the question; the `[QID]` marker keeps `ask.format_question`'s exact shape, so the id parse and the answer-filing flow are unchanged. When there is no live card — a reengagement pick, an expired queue, a question the weekly run never carded — the command prints nothing and today's message format stands. `LIFEHUG_DAILY_DRY_RUN=1 system/daily_question.sh` shows the would-be attach (or its absence).
+
 The cron commits and pushes any pending changes first (ensuring nothing is lost), then checks for updates and delivers the question. The question should be delivered warmly, not robotically.
 
 **Delivery options:**
@@ -1288,6 +1290,7 @@ The daily question cron job handles outbound delivery. For inbound (receiving an
 ### Weekly
 - Run `python3 system/lifehug.py weekly-maintenance` (or `LIFEHUG_WEEKLY_DRY_RUN=1 system/weekly_maintenance.sh` to inspect first)
 - This compiles, source-lints/fixes safe metadata, classifies a capped batch of unclassified sources, updates the quality profile, **synthesizes the Mirror** (`mirror-compile`, v100 — keyless runs emit the task to `state/agent_tasks/mirror/`), auto-promotes the best candidates under caps (backlog-aware, quality-gated, semantically deduped — v68/v69), writes the next queue, scans gaps, reports progress, surfaces pending Focus recommendations, **runs `doctor`** (queue expiry, backlog age, cadence stalls, zombie Focuses, roster continuity), and commits real changes. Every learning step is failure-wrapped. **The Telegram message is a short counts-first summary (v86, issue #35)** — classification ✅/❌ with one-line errors, candidates new/promoted/backlog, queue, coverage, doctor verdict — built by `lifehug.py weekly-summary` from state files; the full step-by-step output is persisted to `state/reports/weekly-YYYY-MM-DD.md` (committed, phone-readable via GitHub, browsable at the wiki viewer's `/views/reports`). Dry-run previews the candidate promotion gate and the summary too.
+- **Arc cards (v154, issue #118)**: directly after the queue is written, the weekly run plans one arc card per queued question (`lifehug.py arc-plan`) — an opening framing quoted from the author's own record plus 2–4 typed follow-up intents drawn from unfilled five-slot scene probes, neighborhood siblings, timeline gaps (landmark anchors, never "what year"; ≤1 per card, ≤`LIFEHUG_WEEKLY_ARC_GAP_MAX`=3 per week), studio format slots, a Mirror "sit with" line on self-arc questions, and demonstrated-knowledge summaries. Deterministic cards are ALWAYS computed first; the one model call per run enriches them, and any failure or invalid output keeps the deterministic plan. Keyless runs write the deterministic cards immediately and emit the prompt to `state/agent_tasks/arcs/` (`arc-plan --from-response` upgrades cards in place). Cards land in `state/arc_cards.json` and expire with the queue.
 - Review any manual source findings that `source-lint --fix` could not safely repair
 - Review classifier/candidate output in the weekly Telegram summary, then check queue balance, progress, and whether any Focus is ready for a deliverable
 
@@ -1297,7 +1300,8 @@ The daily question cron job handles outbound delivery. For inbound (receiving an
 - Review new research-neighborhood candidates before promotion. New gap neighborhoods only open when the planner's expansion urgency ≥ 0.25 (the archive deepens before it widens — v69)
 - Review Focus recommendations and approve only the ones that should become Focuses — **approval creates the Focus for real** (category scaffolded + starter questions seeded via `roadmap.focus_new`; never a zombie — v69)
 - Check if any categories are ready for drafting (GREEN)
-- Perennial re-asks generate automatically (`perennials --generate-due`) and one old answer is resurfaced with a reflection question
+- Perennial re-asks generate automatically (`perennials --generate-due`) and one old answer is resurfaced with a reflection question — both now close as an invitation to talk ("Reply and we'll talk it through"), the mechanism otherwise unchanged (v154)
+- **Conversation-thread offers (v154, issue #118)**: `arc-thread-offers` adds at most `LIFEHUG_MONTHLY_THREAD_OFFERS` (default 1) ignorable line to the monthly summary, offering a research neighborhood that has record to open from AND somewhere left to go. Offers are recorded in `state/arc_cards.json` and never repeat within a quarter
 
 ### At Milestones
 - **Skeleton complete** (all categories have at least one answer): Celebrate, preview what depth pass will look like

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -28,6 +28,10 @@ followup_model: "anthropic/claude-opus-4-6"
 # research_model: "claude-opus-4-20250514"
 # Story/source classification:
 # classify_model: "claude-sonnet-4-20250514"
+# Weekly arc planning (one arc card per queued question — the opening framing
+# and 2-4 follow-up intents the daily chat runs inside). One call per weekly
+# run; falls back to classify_model, then to the classifier's default:
+# arc_plan_model: "claude-sonnet-5"
 # Wiki page synthesis (system/lifehug.py compile); falls back to deterministic
 # excerpts when the selected shared provider is unavailable:
 # wiki_model: "claude-opus-4-20250514"

--- a/docs/adr/0002-interaction-pattern.md
+++ b/docs/adr/0002-interaction-pattern.md
@@ -87,3 +87,42 @@ the free, no-API-key daily run exactly as free as it is today.
   every future AI-driven surface, not just this one; it would only need
   revisiting if the definition/runtime/seat split itself proved
   unworkable in practice, which nothing in this PR's scope tests.
+
+## Amendment (2026-08-11, issue #118): the arc-card contract
+
+The vault-contract addition above ((c), landed in #115) reserved
+`state/arc_cards.json`; the weekly arc planner (#118) fills it, and this
+amendment ratifies the DATA contract everything downstream inherits, so
+there is one findable answer rather than a second ADR.
+
+- **The intent vocabulary is CLOSED** — exactly six kinds: `scene_slot`,
+  `neighborhood_sibling`, `timeline_gap`, `studio_slot`, `sit_with`,
+  `demonstrated_knowledge_summary`. `conversation.ARC_INTENT_KINDS` is the
+  single definition; the turn engine, the evals, and the platform's
+  transport all read it from there. Adding a kind is a schema bump, not an
+  additive change (per the recurring-defect doctrine: one importable
+  definition, guarded by a test, rather than a vocabulary retyped at four
+  call sites).
+- **Intents are intents, not scripts.** A card carries 2–4 typed objects
+  naming what the exchange should reach for; the turn engine phrases them
+  live. The card never contains scripted follow-up text.
+- **Cards live and die with the question queue.** `queue_generated_at` and
+  `expires_at` are copied verbatim from `state/question_queue.json`, and a
+  card is live only while unexpired AND its question is still queued or
+  sent. Staleness therefore needs no expiry code of its own: nothing
+  attaches, and the day degrades to the pre-arc message format.
+- **Openings are receipted or null.** An opening cites `opening_receipts`
+  that must resolve to real answers/sources; an unresolvable receipt costs
+  the card its opening, never its intents. No card text may contain "what
+  year" (research.md §4's landmark-anchor rule, enforced as a validation
+  lint).
+- **The OSS weekly shell step is the parity SPEC** for the platform's
+  `StepSpec("arcs", "arc_plan", llm=True)`. A cap, gate, or fallback that
+  the platform needs must appear in `system/weekly_maintenance.sh` and the
+  CLI first; a platform-side gate absent from the OSS step is a parity
+  merge-blocker on the platform PR.
+- **Ratified deviation (d) is now load-bearing, not aspirational**: the
+  daily attach is a pure file read (`lifehug.py arc-card <QID>
+  --daily-text`) that prints the assembled message or nothing at all, so
+  the daily loop's AI-free property is enforced by the seam's SHAPE, not
+  by convention.

--- a/docs/pr-specs/118-arc-planner.md
+++ b/docs/pr-specs/118-arc-planner.md
@@ -1,0 +1,381 @@
+# Contract: arc-planner (issue #118)
+
+Conversation Interaction, Wave 2 PR5 (design §4, §11; owner-ratified
+2026-08-11). The daily Chat's ~3 exchanges become a coherent, pre-planned
+mini-arc: the WEEKLY loop plans one **arc card** per queued question —
+an opening framing plus 2–4 follow-up *intents* (not scripted text) —
+and the daily loop merely ATTACHES the card. This is the owner-ratified
+deviation from decision C: the daily loop is deliberately AI-free on both
+mediums (OSS convention "daily = free"; the platform's delivery-selection
+sandbox is keyless by construction), so arc GENERATION lives in the weekly
+loop and daily stays attach-only. Related issues: #98, #99, #103.
+
+## Why
+
+Today's three chained daily questions are unrelated to each other — the
+owner's named pain ("feels weird"). The planner queue already decides WHAT
+to ask this week; nothing plans HOW an exchange around each question should
+unfold. Meanwhile three verified gap seams sit unclaimed: (1)
+`timeline.compute_gaps()` emits typed gaps that are display-only — no
+question-generation consumer exists anywhere; (2) unfilled five-slot scene
+probes are counted (book.py) but never planned against at exchange level;
+(3) research neighborhoods are output-oriented arcs with no conversation
+entry point. The arc planner claims all three and gives the (separately
+contracted) turn engine a skeleton to execute live.
+
+## Binding facts
+
+Facts verified against origin/main at c30be1d (v149). Re-verify at
+implementation time; sibling Wave-1/2 PRs may land first (see "Sequencing").
+
+- **Version**: main is v149; bump `system/version.json` to the next
+  unclaimed version at implementation time (check main then — wave siblings
+  are claiming numbers in parallel).
+- **Weekly seam**: `system/weekly_maintenance.sh` — the planner-queue step
+  is `run_learning_step "planner_queue" python3 "$SCRIPT_DIR/lifehug.py"
+  planner-queue --limit "$QUEUE_LIMIT" --arc-max "$ARC_MAX" --expires-days
+  "$EXPIRES_DAYS"` (line ~273). The new arcs step goes DIRECTLY AFTER it
+  (and after the `QUEUE_OUT` capture), so cards are planned against the
+  queue that was just written. The script's existing idioms are binding:
+  `run_learning_step` wrapping (failures recorded via
+  `record_learning_failure`, never kill the flow), the `KEYLESS` variable
+  (already computed at line ~180 via `lifehug.py ai-status`), the
+  `$AGENT_TASKS_DIR` emit convention, the dry-run block (lines ~155–170)
+  gaining a matching preview step, and the report-section table gaining an
+  `Arc cards:ARCS_OUT` row.
+- **Queue shape** (`state/question_queue.json`, written by
+  `question_planner.build_queue`): items carry `question_id`, `category`,
+  `group`, `focus`, `source`, `source_type`, `story_function`, `objective`,
+  `status` ("queued"→"sent" via `ask.mark_queue_item_sent`), `reason`;
+  top-level `generated_at`, `expires_at` (default 8 days,
+  `future_timestamp(expires_days)`).
+- **Daily seam**: `system/daily_question.sh` builds the Telegram TEXT at
+  lines ~252–256 (`TEXT="📖 Lifehug — Daily Question\n\n${QUESTION_OUTPUT}\n\n
+  (Answer whenever you want — voice or text)"`) after parsing QUESTION_ID
+  from `ask.py --dry-run` output. `ask.py` picks via
+  `pick_next_question` (reengagement pre-empts the queue at line ~104;
+  planned queue head at ~109; rotation fallback below). The daily path must
+  stay AI-FREE — attach is a pure file read.
+- **Timeline gaps**: `timeline.compute_gaps(periods, entity_lineup,
+  event_lineup, unplaced_entities, unplaced_events)` (system/timeline.py:581)
+  returns `[{kind, period, message, hint?}]` with kinds `no_chrono`,
+  `no_events`, `all_undated`, `thin_lineup`, `unplaced_events`,
+  `unplaced_entities`. `timeline.timeline_data()` (line 619) assembles the
+  inputs and calls it — the arc planner consumes gaps through that assembled
+  payload (or by replicating its exact load sequence), it does NOT
+  re-derive gap logic. This PR is the FIRST non-display consumer. Gap kinds
+  consumed for intents: `no_events`, `all_undated`, `unplaced_events`.
+  Phrasing rule (research.md §4, hard): landmark anchors, NEVER "what
+  year" — the gap hints already model this.
+- **Five-slot probes**: classifier stamps `scene_slots` per source
+  (classify_story.py schema); slot names are `book.FIVE_SLOTS =
+  ("what_happened", "when_and_where", "who_was_there", "thought_and_felt",
+  "what_it_says_about_me")` — NAMES MUST MATCH (the book.py header warns a
+  mismatch reads as permanently-empty slots; contract test precedent
+  tests/test_v75_book.py). Read via the same pattern as
+  `book._load_scene_slots()` (classifications keyed by
+  `source_path` "answers/<QID>.md"). "What it says about you" is the
+  highest-value follow-up when empty (research.md §1).
+- **Neighborhood siblings**: `state/question_candidates.json` candidates
+  carry `neighborhood_id`, `status` (promotable statuses per
+  question_candidates.py), `story_function`, `text`.
+  `state/neighborhoods.json` (research_expand.py / neighborhoods.py):
+  neighborhoods have `id`, `title`, `type`, `target_output`, `arc` slots
+  (story_function + question_id + status), and derived readiness via
+  `neighborhoods.apply_readiness` (`readiness_status`, `ready_to_draft`,
+  `answered_completeness`).
+- **Studio format slots**: `format_readiness.compute_readiness(framework,
+  categories, format_readiness.load_bank_questions())` computes per-slot
+  coverage for `templates/<format>.json` frameworks (slots keyed to story
+  functions, same verdict vocabulary as book.py); `book.gap_question_ids()`
+  already feeds the planner's chapter boost.
+- **Sit-with tensions**: the Mirror's "## Sit with" section lives in the
+  compiled page at `mirror.mirror_page_path()` (wiki/self/mirror.md),
+  exactly 3 bullets by contract (`mirror.REQUIRED_SECTIONS`,
+  `validate_mirror_body`). Self-arc questions are those whose queue
+  `story_function` ∈ `question_planner.SELF_FUNCTIONS = ("self_image",
+  "value", "fear", "contradiction", "perception_by_others", "growth_edge")`.
+- **Two-sentence rule** (research.md §1, hard): opening framing = ONE
+  context sentence quoting/referencing the author's own record + the
+  question. Never paraphrase the author's account back with altered
+  details — quote exactly (reconsolidation rule). A cold-start coverage
+  question may still prove memory in framing ("You've told me about X;
+  this is somewhere we haven't been yet —") without faking continuity.
+- **AI provider**: `ai_provider.call_ai(prompt: str, model: str) -> str`
+  (fail-closed; raises `AIUnavailableError` in agent-task mode). Model
+  resolution for this surface: config `arc_plan_model` → config
+  `classify_model` → `classify_story.DEFAULT_MODEL` ("claude-sonnet-5").
+  Document the new key in `config.yaml.example` next to `classify_model`.
+- **Keyless emit pattern**: mirror.py `emit_task` / classify-story
+  `--emit-prompts` — write prompt file(s) + `manifest.json` with an
+  `ingest_command` naming the `--from-response` completion path, under
+  `$AGENT_TASKS_DIR/arcs`.
+- **Vault contract**: new durable state file ⇒ entry in
+  `system/vault_contract.json` `data_paths` + resolvable via
+  `vault_paths.py data-path <name>` and included in `git-paths` (tracked).
+  As of drafting there is NO `arc_cards` entry. The Wave-1 conversation ADR
+  (interaction pattern + vault-contract additions) may have landed first —
+  if the entry already exists on main, do not duplicate it; this PR's ADR
+  duty is then only to reference it.
+- **Engagement profile hook** (cross-contract, #119): PR6 adds an
+  `engagement` block to `state/quality_profile.json`. The arc planner reads
+  it GUARDED (`load_profile().get("engagement")`, absent → no-op) for
+  arc-topic/opener-framing bias only. Do not block on PR6; do not invent
+  the block's schema here beyond "by_story_function/by_category buckets with
+  a clamped `multiplier`" (PR6's contract owns it).
+- **Parity (BINDING, platform merge-blocker)**: the weekly shell step IS
+  the parity SPEC. The platform transports it verbatim as
+  `StepSpec("arcs", "arc_plan", llm=True)` + `LlmPurpose "arc_plan"`; any
+  cap, limit, gate, or fallback the platform needs MUST appear in the OSS
+  shell step / CLI first — a platform-side gate not present here is a
+  parity merge-blocker on the platform PR. Write the shell step (env-var
+  knobs, exit behavior, keyless branch) knowing it will be read as spec.
+
+## Scope
+
+**In:**
+1. `state/arc_cards.json` — the arc-card store, schema below, registered in
+   `system/vault_contract.json` (tracked) so weekly/daily autocommit and
+   the platform selection layer can carry it.
+2. `system/arc_planner.py` — pure planning module (no Telegram, no direct
+   provider import at module scope): card store read/write, deterministic
+   intent derivation, AI prompt builder, response validation/ingest, expiry
+   logic. CLI via new `lifehug.py` subcommands (repo pattern:
+   `cmd_arc_plan` thin wrapper):
+   - `lifehug.py arc-plan [--limit N] [--dry-run] [--emit-tasks DIR]
+     [--from-response PATH] [--model M]`
+   - `lifehug.py arc-card <QUESTION_ID> [--daily-text]` — pure read; with
+     `--daily-text` prints the assembled daily message text when a live
+     (unexpired, current-queue) card with an opening exists, else prints
+     nothing and exits 0 (the shell attach hinges on empty-vs-nonempty).
+3. Weekly step in `weekly_maintenance.sh` (after planner_queue; keyed +
+   keyless branches; dry-run preview; report section; summary counts).
+4. Daily attach in `daily_question.sh` + `ask.py` (AI-free, read-only).
+5. Monthly conversation-thread offers + resurfacing/perennial copy shift in
+   `monthly_research.sh` (details below).
+6. ADR (docs/adr/) for the arc-card contract IF the Wave-1 ADR hasn't
+   already ratified the vault-contract addition — otherwise extend/reference.
+7. Tests + dry-run walkthrough evidence.
+
+**Out** (explicitly deferred / owned elsewhere):
+- Executing intents live (turn engine — Wave-2 PR3) and session documents
+  (Wave-1 PR2). This PR produces DATA the turn engine consumes; if PR3 has
+  not merged yet, cards simply improve the daily message text and wait.
+- Router, deflection, story→conversation (PR4).
+- Engagement profile computation (PR6, issue #119).
+- Platform transport step + `_SELECTION_DATA_KEYS`/SELECTION_VAULT_PATHS
+  additions (platform Wave-3 PR10; parity note above binds its shape).
+- Reengagement redesign: reengagement (silent ≥4 days) PRE-EMPTS the queue
+  exactly as today; its question has no planned card by design (minimal arc
+  is synthesized at session-open by PR3, not here).
+
+## The arc-card schema (binding)
+
+`state/arc_cards.json`:
+
+```json
+{
+  "version": 1,
+  "generated_at": "2026-08-16T09:00:00Z",
+  "queue_generated_at": "<question_queue.json generated_at verbatim>",
+  "expires_at": "<question_queue.json expires_at verbatim>",
+  "source": "model | deterministic | mixed",
+  "cards": [
+    {
+      "question_id": "A14",
+      "opening": "one context sentence from the record + the question, or null",
+      "opening_receipts": ["A7", "sources/manual/2026-03-01-ghana.md"],
+      "intents": [
+        {"kind": "scene_slot", "slot": "who_was_there", "note": "…"},
+        {"kind": "neighborhood_sibling", "candidate_id": "…", "neighborhood_id": "…", "note": "…"},
+        {"kind": "timeline_gap", "gap_kind": "unplaced_events", "period": "denver-years", "note": "landmark-anchor phrasing"},
+        {"kind": "studio_slot", "format": "letter", "slot": "…", "note": "…"},
+        {"kind": "sit_with", "text": "<the Sit-with line, quoted>"},
+        {"kind": "demonstrated_knowledge_summary", "receipts": ["A7", "A22"], "note": "…"}
+      ],
+      "planned_at": "…",
+      "planner": "model | deterministic"
+    }
+  ]
+}
+```
+
+Rules:
+- Exactly the six intent `kind` values above — this is the shared
+  vocabulary the turn engine, evals, and the platform inherit; adding a
+  kind later is a schema bump.
+- 2–4 intents per card (design §1). Deterministic fallback may emit fewer
+  (minimum 1) but never zero cards for a queued question.
+- `opening` is nullable: null ⇒ daily uses today's message format
+  unchanged. When present it must satisfy the two-sentence rule and cite
+  `opening_receipts` (answer ids / source paths actually on record —
+  validation rejects openings whose receipts don't resolve; session honesty
+  rule: never fabricate memory).
+- No intent note, opening, or any card text may contain the phrase "what
+  year" (case-insensitive) — a validation lint, mirroring research.md §4.
+- Expiry: cards live and die WITH the queue (`expires_at` copied verbatim).
+  A card is "live" only if unexpired AND its `question_id` appears in the
+  current queue (status queued or sent). `arc-card` returns nothing for
+  dead cards. Stale-plan fallback is therefore automatic: when the queue
+  expires, `ask.py` already falls back to the rotation pick, no card
+  attaches, and the (future) session opens with a minimal arc — chats keep
+  working with a stale plan, degraded not broken.
+- Idempotent regeneration: re-running arc-plan for the same queue
+  (`queue_generated_at` match) replaces the file wholesale; a model-planned
+  card is not clobbered by a later deterministic re-run in the same week
+  unless `--force` (keyless completion via `--from-response` UPGRADES
+  deterministic cards in place, `planner` flips to "model").
+
+## Implementation notes (seams, not diffs)
+
+- **Deterministic fallback** (always computed first; the model pass, when
+  available, replaces/enriches): for each queued item —
+  scene_slot intents from unfilled `FIVE_SLOTS` of the answered material in
+  the item's category (empty-classification ⇒ all five unfilled ⇒ prefer
+  `what_it_says_about_me` + one concrete slot); neighborhood_sibling
+  intents from same-`neighborhood_id` candidates (promotable statuses)
+  when the queued question or its category maps into a neighborhood arc;
+  timeline_gap intent when a consumed-kind gap touches the item's
+  category/focus era or global `unplaced_events` exist (cap: at most one
+  timeline_gap intent per card, at most `LIFEHUG_WEEKLY_ARC_GAP_MAX`
+  (default 3) across the week's cards — the timeline whispers, per the
+  wiki-harvest precedent); sit_with intent ONLY for self-arc items
+  (`SELF_FUNCTIONS`), quoting one current Sit-with line; studio_slot from
+  the focus's format framework's unfilled slots (guarded import, silent
+  no-op when unavailable — the book/chapter-boost precedent);
+  demonstrated_knowledge_summary only when the item's category has ≥2
+  answered questions (gradual introduction, phase-3 A: small summaries
+  before dossiers), receipts = up to 3 real answer ids. Deterministic
+  openings: permitted without a model ONLY as verbatim-quote framings
+  ("You wrote: \"…\" — " + question) built from an on-record answer in the
+  same category; otherwise null.
+- **Model pass**: one prompt per run (not per card — bounded cost, weekly
+  cadence) carrying the queue, the deterministic intent material, mission
+  excerpt, and the craft rules (two-sentence rule, landmark anchors, no
+  "what year", quote-exactly); response = strict JSON matching the card
+  schema; `validate_cards()` rejects schema/lint violations and falls back
+  to the deterministic cards (never a broken file, never a lost week).
+  Keyed weekly branch mirrors the classify branch; keyless branch writes
+  deterministic cards AND emits the prompt + manifest to
+  `$AGENT_TASKS_DIR/arcs` (`ingest_command: lifehug.py arc-plan
+  --from-response <path>`), reported with the "⏸ keyless — task emitted,
+  not a failure" convention.
+- **Daily attach**: in `daily_question.sh`, after QUESTION_ID is parsed,
+  `ARC_TEXT=$(python3 "$SCRIPT_DIR/lifehug.py" arc-card "$QUESTION_ID"
+  --daily-text || true)`; non-empty ⇒ TEXT uses it (still prefixed
+  "📖 Lifehug — Daily Question" and suffixed with the answer-hint line);
+  empty ⇒ today's TEXT unchanged. `--daily-text` composes: opening framing
+  (which embeds or is followed by the question text) — it must include the
+  `[QID]` marker exactly as `format_question` does, because
+  daily_question.sh's ID parse and the answer-filing flow key on it.
+  Dry-run daily (`LIFEHUG_DAILY_DRY_RUN=1`) prints the would-be attach.
+- **Monthly** (`monthly_research.sh`):
+  1. Conversation-thread offers: a new deterministic step marks
+     neighborhoods "conversation-ready" (derived, computed like
+     `apply_readiness`: status active/draft with unanswered arc slots and
+     ≥1 answered or promoted slot — i.e., there is somewhere to go AND
+     record to open from) and writes at most
+     `LIFEHUG_MONTHLY_THREAD_OFFERS` (default 1) offer line(s) into the
+     monthly Telegram summary ("I've been wanting to ask about the Ghana
+     years — shall we?" register), recording offered neighborhood ids in
+     `state/arc_cards.json` under a top-level `thread_offers` list
+     (`{neighborhood_id, offered_at, month}`) so offers never repeat within
+     a quarter (the second-voice never-repeat precedent, scoped lighter).
+  2. Perennial/echo copy shift: the existing resurfacing message (lines
+     ~350–391) and perennial re-asks keep their mechanisms (last year's
+     answer attached — already built) but their closing line becomes a
+     conversation opener ("Reply and we'll talk it through — it saves as a
+     reflection on <id>") — copy-only change, reply handling stays whatever
+     is live (ingest path today; sessions once PR3/PR4 land).
+- **Where quality/engagement bias applies**: arc-topic choice among
+  OPTIONAL intents (siblings, studio slots) may be ordered by
+  `quality_profile` multipliers (guarded, and engagement per the
+  cross-contract note). Never drops scene_slot/timeline_gap/sit_with
+  intents — behavioral signals tune pacing/framing, never whether hard
+  questions get asked (owner: drain is not negative).
+- **Convergence property (owner-set) — acceptance criteria**: on a
+  synthetic fixture vault containing each gap type, assert the named
+  consumer fires:
+  - timeline `unplaced_events` / `all_undated` ⇒ ≥1 `timeline_gap` intent
+    exists across the week's cards, phrased without "what year";
+  - unfilled five-slot scenes ⇒ `scene_slot` intents naming exact
+    `FIVE_SLOTS` members;
+  - a self-arc queued item + a Mirror page with Sit-with bullets ⇒
+    `sit_with` intent quoting one;
+  - a neighborhood with pending siblings ⇒ `neighborhood_sibling` intent;
+  - an unfilled format-framework slot for the item's focus ⇒ `studio_slot`
+    intent (or documented silent no-op when framework absent);
+  - a category with ≥2 answers ⇒ `demonstrated_knowledge_summary` with
+    resolvable receipts.
+  Downstream halves of the loop (answers → classification →
+  timeline-retire; mirror responses → weekly edition) are owned by existing
+  mechanisms and PR6 — this PR's convergence duty ends at "every detectable
+  gap type emits a conversation input."
+
+## Test plan
+
+New file `tests/test_arc_planner.py` (unittest, repo standard; synthetic
+fixture vault via the tempdirs/tempdir conventions — NEVER
+~/Workspace/dave). Named subtests:
+
+- `test_deterministic_cards_for_every_queued_item` (cards ≥ queue length
+  match, ≥1 intent each, 2–4 cap respected when material allows)
+- `test_intent_vocabulary_closed` (unknown kind rejected by validator)
+- `test_scene_slot_names_match_book_five_slots` (parity with
+  `book.FIVE_SLOTS` — the v75 contract-test pattern)
+- `test_timeline_gap_consumer_fires_and_never_says_what_year`
+- `test_sit_with_only_for_self_arc_items`
+- `test_demonstrated_knowledge_requires_two_answers_and_real_receipts`
+- `test_opening_receipts_must_resolve` (fabricated receipt ⇒ opening
+  rejected ⇒ null opening, card survives)
+- `test_expiry_follows_queue_and_dead_cards_never_attach`
+- `test_daily_text_contains_qid_marker_and_is_empty_without_live_card`
+- `test_from_response_upgrades_deterministic_cards`
+- `test_model_failure_falls_back_to_deterministic` (call_ai raising ⇒
+  cards still written, learning failure recorded)
+- `test_thread_offers_never_repeat_within_quarter`
+- convergence-property subtests per the acceptance list above
+
+Prove with: `python3 -m unittest tests.test_arc_planner -v` and the full
+`python3 -m unittest discover -s tests -p "test_*.py"` (CI runs 3.11 + 3.14;
+no new dependencies — the repo is deliberately dependency-free).
+
+## Launch-and-verify
+
+No `serve_wiki.py` surface is touched, so no Playwright walkthrough is
+required (BUILDING.md §4). The runnable evidence is the three dry-runs, to
+be pasted into a PR comment:
+
+```
+LIFEHUG_WEEKLY_DRY_RUN=1  bash system/weekly_maintenance.sh   # shows the arc-plan preview step after planner-report
+LIFEHUG_DAILY_DRY_RUN=1   bash system/daily_question.sh       # shows the would-be attach (or its absence) for today's pick
+LIFEHUG_MONTHLY_DRY_RUN=1 bash system/monthly_research.sh     # shows the thread-offer preview
+python3 system/lifehug.py arc-plan --dry-run                  # prints planned cards, writes nothing
+python3 system/lifehug.py arc-card <QID> --daily-text         # prints the attach text for a live card
+```
+
+Pass = the weekly dry run previews one card per queued question with typed
+intents; the daily dry run shows the opening-framing message for a carded
+question and today's unchanged format otherwise; nothing in any preview
+contains "what year"; no state file is written by any dry run.
+
+## Definition of done
+
+- [ ] Code + tests pass locally (`python3 -m unittest discover -s tests`)
+- [ ] `system/version.json` bumped (version, released, changelog sized to
+      user impact; `framework_files` gains `system/arc_planner.py`)
+- [ ] `system/vault_contract.json` gains `arc_cards` (or references the
+      Wave-1 entry if already landed) and `config.yaml.example` documents
+      `arc_plan_model`
+- [ ] AGENTS.md/CLAUDE.md updated where described behavior changed (daily
+      message composition, weekly steps)
+- [ ] ADR written/extended for the arc-card contract (coordinates with the
+      Wave-1 conversation ADR — one findable answer, not two)
+- [ ] Parity note honored: the shell step readable as the platform spec;
+      twin transport tracked on lifehug-platform (Wave-3 PR10) — file or
+      link the twin issue in the same session per AGENTS.md Cross-Medium
+      Parity
+- [ ] Issue #118 commented with verification results; dry-run evidence
+      embedded in a PR comment
+- [ ] No reference to ~/Workspace/dave anywhere in code or tests (hard
+      boundary)

--- a/system/arc_planner.py
+++ b/system/arc_planner.py
@@ -1,0 +1,1397 @@
+#!/usr/bin/env python3
+"""Lifehug — the weekly arc planner (issue #118, Conversation Interaction Wave 2).
+
+The daily Chat's ~3 exchanges used to be three unrelated questions. This
+module plans, once a week, ONE **arc card** per queued question — an opening
+framing plus 2–4 follow-up *intents* (not scripted text) — so the daily loop
+merely ATTACHES a card that already exists. That split is the ratified
+deviation from design decision C: arc GENERATION lives in the weekly loop
+precisely so the daily loop stays AI-FREE by construction (``arc-card
+--daily-text`` is a pure file read).
+
+The spec this implements is ``interactions/conversation/plan/arc-templates.md``
+(read verbatim into the model prompt via
+``conversation.read_conversation_definition``); the card schema below is the
+authority the store helpers in ``conversation.py`` defer to (their mid-flight
+amendment M1).
+
+``state/arc_cards.json``::
+
+    {
+      "version": 1,
+      "generated_at": "...",
+      "queue_generated_at": "<question_queue.json generated_at verbatim>",
+      "expires_at":        "<question_queue.json expires_at verbatim>",
+      "source": "model | deterministic | mixed",
+      "cards": [
+        {
+          "question_id": "A14",
+          "opening": "one context sentence drawn from the record, or null",
+          "opening_receipts": ["A7", "sources/manual/2026-03-01-ghana.md"],
+          "intents": [{"kind": "<one of ARC_INTENT_KINDS>", ...}],
+          "planned_at": "...",
+          "planner": "model | deterministic"
+        }
+      ],
+      "thread_offers": [{"neighborhood_id": "...", "offered_at": "...", "month": "2026-08"}]
+    }
+
+Binding rules:
+
+- The intent ``kind`` vocabulary is CLOSED — ``conversation.ARC_INTENT_KINDS``
+  is the single definition (the turn engine, the evals, and the platform all
+  inherit it); adding a kind is a schema bump.
+- 2–4 intents per card. The deterministic pass may emit fewer (minimum 1) but
+  never zero cards for a queued question.
+- ``opening`` is nullable. When present it obeys research.md §1's two-sentence
+  rule (one context sentence from the author's own record, then the question)
+  and every id/path in ``opening_receipts`` must resolve on disk — an opening
+  citing a receipt that does not exist is dropped to null and the card
+  survives (session honesty: never fabricate memory).
+- No card text may contain "what year" (case-insensitive) — research.md §4's
+  landmark-anchor rule, enforced as a validation lint.
+- Cards live and die WITH the queue: ``expires_at`` is copied verbatim, and a
+  card is "live" only while unexpired AND its question is still in the current
+  queue. Stale-plan fallback therefore needs no code — ``ask.py`` falls back to
+  the rotation pick, nothing attaches, and the day degrades to today's format.
+
+Every vault read/write goes through ``vault_paths``; the planner never sends a
+message and imports no AI provider at module scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import conversation
+from lifehug_core import (
+    REPO_DIR,
+    SYSTEM_DIR,
+    load_config,
+    now_utc,
+    split_frontmatter,
+    write_json,
+    write_text,
+)
+from vault_paths import read_vault_text, vault_data_path
+
+# The closed intent vocabulary has exactly one definition (recurring-defect
+# doctrine): conversation.py's, shared with the store and the turn engine.
+INTENT_KINDS = conversation.ARC_INTENT_KINDS
+
+#: Timeline gap kinds this planner turns into conversation input. The other
+#: kinds compute_gaps() emits (no_chrono, thin_lineup, unplaced_entities,
+#: date_contradiction) stay display-only — they name a curation chore, not a
+#: question the author can answer.
+CONSUMED_GAP_KINDS = ("no_events", "all_undated", "unplaced_events")
+
+MIN_INTENTS = 1          # deterministic floor — a card with one intent is still a card
+TARGET_MIN_INTENTS = 2   # design §1 target band …
+MAX_INTENTS = 4          # … 2–4 intents per card
+
+#: The timeline whispers (the wiki-harvest precedent): at most one timeline_gap
+#: intent per card, and this many across the whole week.
+DEFAULT_GAP_MAX = 3
+
+#: Monthly conversation-thread offers, and how long an offered neighborhood
+#: stays quiet afterwards (a quarter — the second-voice never-repeat precedent,
+#: scoped lighter).
+DEFAULT_THREAD_OFFERS = 1
+THREAD_OFFER_QUIET_DAYS = 92
+
+#: research.md §4, hard: landmark anchors, never a demand for a calendar year.
+BANNED_PHRASE = "what year"
+
+DEFAULT_MODEL_FALLBACK = "claude-sonnet-5"  # classify_story.DEFAULT_MODEL, resolved lazily
+
+
+class ArcPlanError(Exception):
+    """A planning input or an ingested response was unusable."""
+
+
+# ---------------------------------------------------------------------------
+# Vault I/O — every path resolves through vault_paths, with a vault_root
+# override so tests point at a synthetic vault without rebinding the process.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_root(vault_root: str | Path | None) -> Path:
+    return REPO_DIR if vault_root is None else Path(vault_root)
+
+
+def _data_path(name: str, root: Path) -> Path:
+    return vault_data_path(name, vault_root=root, framework_system_dir=SYSTEM_DIR)
+
+
+def _read_json(path: Path, root: Path, default):
+    try:
+        text = read_vault_text(path, vault_root=root)
+    except (FileNotFoundError, OSError):
+        return default
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return default
+
+
+def _read_text(path: Path, root: Path) -> str:
+    try:
+        return read_vault_text(path, vault_root=root)
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+def load_queue(*, vault_root: str | Path | None = None) -> dict:
+    """``state/question_queue.json`` as written by question_planner.build_queue."""
+    root = _resolve_root(vault_root)
+    data = _read_json(_data_path("question_queue", root), root, {})
+    return data if isinstance(data, dict) else {}
+
+
+def queued_items(queue: dict, *, limit: int | None = None,
+                 statuses: tuple[str, ...] = ("queued",)) -> list[dict]:
+    """Queue items in queue order, filtered by status."""
+    items = queue.get("queue")
+    if not isinstance(items, list):
+        return []
+    rows = [item for item in items
+            if isinstance(item, dict)
+            and str(item.get("status", "queued")) in statuses
+            and item.get("question_id")]
+    return rows[:limit] if limit else rows
+
+
+def _parse_time(value: object) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        moment = datetime.fromisoformat(raw[:-1] + "+00:00" if raw.endswith("Z") else raw)
+    except ValueError:
+        return None
+    return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Material collection — the gap seams this planner claims. Every collector is
+# individually guarded: a missing/oddly-shaped source silently contributes no
+# intents (the book/chapter-boost precedent) rather than costing the week its
+# cards.
+# ---------------------------------------------------------------------------
+
+
+def _five_slots() -> tuple[str, ...]:
+    """book.FIVE_SLOTS — the classifier's slot NAMES have one definition.
+
+    A name mismatch here reads as permanently-empty slots (book.py's own
+    header warns about exactly this), so the names are imported, never
+    retyped; tests/test_arc_planner.py pins the parity.
+    """
+    try:
+        import book  # noqa: PLC0415
+        slots = tuple(str(slot) for slot in book.FIVE_SLOTS)
+        return slots
+    except Exception:  # noqa: BLE001 — an unavailable book module is a silent no-op
+        return ()
+
+
+def collect_scene_slots(*, vault_root: str | Path | None = None) -> dict[str, dict[str, bool]]:
+    """``{question_id: {slot: filled}}`` from the classifier's scene_slots stamp.
+
+    Same read as ``book._load_scene_slots`` (classifications keyed by
+    ``source_path`` "answers/<QID>.md"), honoring a vault_root override so a
+    synthetic fixture vault works without rebinding the process.
+    """
+    slots = _five_slots()
+    if not slots:
+        return {}
+    root = _resolve_root(vault_root)
+    directory = _data_path("classifications", root)
+    if not directory.exists():
+        return {}
+    out: dict[str, dict[str, bool]] = {}
+    for path in sorted(directory.glob("*.json")):
+        data = _read_json(path, root, {})
+        if not isinstance(data, dict):
+            continue
+        source = str(data.get("source_path", "")).strip()
+        if not source.startswith("answers/") or not source.endswith(".md"):
+            continue
+        stamped = data.get("scene_slots") or {}
+        if not isinstance(stamped, dict):
+            continue
+        out[Path(source).stem] = {slot: bool(stamped.get(slot)) for slot in slots}
+    return out
+
+
+def collect_timeline_gaps(*, payload: dict | None = None) -> list[dict]:
+    """The consumed-kind gaps, read from ``timeline.timeline_data()``'s payload.
+
+    This is the FIRST non-display consumer of ``timeline.compute_gaps()`` — and
+    it consumes the ASSEMBLED payload rather than re-deriving gap logic, so the
+    two views can never disagree about what a gap is. ``payload`` may be
+    injected (tests assemble one with the real compute_gaps); otherwise the
+    real timeline is assembled, guarded.
+    """
+    if payload is None:
+        try:
+            import timeline  # noqa: PLC0415
+            payload = timeline.timeline_data()
+        except Exception:  # noqa: BLE001 — no timeline is a silent no-op
+            return []
+    if not isinstance(payload, dict):
+        return []
+    gaps: list[dict] = []
+    by_period = payload.get("gaps_by_period")
+    if isinstance(by_period, dict):
+        for rows in by_period.values():
+            if isinstance(rows, list):
+                gaps.extend(row for row in rows if isinstance(row, dict))
+    global_gaps = payload.get("global_gaps")
+    if isinstance(global_gaps, list):
+        gaps.extend(row for row in global_gaps if isinstance(row, dict))
+    return [gap for gap in gaps if str(gap.get("kind")) in CONSUMED_GAP_KINDS]
+
+
+def collect_sit_with(*, vault_root: str | Path | None = None) -> list[str]:
+    """The Mirror's "## Sit with" lines (exactly 3 by mirror.py's contract)."""
+    root = _resolve_root(vault_root)
+    page = _data_path("wiki", root) / "self" / "mirror.md"
+    body = _read_text(page, root)
+    if "## Sit with" not in body:
+        return []
+    tail = body.split("## Sit with", 1)[1].split("\n## ", 1)[0]
+    lines: list[str] = []
+    for raw in tail.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        cleaned = re.sub(r"^([-*]|\d+\.)\s+", "", stripped)
+        if cleaned != stripped:
+            lines.append(cleaned.strip())
+    return lines[:3]
+
+
+def collect_neighborhoods(*, vault_root: str | Path | None = None) -> dict:
+    """Sibling material: which neighborhood a question sits in, and its pending
+    siblings (promotable candidates sharing the neighborhood_id).
+
+    Returns ``{"by_question": {qid: nid}, "siblings": {nid: [candidate, ...]},
+    "neighborhoods": [...]}``.
+    """
+    root = _resolve_root(vault_root)
+    neighborhoods = _read_json(_data_path("neighborhoods", root), root, {})
+    candidates = _read_json(_data_path("question_candidates", root), root, {})
+    rows = neighborhoods.get("neighborhoods") if isinstance(neighborhoods, dict) else None
+    rows = [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
+    cand_rows = candidates.get("candidates") if isinstance(candidates, dict) else None
+    cand_rows = [row for row in cand_rows if isinstance(row, dict)] if isinstance(cand_rows, list) else []
+
+    try:
+        from question_candidates import PROMOTABLE_STATUSES  # noqa: PLC0415
+        promotable = set(PROMOTABLE_STATUSES)
+    except Exception:  # noqa: BLE001
+        promotable = {"candidate", "accepted", "deferred"}
+
+    by_id = {str(row.get("id")): row for row in cand_rows if row.get("id")}
+    by_question: dict[str, str] = {}
+    for neighborhood in rows:
+        nid = str(neighborhood.get("id") or "")
+        if not nid:
+            continue
+        for slot in neighborhood.get("arc") or []:
+            if not isinstance(slot, dict):
+                continue
+            raw_id = str(slot.get("question_id") or "").strip()
+            if not raw_id:
+                continue
+            by_question[raw_id] = nid
+            promoted = str(by_id.get(raw_id, {}).get("promoted_question_id") or "").strip()
+            if promoted:
+                by_question[promoted] = nid
+
+    siblings: dict[str, list[dict]] = {}
+    for candidate in cand_rows:
+        nid = str(candidate.get("neighborhood_id") or "")
+        if not nid or str(candidate.get("status", "candidate")) not in promotable:
+            continue
+        siblings.setdefault(nid, []).append(candidate)
+    return {"by_question": by_question, "siblings": siblings, "neighborhoods": rows}
+
+
+def collect_answers(*, vault_root: str | Path | None = None) -> dict:
+    """Answered material on record: ids per category, bodies, and answered dates.
+
+    Category is the answer id's leading letter(s) — the same convention the
+    question bank and every state index use.
+    """
+    root = _resolve_root(vault_root)
+    directory = _data_path("answers", root)
+    ids: list[str] = []
+    bodies: dict[str, str] = {}
+    dates: dict[str, str] = {}
+    if directory.exists():
+        for path in sorted(directory.glob("*.md")):
+            qid = path.stem
+            text = _read_text(path, root)
+            if not text:
+                continue
+            metadata, body = split_frontmatter(text)
+            ids.append(qid)
+            bodies[qid] = body.strip()
+            dates[qid] = str(metadata.get("answered_date", "") or "")
+    by_category: dict[str, list[str]] = {}
+    for qid in ids:
+        match = re.match(r"^([A-Za-z]+)", qid)
+        if match:
+            by_category.setdefault(match.group(1).upper(), []).append(qid)
+    return {"ids": ids, "bodies": bodies, "dates": dates, "by_category": by_category}
+
+
+def collect_studio_slots(items: list[dict], *, vault_root: str | Path | None = None,
+                         cards: list[dict] | None = None) -> dict[str, list[dict]]:
+    """Unfilled format-framework slots per focus id (guarded; silent no-op).
+
+    ``cards`` may be injected (readiness cards as produced by
+    ``format_readiness.readiness_for_focus``); otherwise they are computed for
+    the focuses this week's queue actually touches.
+    """
+    if cards is None:
+        wanted = {str(item.get("focus")) for item in items if item.get("focus")}
+        if not wanted:
+            return {}
+        try:
+            import format_readiness  # noqa: PLC0415
+            import roadmap as roadmap_mod  # noqa: PLC0415
+            from lifehug_core import QUESTIONS_FILE, parse_questions  # noqa: PLC0415
+            questions = parse_questions(QUESTIONS_FILE.read_text(encoding="utf-8"))
+            focuses = roadmap_mod.load_roadmap().get("focuses", [])
+            cards = []
+            for focus in focuses:
+                if str(focus.get("id")) not in wanted:
+                    continue
+                cards.extend(format_readiness.readiness_for_focus(focus, questions))
+        except Exception:  # noqa: BLE001 — no framework, no studio intents
+            return {}
+    out: dict[str, list[dict]] = {}
+    for card in cards or []:
+        if not isinstance(card, dict):
+            continue
+        focus_id = str(card.get("focus_id") or "")
+        for slot in card.get("slots") or []:
+            if not isinstance(slot, dict) or slot.get("filled"):
+                continue
+            out.setdefault(focus_id, []).append({
+                "format": str(card.get("format") or ""),
+                "slot": str(slot.get("id") or ""),
+                "label": str(slot.get("label") or ""),
+            })
+    return out
+
+
+def collect_quality_profile(*, vault_root: str | Path | None = None) -> dict:
+    """quality_profile + PR6's engagement block, both read GUARDED.
+
+    Behavioral signals order OPTIONAL intents only; they never drop a
+    scene_slot, timeline_gap, or sit_with intent (owner: drain is not
+    negative — pacing and framing may adapt, whether hard questions get asked
+    may not).
+    """
+    root = _resolve_root(vault_root)
+    profile = _read_json(_data_path("quality_profile", root), root, {})
+    return profile if isinstance(profile, dict) else {}
+
+
+def collect_material(items: list[dict], *, vault_root: str | Path | None = None,
+                     timeline_payload: dict | None = None,
+                     readiness_cards: list[dict] | None = None) -> dict:
+    """Everything the deterministic pass and the model prompt plan against."""
+    return {
+        "scene_slots": collect_scene_slots(vault_root=vault_root),
+        "timeline_gaps": collect_timeline_gaps(payload=timeline_payload),
+        "sit_with": collect_sit_with(vault_root=vault_root),
+        "neighborhoods": collect_neighborhoods(vault_root=vault_root),
+        "answers": collect_answers(vault_root=vault_root),
+        "studio_slots": collect_studio_slots(items, vault_root=vault_root, cards=readiness_cards),
+        "quality": collect_quality_profile(vault_root=vault_root),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Deterministic planning — ALWAYS computed first. The model pass, when a route
+# exists, replaces/enriches these cards; when it doesn't (keyless, failure,
+# invalid output) these ARE the week's cards. A queued question never ends the
+# week without one.
+# ---------------------------------------------------------------------------
+
+
+def _self_functions() -> tuple[str, ...]:
+    try:
+        from question_planner import SELF_FUNCTIONS  # noqa: PLC0415
+        return tuple(str(fn) for fn in SELF_FUNCTIONS)
+    except Exception:  # noqa: BLE001
+        return ("self_image", "value", "fear", "contradiction",
+                "perception_by_others", "growth_edge")
+
+
+def is_self_arc(item: dict) -> bool:
+    """A self-arc queue item — the SELF_ARC dimension the Mirror speaks to."""
+    return str(item.get("story_function", "")) in _self_functions()
+
+
+def _category_of(item: dict) -> str:
+    return str(item.get("category", "")).strip().upper()
+
+
+def _answered_in_category(item: dict, material: dict) -> list[str]:
+    answers = material.get("answers") or {}
+    by_category = answers.get("by_category") or {}
+    dates = answers.get("dates") or {}
+    ids = list(by_category.get(_category_of(item), []))
+    # Newest first — the freshest material is the most conversational.
+    return sorted(ids, key=lambda qid: (dates.get(qid, ""), qid), reverse=True)
+
+
+def _scene_slot_intents(item: dict, material: dict) -> list[dict]:
+    """Unfilled five-slot probes for the answered material in this category.
+
+    "What it says about you" is the highest-value follow-up when empty
+    (research.md §1), so it leads; one concrete slot follows it. With no
+    classification at all every slot reads unfilled — which is the correct
+    reading of a category with nothing on record yet.
+    """
+    slots = _five_slots()
+    if not slots:
+        return []
+    stamped = material.get("scene_slots") or {}
+    answered = _answered_in_category(item, material)
+    source_qid = ""
+    unfilled: list[str] = []
+    for qid in answered:
+        card = stamped.get(qid)
+        if card is None:
+            continue
+        missing = [slot for slot in slots if not card.get(slot)]
+        if missing:
+            source_qid, unfilled = qid, missing
+            break
+    if not unfilled:
+        # No classified material (or every slot filled on the ones we have) —
+        # an unanswered category reads as all five unfilled.
+        if any(stamped.get(qid) and not [s for s in slots if not stamped[qid].get(s)]
+               for qid in answered):
+            return []
+        unfilled = list(slots)
+        source_qid = answered[0] if answered else ""
+
+    ordered: list[str] = []
+    if "what_it_says_about_me" in unfilled:
+        ordered.append("what_it_says_about_me")
+    ordered.extend(slot for slot in unfilled if slot not in ordered)
+
+    intents: list[dict] = []
+    for slot in ordered[:2]:
+        note = f"the answer's {slot.replace('_', ' ')} is not on record yet"
+        if source_qid:
+            note += f" (nearest material: {source_qid})"
+        intent = {"kind": "scene_slot", "slot": slot, "note": note}
+        if source_qid:
+            intent["source_question_id"] = source_qid
+        intents.append(intent)
+    return intents
+
+
+def _sit_with_intent(item: dict, material: dict) -> list[dict]:
+    """Only for self-arc items, quoting ONE current Sit-with line verbatim.
+
+    The conversation invites toward a tension; it never adjudicates it.
+    """
+    if not is_self_arc(item):
+        return []
+    lines = material.get("sit_with") or []
+    if not lines:
+        return []
+    index = sum(ord(ch) for ch in str(item.get("question_id", ""))) % len(lines)
+    return [{"kind": "sit_with", "text": lines[index],
+             "note": "invite toward this tension; never adjudicate it"}]
+
+
+def _gap_note(gap: dict) -> str:
+    """Landmark-anchor phrasing, taken from the gap's own hint where it has one.
+
+    compute_gaps already models the rule ("dates arrive as landmark anchors …
+    never guessed years"); reusing its words is how this consumer inherits the
+    phrasing instead of inventing a second, driftable copy.
+    """
+    hint = str(gap.get("hint") or "").strip()
+    message = str(gap.get("message") or "").strip()
+    note = hint or message or "anchor this against a landmark the author already named"
+    return f"landmark-anchor phrasing — {note}"
+
+
+def _timeline_gap_intent(item: dict, material: dict, used: dict) -> list[dict]:
+    """At most one timeline_gap intent per card, capped across the week.
+
+    Period-scoped gaps prefer the item's own era (its focus/category slug
+    appearing in the period slug); global ``unplaced_events`` apply to anyone.
+    """
+    if used["gaps"] >= used["gap_max"]:
+        return []
+    gaps = material.get("timeline_gaps") or []
+    if not gaps:
+        return []
+    era_hints = {str(item.get("focus") or "").lower(), _category_of(item).lower()}
+    era_hints.discard("")
+
+    def era_match(gap: dict) -> bool:
+        period = str(gap.get("period") or "").lower()
+        return bool(period) and any(hint and hint in period for hint in era_hints)
+
+    ordered = ([gap for gap in gaps if era_match(gap)]
+               + [gap for gap in gaps if gap.get("period") is None]
+               + [gap for gap in gaps if not era_match(gap) and gap.get("period")])
+    for gap in ordered:
+        key = (str(gap.get("kind")), str(gap.get("period") or ""))
+        if key in used["gap_keys"]:
+            continue
+        used["gap_keys"].add(key)
+        used["gaps"] += 1
+        return [{"kind": "timeline_gap", "gap_kind": str(gap.get("kind")),
+                 "period": gap.get("period"), "note": _gap_note(gap)}]
+    return []
+
+
+def _neighborhood_sibling_intents(item: dict, material: dict) -> list[dict]:
+    """Pending siblings in the same neighborhood arc — the research
+    neighborhood's conversation entry point (it had none before this)."""
+    neighborhoods = material.get("neighborhoods") or {}
+    by_question = neighborhoods.get("by_question") or {}
+    siblings = neighborhoods.get("siblings") or {}
+    qid = str(item.get("question_id", ""))
+    nid = by_question.get(qid)
+    if not nid:
+        return []
+    intents = []
+    for candidate in siblings.get(nid, []):
+        if str(candidate.get("id")) == qid or str(candidate.get("promoted_question_id") or "") == qid:
+            continue
+        intents.append({
+            "kind": "neighborhood_sibling",
+            "candidate_id": str(candidate.get("id") or ""),
+            "neighborhood_id": nid,
+            "note": " ".join(str(candidate.get("text") or "").split())[:200]
+                    or "a sibling question in the same arc",
+        })
+    return intents[:2]
+
+
+def _studio_slot_intents(item: dict, material: dict) -> list[dict]:
+    """Format slots the eventual answer could fill (silent no-op without a
+    framework — the book/chapter-boost precedent)."""
+    focus_id = str(item.get("focus") or "")
+    if not focus_id:
+        return []
+    rows = (material.get("studio_slots") or {}).get(focus_id) or []
+    return [{
+        "kind": "studio_slot",
+        "format": row.get("format", ""),
+        "slot": row.get("slot", ""),
+        "note": f"unfilled {row.get('format', '')} slot: {row.get('label') or row.get('slot')}",
+    } for row in rows[:2]]
+
+
+def _demonstrated_knowledge_intent(item: dict, material: dict) -> list[dict]:
+    """Small summaries before dossiers (gradual introduction, phase-3 A):
+    only once a category has ≥2 answers to summarize FROM, receipts real."""
+    answered = _answered_in_category(item, material)
+    if len(answered) < 2:
+        return []
+    receipts = answered[:3]
+    return [{"kind": "demonstrated_knowledge_summary", "receipts": receipts,
+             "note": "summarize what the record already shows about this "
+                     "category before asking for more"}]
+
+
+def _multiplier_for(item: dict, profile: dict) -> float:
+    """quality_profile / PR6 engagement multiplier for OPTIONAL intent order.
+
+    Guarded on every level: an absent profile, an absent engagement block, or a
+    non-numeric multiplier all read as 1.0 (no bias).
+    """
+    if not isinstance(profile, dict):
+        return 1.0
+    weight = 1.0
+    story_function = str(item.get("story_function", ""))
+    category = _category_of(item)
+    for block in (profile, profile.get("engagement") if isinstance(profile.get("engagement"), dict) else {}):
+        if not isinstance(block, dict):
+            continue
+        for key, lookup in (("by_story_function", story_function), ("by_category", category)):
+            bucket = block.get(key)
+            if not isinstance(bucket, dict):
+                continue
+            row = bucket.get(lookup)
+            value = row.get("multiplier") if isinstance(row, dict) else row
+            try:
+                weight *= max(0.1, min(3.0, float(value)))
+            except (TypeError, ValueError):
+                continue
+    return weight
+
+
+def _first_sentence(text: str) -> str:
+    flat = " ".join(str(text).split())
+    if not flat:
+        return ""
+    match = re.search(r"^(.{20,240}?[.!?])(\s|$)", flat)
+    return (match.group(1) if match else flat[:240]).strip()
+
+
+def deterministic_opening(item: dict, material: dict) -> tuple[str | None, list[str]]:
+    """A verbatim-quote framing, or (None, []).
+
+    Without a model the ONLY honest opening is the author's own words quoted
+    exactly — paraphrasing an account back with altered details is the
+    reconsolidation failure research.md §1 forbids. No on-record answer in the
+    category ⇒ null opening ⇒ the daily message keeps today's format.
+    """
+    answers = material.get("answers") or {}
+    bodies = answers.get("bodies") or {}
+    for qid in _answered_in_category(item, material):
+        quote = _first_sentence(bodies.get(qid, ""))
+        if len(quote) >= 20 and BANNED_PHRASE not in quote.lower():
+            return (f'You wrote: "{quote}"', [qid])
+    return (None, [])
+
+
+def plan_deterministic(items: list[dict], material: dict, *,
+                       gap_max: int = DEFAULT_GAP_MAX,
+                       now: str | None = None) -> list[dict]:
+    """One card per queued item — the always-computed floor."""
+    planned_at = now or now_utc()
+    profile = material.get("quality") or {}
+    used = {"gaps": 0, "gap_max": max(0, int(gap_max)), "gap_keys": set()}
+    cards: list[dict] = []
+    for item in items:
+        # Hard intents first: they are the reason the question is worth asking
+        # and behavioral bias may never drop them.
+        hard = (_scene_slot_intents(item, material)
+                + _sit_with_intent(item, material)
+                + _timeline_gap_intent(item, material, used))
+        optional = _neighborhood_sibling_intents(item, material) + _studio_slot_intents(item, material)
+        if _multiplier_for(item, profile) < 1.0:
+            optional.reverse()  # weak signal: try the other optional lane first
+        optional += _demonstrated_knowledge_intent(item, material)
+
+        intents = (hard + optional)[:MAX_INTENTS]
+        if not intents:
+            # Never zero intents for a queued question: the five-slot probe is
+            # always available, since an unclassified category reads unfilled.
+            slots = _five_slots()
+            if slots:
+                intents = [{"kind": "scene_slot", "slot": "what_it_says_about_me",
+                            "note": "nothing on record for this category yet"}]
+        opening, receipts = deterministic_opening(item, material)
+        cards.append({
+            "question_id": str(item.get("question_id")),
+            "opening": opening,
+            "opening_receipts": receipts,
+            "intents": intents,
+            "planned_at": planned_at,
+            "planner": "deterministic",
+        })
+    return cards
+
+
+# ---------------------------------------------------------------------------
+# Validation — the lint gate every card passes, model-planned or not.
+# ---------------------------------------------------------------------------
+
+
+def _card_text_blob(card: dict) -> str:
+    parts = [str(card.get("opening") or "")]
+    for intent in card.get("intents") or []:
+        if isinstance(intent, dict):
+            parts.extend(str(value) for value in intent.values())
+    return " ".join(parts)
+
+
+def receipt_resolves(receipt: str, material: dict, *, vault_root: str | Path | None = None) -> bool:
+    """An answer id on record, or a vault-relative path that exists."""
+    raw = str(receipt or "").strip()
+    if not raw:
+        return False
+    answers = material.get("answers") or {}
+    if raw in set(answers.get("ids") or []):
+        return True
+    if "/" not in raw:
+        return False
+    root = _resolve_root(vault_root)
+    try:
+        return (root / raw).exists()
+    except OSError:
+        return False
+
+
+def validate_card(card: object, *, allowed_ids: set[str], material: dict,
+                  vault_root: str | Path | None = None,
+                  require_target_band: bool = False) -> tuple[dict | None, list[str]]:
+    """Return (clean card, errors). Errors ⇒ the caller keeps the deterministic one.
+
+    A fabricated receipt is NOT fatal: the opening drops to null and the card
+    survives (the intents are still good planning). A closed-vocabulary breach,
+    a foreign question id, an empty/oversized intent list, or the "what year"
+    lint rejects the card outright.
+    """
+    errors: list[str] = []
+    if not isinstance(card, dict):
+        return None, ["card is not an object"]
+    question_id = str(card.get("question_id") or "")
+    if question_id not in allowed_ids:
+        return None, [f"question_id {question_id!r} is not in the current queue"]
+
+    intents_raw = card.get("intents")
+    if not isinstance(intents_raw, list) or not intents_raw:
+        return None, [f"{question_id}: intents must be a non-empty list"]
+    intents: list[dict] = []
+    for intent in intents_raw:
+        if not isinstance(intent, dict):
+            return None, [f"{question_id}: intent is not an object"]
+        kind = str(intent.get("kind", ""))
+        if kind not in INTENT_KINDS:
+            return None, [f"{question_id}: unknown intent kind {kind!r}"]
+        intents.append(intent)
+    floor = TARGET_MIN_INTENTS if require_target_band else MIN_INTENTS
+    if not floor <= len(intents) <= MAX_INTENTS:
+        return None, [f"{question_id}: {len(intents)} intent(s) outside the "
+                      f"{floor}–{MAX_INTENTS} band"]
+
+    clean = {
+        "question_id": question_id,
+        "opening": card.get("opening") if isinstance(card.get("opening"), str) and card.get("opening").strip() else None,
+        "opening_receipts": [str(r) for r in (card.get("opening_receipts") or [])
+                             if isinstance(r, str | int)],
+        "intents": intents,
+        "planned_at": str(card.get("planned_at") or now_utc()),
+        "planner": "model" if str(card.get("planner")) == "model" else "deterministic",
+    }
+    if BANNED_PHRASE in _card_text_blob(clean).lower():
+        return None, [f"{question_id}: contains the banned phrase {BANNED_PHRASE!r} "
+                      "(research.md §4 — landmark anchors, never a calendar year)"]
+
+    if clean["opening"]:
+        unresolved = [r for r in clean["opening_receipts"]
+                      if not receipt_resolves(r, material, vault_root=vault_root)]
+        if unresolved or not clean["opening_receipts"]:
+            errors.append(f"{question_id}: opening dropped — unresolvable receipts "
+                          f"{unresolved or '(none cited)'}")
+            clean["opening"] = None
+            clean["opening_receipts"] = []
+    else:
+        clean["opening_receipts"] = []
+    return clean, errors
+
+
+def validate_cards(cards: object, *, allowed_ids: set[str], material: dict,
+                   vault_root: str | Path | None = None,
+                   require_target_band: bool = False) -> tuple[list[dict], list[str]]:
+    """Validate a whole model response; returns (valid cards, all errors)."""
+    if isinstance(cards, dict):
+        cards = cards.get("cards")
+    if not isinstance(cards, list):
+        return [], ["response has no `cards` list"]
+    valid: list[dict] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for card in cards:
+        clean, card_errors = validate_card(
+            card, allowed_ids=allowed_ids, material=material,
+            vault_root=vault_root, require_target_band=require_target_band)
+        errors.extend(card_errors)
+        if clean is None:
+            continue
+        if clean["question_id"] in seen:
+            errors.append(f"{clean['question_id']}: duplicate card ignored")
+            continue
+        seen.add(clean["question_id"])
+        valid.append(clean)
+    return valid, errors
+
+
+def merge_model_cards(deterministic: list[dict], model_cards: list[dict]) -> tuple[list[dict], str]:
+    """Upgrade deterministic cards IN PLACE with their model counterparts.
+
+    Returns (cards, source) where source is model / deterministic / mixed —
+    the container's honesty field about who planned this week.
+    """
+    by_id = {card["question_id"]: dict(card) for card in deterministic}
+    upgraded = 0
+    for card in model_cards:
+        qid = card["question_id"]
+        if qid not in by_id:
+            continue
+        merged = dict(card)
+        merged["planner"] = "model"
+        by_id[qid] = merged
+        upgraded += 1
+    cards = [by_id[card["question_id"]] for card in deterministic]
+    if upgraded == 0:
+        return cards, "deterministic"
+    return cards, ("model" if upgraded == len(cards) else "mixed")
+
+
+# ---------------------------------------------------------------------------
+# The model pass — ONE prompt per weekly run (not per card: bounded cost at a
+# weekly cadence), carrying the definition file verbatim plus this week's
+# assembled material.
+# ---------------------------------------------------------------------------
+
+
+def resolve_model(explicit: str | None = None) -> str:
+    """arc_plan_model → classify_model → classify_story.DEFAULT_MODEL."""
+    if explicit:
+        return explicit
+    config = load_config()
+    for key in ("arc_plan_model", "classify_model"):
+        value = str(config.get(key) or "").strip()
+        if value:
+            return value
+    try:
+        from classify_story import DEFAULT_MODEL  # noqa: PLC0415
+        return str(DEFAULT_MODEL)
+    except Exception:  # noqa: BLE001
+        return DEFAULT_MODEL_FALLBACK
+
+
+def _record_summary(item: dict, material: dict) -> str:
+    answers = material.get("answers") or {}
+    bodies = answers.get("bodies") or {}
+    dates = answers.get("dates") or {}
+    lines = []
+    for qid in _answered_in_category(item, material)[:3]:
+        excerpt = " ".join(str(bodies.get(qid, "")).split())[:300]
+        lines.append(f"  [{qid}, {dates.get(qid) or 'undated'}] {excerpt}")
+    return "\n".join(lines) or "  (nothing on record in this category yet — cold start)"
+
+
+def build_plan_prompt(items: list[dict], material: dict, deterministic: list[dict]) -> str:
+    """The definition file verbatim + a runtime INPUT block (the shape
+    ``conversation.build_arc_prompt`` established), extended from one question
+    to the whole week's queue."""
+    template = conversation.read_conversation_definition("plan", "arc-templates.md")
+    by_id = {card["question_id"]: card for card in deterministic}
+    blocks: list[str] = []
+    for item in items:
+        qid = str(item.get("question_id"))
+        card = by_id.get(qid, {})
+        blocks.append(
+            f"### QUESTION [{qid}] (category {item.get('category', '')}, "
+            f"focus {item.get('focus') or '—'}, story function "
+            f"{item.get('story_function', '')}{', SELF-ARC' if is_self_arc(item) else ''})\n"
+            f"Why it was queued: {item.get('reason', '')}\n"
+            f"RECORD (quote from this exactly, never paraphrased):\n{_record_summary(item, material)}\n"
+            f"DETERMINISTIC INTENT MATERIAL (typed; keep, reorder, or replace — "
+            f"same closed vocabulary):\n{json.dumps(card.get('intents', []), indent=2)}"
+        )
+    gaps = json.dumps(material.get("timeline_gaps") or [], indent=2)
+    sit_with = "\n".join(f"  - {line}" for line in material.get("sit_with") or []) or "  (none)"
+    return (
+        f"{template}\n\n"
+        "## INPUT (assembled at runtime — plan this week's arc cards)\n\n"
+        f"{chr(10).join(blocks)}\n\n"
+        f"TIMELINE GAPS (consumed kinds only):\n{gaps}\n\n"
+        f"MIRROR — Sit with (quote one verbatim, self-arc questions only):\n{sit_with}\n\n"
+        "## CRAFT RULES (hard)\n\n"
+        "1. Two-sentence rule: `opening` is ONE context sentence drawn from the "
+        "record above — quote the author's own words EXACTLY, never paraphrased "
+        "with altered details. A cold-start question may prove memory without "
+        "faking continuity (\"You've told me about X; this is somewhere we "
+        "haven't been yet —\"). Set it to null rather than invent one.\n"
+        "2. Every id or path in `opening_receipts` must be one that appears "
+        "above. An unresolvable receipt costs the card its opening.\n"
+        "3. Dates arrive as landmark anchors (before/after a move, a birth). "
+        f"The phrase \"{BANNED_PHRASE}\" is forbidden anywhere in your output.\n"
+        f"4. 2–4 intents per card, each an object whose `kind` is one of: "
+        f"{', '.join(sorted(INTENT_KINDS))}. Intents are INTENTS, not scripted "
+        "questions — the turn engine phrases them live.\n"
+        "5. Quality first, coverage second: a card that would make a "
+        "technically-uncovered topic feel forced is the wrong card.\n\n"
+        "## OUTPUT\n\n"
+        "Return STRICT JSON only (no prose, no code fence):\n"
+        '{"cards": [{"question_id": "...", "opening": "..." | null, '
+        '"opening_receipts": ["..."], "intents": [{"kind": "...", ...}]}]}\n'
+        f"Plan exactly {len(items)} card(s), one per question above.\n"
+    )
+
+
+def emit_tasks(out_dir: Path, prompt: str, *, count: int) -> Path:
+    """Keyless path: the prompt + a manifest naming the --from-response ingest
+    (the mirror.emit_task / classify --emit-prompts convention).
+
+    Both writes go through lifehug_core's helpers, which route vault paths to
+    the no-follow I/O authority in vault_paths — never a bare Path.write_text
+    (v120's runtime guard).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = out_dir / "arcs.prompt.md"
+    write_text(prompt_file, prompt)
+    manifest = out_dir / "manifest.json"
+    write_json(manifest, {
+        "task": "arcs",
+        "emitted_at": now_utc(),
+        "ingest_command": "python3 system/lifehug.py arc-plan --from-response <response>",
+        "cards_expected": count,
+        "items": [{"prompt": prompt_file.name, "response": "arcs.response.json"}],
+    })
+    return manifest
+
+
+def _strip_fences(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```[a-zA-Z]*\n", "", stripped)
+        stripped = re.sub(r"\n```\s*$", "", stripped)
+    return stripped.strip()
+
+
+def parse_model_response(raw: str) -> object:
+    try:
+        return json.loads(_strip_fences(raw))
+    except json.JSONDecodeError as exc:
+        raise ArcPlanError(f"model response is not valid JSON: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# The weekly run
+# ---------------------------------------------------------------------------
+
+
+def build_container(queue: dict, cards: list[dict], source: str, *,
+                    thread_offers: list[dict] | None = None,
+                    now: str | None = None) -> dict:
+    """Cards live and die WITH the queue: both stamps are copied VERBATIM."""
+    return {
+        "version": conversation.ARC_CARDS_VERSION,
+        "generated_at": now or now_utc(),
+        "queue_generated_at": queue.get("generated_at"),
+        "expires_at": queue.get("expires_at"),
+        "source": source,
+        "cards": cards,
+        "thread_offers": list(thread_offers or []),
+    }
+
+
+def plan(*, limit: int | None = None, model: str | None = None, dry_run: bool = False,
+         emit_tasks_dir: str | Path | None = None, gap_max: int = DEFAULT_GAP_MAX,
+         force: bool = False, vault_root: str | Path | None = None,
+         now: str | None = None, timeline_payload: dict | None = None,
+         readiness_cards: list[dict] | None = None) -> tuple[int, list[str]]:
+    """Plan this week's arc cards. Returns (exit code, report lines)."""
+    root = _resolve_root(vault_root)
+    report: list[str] = []
+    queue = load_queue(vault_root=root)
+    items = queued_items(queue, limit=limit)
+    if not items:
+        report.append("No queued questions to plan arcs for.")
+        return 0, report
+
+    existing = conversation.load_arc_cards(vault_root=root)
+    same_queue = (existing.get("queue_generated_at")
+                  and existing.get("queue_generated_at") == queue.get("generated_at"))
+    model_planned = {str(card.get("question_id")) for card in existing.get("cards") or []
+                     if isinstance(card, dict) and card.get("planner") == "model"}
+
+    material = collect_material(items, vault_root=root, timeline_payload=timeline_payload,
+                               readiness_cards=readiness_cards)
+    cards = plan_deterministic(items, material, gap_max=gap_max, now=now)
+    source = "deterministic"
+
+    # A model-planned card is not clobbered by a later deterministic re-run in
+    # the same week (unless --force): the week's best plan survives a re-run.
+    if same_queue and model_planned and not force:
+        preserved = {str(card.get("question_id")): card for card in existing.get("cards") or []
+                     if isinstance(card, dict) and card.get("planner") == "model"}
+        cards = [preserved.get(card["question_id"], card) for card in cards]
+        if preserved:
+            source = "mixed" if len(preserved) < len(cards) else "model"
+            report.append(f"Preserved {len(preserved)} model-planned card(s) from this week's run "
+                          "(--force replans them).")
+
+    allowed_ids = {str(item.get("question_id")) for item in items}
+    prompt = build_plan_prompt(items, material, cards)
+
+    if emit_tasks_dir is not None:
+        # Keyless: the deterministic cards are written NOW (the week is never
+        # lost) and the prompt goes out for agent completion.
+        manifest = emit_tasks(Path(emit_tasks_dir), prompt, count=len(items))
+        report.append(f"✓ Emitted arc-plan task to {Path(emit_tasks_dir)}")
+        report.append(f"  Manifest: {manifest}")
+        report.append("  Write strict JSON to arcs.response.json, then run the ingest_command.")
+    elif not dry_run:
+        try:
+            from ai_provider import call_ai  # noqa: PLC0415
+            resolved = resolve_model(model)
+            report.append(f"Planning {len(items)} arc card(s) with {resolved}…")
+            valid, errors = validate_cards(
+                parse_model_response(call_ai(prompt, resolved)),
+                allowed_ids=allowed_ids, material=material, vault_root=root,
+                require_target_band=True)
+            for error in errors:
+                report.append(f"  ⚠ {error}")
+            if valid:
+                cards, source = merge_model_cards(cards, valid)
+                report.append(f"✓ {len(valid)} card(s) planned by the model.")
+            else:
+                report.append("⚠ No usable model cards — keeping the deterministic plan.")
+        except Exception as exc:  # noqa: BLE001 — a model failure never costs the week its cards
+            report.append(f"⚠ Model pass unavailable ({exc.__class__.__name__}: {exc}) — "
+                          "deterministic cards kept.")
+            _record_failure("arc_plan_model", exc, root=root)
+
+    # Every card passes the same lint gate, model-planned or not.
+    cards, lint_errors = validate_cards(cards, allowed_ids=allowed_ids, material=material,
+                                        vault_root=root)
+    for error in lint_errors:
+        report.append(f"  ⚠ {error}")
+    if len(cards) != len(items):
+        planned = {card["question_id"] for card in cards}
+        for item in items:
+            qid = str(item.get("question_id"))
+            if qid not in planned:
+                report.append(f"  ⚠ {qid}: no valid card survived validation")
+
+    container = build_container(queue, cards, source,
+                                thread_offers=existing.get("thread_offers"), now=now)
+    if dry_run:
+        report.append(f"DRY RUN — would write {len(cards)} card(s) "
+                      f"(source: {source}, expires {container['expires_at']}):")
+        report.extend(describe_cards(cards))
+        return 0, report
+
+    conversation.save_arc_cards(container, vault_root=root)
+    report.append(f"✓ Wrote {len(cards)} arc card(s) to state/arc_cards.json "
+                  f"(source: {source}, expires {container['expires_at']})")
+    report.extend(describe_cards(cards))
+    return 0, report
+
+
+def describe_cards(cards: list[dict]) -> list[str]:
+    lines = []
+    for card in cards:
+        kinds = ", ".join(str(intent.get("kind")) for intent in card.get("intents") or [])
+        opening = card.get("opening")
+        lines.append(f"  [{card['question_id']}] {card.get('planner')}: {kinds}")
+        if opening:
+            lines.append(f"      opening: {opening[:120]}")
+    return lines
+
+
+def _record_failure(operation: str, exc: BaseException, *, root: Path | None = None) -> None:
+    """Record a non-blocking learning-loop failure IN THE PLANNED VAULT.
+
+    Scoped to ``root`` so a run against a synthetic vault (tests, a second
+    checkout) never appends to the process-bound vault's ledger — the default
+    resolves to REPO_DIR exactly as every other caller's does.
+    """
+    try:
+        from lifehug_core import LEARNING_FAILURES_FILE, record_learning_failure  # noqa: PLC0415
+        path = LEARNING_FAILURES_FILE
+        # Never wrap REPO_DIR in Path() — that strips its VaultPath authority
+        # (v120 runtime guard); compare the string forms instead.
+        if root is not None and os.fspath(root) != os.fspath(REPO_DIR):
+            path = _data_path("learning_failures", Path(root))
+        record_learning_failure("arc_planner", operation,
+                                f"{exc.__class__.__name__}: {exc}", path=path)
+    except Exception:  # noqa: BLE001 — never let bookkeeping raise on a fallback path
+        pass
+
+
+def ingest_response(path: str | Path, *, dry_run: bool = False,
+                    vault_root: str | Path | None = None,
+                    now: str | None = None) -> tuple[int, list[str]]:
+    """`--from-response`: UPGRADE deterministic cards in place (planner→model)."""
+    root = _resolve_root(vault_root)
+    report: list[str] = []
+    raw = Path(path).read_text(encoding="utf-8")
+    payload = parse_model_response(raw)
+
+    queue = load_queue(vault_root=root)
+    items = queued_items(queue)
+    allowed_ids = {str(item.get("question_id")) for item in items}
+    if not allowed_ids:
+        report.append("No queued questions — nothing to ingest against.")
+        return 1, report
+
+    material = collect_material(items, vault_root=root)
+    valid, errors = validate_cards(payload, allowed_ids=allowed_ids, material=material,
+                                   vault_root=root, require_target_band=True)
+    for error in errors:
+        report.append(f"  ⚠ {error}")
+    if not valid:
+        report.append("✗ No valid cards in the response — the existing plan is unchanged.")
+        return 1, report
+
+    existing = conversation.load_arc_cards(vault_root=root)
+    base = [card for card in existing.get("cards") or [] if isinstance(card, dict)]
+    if not base:
+        base = plan_deterministic(items, material, now=now)
+    cards, source = merge_model_cards(base, valid)
+    container = build_container(queue, cards, source,
+                                thread_offers=existing.get("thread_offers"), now=now)
+    if dry_run:
+        report.append(f"DRY RUN — would upgrade {len(valid)} card(s) to model-planned.")
+        report.extend(describe_cards(cards))
+        return 0, report
+    conversation.save_arc_cards(container, vault_root=root)
+    report.append(f"✓ Upgraded {len(valid)} card(s) to model-planned (source: {source})")
+    report.extend(describe_cards(cards))
+    return 0, report
+
+
+# ---------------------------------------------------------------------------
+# The daily attach — a pure file read. No model, no network, no state write.
+# ---------------------------------------------------------------------------
+
+
+def live_card(question_id: str, *, vault_root: str | Path | None = None,
+              now: datetime | None = None) -> dict | None:
+    """The card for this question IF it is live.
+
+    Live = unexpired AND the question is still in the current queue (queued or
+    already sent today). Dead cards return None, which is the whole of the
+    stale-plan fallback: nothing attaches and the daily message keeps today's
+    format.
+    """
+    root = _resolve_root(vault_root)
+    container = conversation.load_arc_cards(vault_root=root)
+    cards = [card for card in container.get("cards") or []
+             if isinstance(card, dict) and str(card.get("question_id")) == str(question_id)]
+    if not cards:
+        return None
+    expires = _parse_time(container.get("expires_at"))
+    moment = now or datetime.now(timezone.utc)
+    if expires and expires <= moment:
+        return None
+    queue = load_queue(vault_root=root)
+    in_queue = {str(item.get("question_id"))
+                for item in queued_items(queue, statuses=("queued", "sent"))}
+    if str(question_id) not in in_queue:
+        return None
+    return cards[0]
+
+
+def _question_and_categories(question_id: str, root: Path):
+    """The bank row + category map for one question (vault-root aware)."""
+    from lifehug_core import parse_categories, parse_questions, question_by_id  # noqa: PLC0415
+    text = _read_text(_data_path("question_bank", root), root)
+    if not text:
+        return None, {}
+    questions = parse_questions(text)
+    return question_by_id(questions, question_id), parse_categories(text)
+
+
+def daily_text(question_id: str, *, vault_root: str | Path | None = None,
+               now: datetime | None = None) -> str:
+    """The assembled daily message for a LIVE carded question, else "".
+
+    The shell attach hinges on empty-vs-nonempty, which keeps the daily loop
+    AI-free and branch-free. The output ALWAYS carries the ``[QID]`` marker in
+    ``ask.format_question``'s exact shape — daily_question.sh parses it and the
+    answer-filing flow keys on it, so the marker is produced by that one
+    function rather than retyped here.
+    """
+    root = _resolve_root(vault_root)
+    card = live_card(question_id, vault_root=root, now=now)
+    if not card or not card.get("opening"):
+        return ""
+    question, categories = _question_and_categories(question_id, root)
+    if not question:
+        return ""
+    import ask  # noqa: PLC0415
+    formatted = ask.format_question(question, categories)
+    header, _, body = formatted.partition("\n")
+    opening = str(card["opening"]).strip()
+    question_text = body.strip() or str(question.get("text", "")).strip()
+    if question_text and question_text.lower() in opening.lower():
+        # The planner embedded the question in the framing — don't say it twice.
+        return f"{header}\n{opening}"
+    return f"{header}\n{opening}\n\n{question_text}"
+
+
+# ---------------------------------------------------------------------------
+# Monthly conversation-thread offers
+# ---------------------------------------------------------------------------
+
+
+def conversation_ready_neighborhoods(*, vault_root: str | Path | None = None) -> list[dict]:
+    """Neighborhoods with somewhere to go AND record to open from.
+
+    Derived exactly like ``neighborhoods.apply_readiness`` reads: an active or
+    draft neighborhood with at least one unanswered arc slot (somewhere to go)
+    and at least one answered or promoted slot (record to open from). Nothing
+    is written to the neighborhood — "conversation-ready" is derived, never a
+    stored flag that can go stale.
+    """
+    root = _resolve_root(vault_root)
+    material = collect_neighborhoods(vault_root=root)
+    candidates = _read_json(_data_path("question_candidates", root), root, {})
+    cand_rows = candidates.get("candidates") if isinstance(candidates, dict) else []
+    try:
+        import neighborhoods as neighborhoods_mod  # noqa: PLC0415
+        from lifehug_core import parse_questions  # noqa: PLC0415
+        questions = parse_questions(_read_text(_data_path("question_bank", root), root))
+        candidates_by_id = neighborhoods_mod.candidate_lookup(cand_rows)
+        questions_by_id = neighborhoods_mod.question_lookup(questions)
+        resolve = neighborhoods_mod.resolve_slot
+    except Exception:  # noqa: BLE001
+        return []
+
+    ready: list[dict] = []
+    for neighborhood in material.get("neighborhoods") or []:
+        if str(neighborhood.get("status", "active")) not in {"active", "draft"}:
+            continue
+        slots = [slot for slot in neighborhood.get("arc") or [] if isinstance(slot, dict)]
+        if not slots:
+            continue
+        resolved = [resolve(slot, candidates_by_id, questions_by_id) for slot in slots]
+        lifecycles = [str(slot.get("lifecycle_status")) for slot in resolved]
+        somewhere_to_go = any(state != "answered" for state in lifecycles)
+        record_to_open_from = any(state in {"answered", "promoted"} for state in lifecycles)
+        if somewhere_to_go and record_to_open_from:
+            ready.append(neighborhood)
+    return ready
+
+
+def plan_thread_offers(*, limit: int = DEFAULT_THREAD_OFFERS, dry_run: bool = False,
+                       vault_root: str | Path | None = None,
+                       now: datetime | None = None) -> tuple[list[str], list[dict]]:
+    """At most `limit` offer line(s); an offered neighborhood stays quiet a quarter.
+
+    Returns (telegram lines, new offer records).
+    """
+    root = _resolve_root(vault_root)
+    moment = now or datetime.now(timezone.utc)
+    container = conversation.load_arc_cards(vault_root=root)
+    offers = [row for row in container.get("thread_offers") or [] if isinstance(row, dict)]
+    quiet_since = moment - timedelta(days=THREAD_OFFER_QUIET_DAYS)
+    recent = {str(row.get("neighborhood_id")) for row in offers
+              if (_parse_time(row.get("offered_at")) or moment) > quiet_since}
+
+    lines: list[str] = []
+    fresh: list[dict] = []
+    for neighborhood in conversation_ready_neighborhoods(vault_root=root):
+        if len(fresh) >= max(0, int(limit)):
+            break
+        nid = str(neighborhood.get("id") or "")
+        if not nid or nid in recent:
+            continue
+        title = str(neighborhood.get("title") or nid)
+        lines.append(f"💬 I've been wanting to ask about {title} — shall we?")
+        fresh.append({"neighborhood_id": nid,
+                      "offered_at": moment.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                      "month": moment.strftime("%Y-%m")})
+    if fresh and not dry_run:
+        container["thread_offers"] = offers + fresh
+        conversation.save_arc_cards(container, vault_root=root)
+    return lines, fresh
+
+
+# ---------------------------------------------------------------------------
+# CLI (wrapped by lifehug.py's arc-plan / arc-card / arc-thread-offers)
+# ---------------------------------------------------------------------------
+
+
+def _emit(report: list[str]) -> None:
+    for line in report:
+        print(line)
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    if args.from_response:
+        code, report = ingest_response(args.from_response, dry_run=args.dry_run)
+        _emit(report)
+        return code
+    code, report = plan(
+        limit=args.limit,
+        model=args.model,
+        dry_run=args.dry_run,
+        emit_tasks_dir=args.emit_tasks,
+        gap_max=args.gap_max,
+        force=args.force,
+    )
+    _emit(report)
+    return code
+
+
+def cmd_card(args: argparse.Namespace) -> int:
+    if args.daily_text:
+        text = daily_text(args.question_id)
+        if text:
+            print(text)
+        return 0
+    card = live_card(args.question_id)
+    if not card:
+        print(f"No live arc card for {args.question_id}.")
+        return 0
+    print(json.dumps(card, indent=2))
+    return 0
+
+
+def cmd_thread_offers(args: argparse.Namespace) -> int:
+    lines, fresh = plan_thread_offers(limit=args.limit, dry_run=args.dry_run)
+    if not lines:
+        print("No conversation-thread offers this month.")
+        return 0
+    prefix = "DRY RUN — would offer:" if args.dry_run else f"✓ Offered {len(fresh)} thread(s):"
+    print(prefix)
+    for line in lines:
+        print(line)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Lifehug weekly arc planner")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("plan", help="Plan this week's arc cards")
+    p.add_argument("--limit", type=int, default=None, help="Plan at most N queued questions")
+    p.add_argument("--gap-max", type=int, default=int(os.environ.get("LIFEHUG_WEEKLY_ARC_GAP_MAX", DEFAULT_GAP_MAX)),
+                   help="Max timeline_gap intents across the week (default 3)")
+    p.add_argument("--model", default=None, help="AI model override")
+    p.add_argument("--dry-run", action="store_true", help="Print the plan; write nothing")
+    p.add_argument("--emit-tasks", metavar="DIR", default=None,
+                   help="Keyless: write deterministic cards and emit the prompt for agent completion")
+    p.add_argument("--from-response", metavar="PATH", default=None,
+                   help="Ingest an agent-written response and upgrade cards in place")
+    p.add_argument("--force", action="store_true",
+                   help="Replan model-planned cards for the same queue")
+    p.set_defaults(func=cmd_plan)
+
+    p = sub.add_parser("card", help="Read one live arc card (pure read)")
+    p.add_argument("question_id")
+    p.add_argument("--daily-text", action="store_true",
+                   help="Print the assembled daily message for a live card, else nothing")
+    p.set_defaults(func=cmd_card)
+
+    p = sub.add_parser("thread-offers", help="Monthly conversation-thread offers")
+    p.add_argument("--limit", type=int,
+                   default=int(os.environ.get("LIFEHUG_MONTHLY_THREAD_OFFERS", DEFAULT_THREAD_OFFERS)))
+    p.add_argument("--dry-run", action="store_true")
+    p.set_defaults(func=cmd_thread_offers)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except ArcPlanError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system/conversation.py
+++ b/system/conversation.py
@@ -46,6 +46,14 @@ Arc-card helpers (minimal, typed; storage only — the planner is Wave 2):
 
     load_arc_card(question_id, *, vault_root=None) -> dict | None
     save_arc_card(card, *, vault_root=None) -> None
+    load_arc_cards(*, vault_root=None) -> dict          # the whole container
+    save_arc_cards(container, *, vault_root=None) -> None
+
+(The two container-level helpers and ``read_conversation_definition`` are
+the issue #118 extension: ``system/arc_planner.py`` rewrites the container
+wholesale every week and reads ``plan/arc-templates.md``, and both go
+through this module rather than re-deriving the container defaults or
+hand-building a path into the interaction definition.)
 
 There is deliberately no ``append_mirror_response`` here (mid-flight
 cross-contract audit amendment M14): issue #119 ships the single mirror
@@ -419,13 +427,16 @@ def merge_session_extraction(
 # here.
 # --------------------------------------------------------------------------
 
+ARC_CARDS_VERSION = 1
+
+
 def _arc_cards_default() -> dict:
     # A fresh dict/list on every call — never a shared module-level mutable
     # (a `dict(SHARED_CONSTANT)` shallow copy would alias the "cards" list
     # across every vault this process touches; the bug this factory avoids
     # was caught by this PR's own upsert-without-duplicating test).
     return {
-        "version": 1,
+        "version": ARC_CARDS_VERSION,
         "generated_at": None,
         "queue_generated_at": None,
         "expires_at": None,
@@ -433,6 +444,40 @@ def _arc_cards_default() -> dict:
         "cards": [],
         "thread_offers": [],
     }
+
+
+def load_arc_cards(*, vault_root: str | Path | None = None) -> dict:
+    """The whole arc-card CONTAINER, defaults filled (issue #118 extension).
+
+    ``load_arc_card`` answers "one card for this question"; the arc planner
+    rewrites the container wholesale each week (generation-run bookkeeping
+    included), so both halves resolve the container through this one
+    function rather than each re-deriving the defaults. A cold vault, a
+    corrupt file, or a non-object payload all degrade to the default
+    container — never an exception on a read path the daily loop touches.
+    """
+    root = _resolve_root(vault_root)
+    data = _read_json_at(_arc_cards_path(root), vault_root=root, default=None)
+    if not isinstance(data, dict):
+        return _arc_cards_default()
+    for key, default in _arc_cards_default().items():
+        data.setdefault(key, default)
+    if not isinstance(data.get("cards"), list):
+        data["cards"] = []
+    if not isinstance(data.get("thread_offers"), list):
+        data["thread_offers"] = []
+    return data
+
+
+def save_arc_cards(data: dict, *, vault_root: str | Path | None = None) -> None:
+    """Write the whole container (issue #118 extension; defaults filled)."""
+    if not isinstance(data, dict):
+        raise ValueError("arc-card container must be a JSON object")
+    payload = dict(data)
+    for key, default in _arc_cards_default().items():
+        payload.setdefault(key, default)
+    root = _resolve_root(vault_root)
+    _write_json_at(_arc_cards_path(root), payload, vault_root=root)
 
 
 def load_arc_card(question_id: str, *, vault_root: str | Path | None = None) -> dict | None:
@@ -455,14 +500,7 @@ def save_arc_card(card: dict, *, vault_root: str | Path | None = None) -> None:
     if not question_id:
         raise ValueError("arc card requires a question_id")
     root = _resolve_root(vault_root)
-    path = _arc_cards_path(root)
-    data = _read_json_at(path, vault_root=root, default=None)
-    if not isinstance(data, dict):
-        data = _arc_cards_default()
-    for key, default in _arc_cards_default().items():
-        data.setdefault(key, default)
-    if not isinstance(data.get("cards"), list):
-        data["cards"] = []
+    data = load_arc_cards(vault_root=root)
     cards = data["cards"]
     for index, existing in enumerate(cards):
         if isinstance(existing, dict) and existing.get("question_id") == question_id:
@@ -470,7 +508,7 @@ def save_arc_card(card: dict, *, vault_root: str | Path | None = None) -> None:
             break
     else:
         cards.append(card)
-    _write_json_at(path, data, vault_root=root)
+    save_arc_cards(data, vault_root=root)
 
 
 # --------------------------------------------------------------------------
@@ -520,8 +558,19 @@ def _safe_manifest() -> dict:
         return {}
 
 
+def read_conversation_definition(*parts: str, framework_root: str | Path | None = None) -> str:
+    """Read one ``interactions/conversation/`` definition file verbatim.
+
+    The public accessor (issue #118 extension) so other modules — the arc
+    planner reads ``plan/arc-templates.md`` — never hand-build a path into
+    the interaction definition. Raises OSError when the file is absent; the
+    definition tree is a framework file, not optional vault state.
+    """
+    return _conversation_dir_path(*parts, framework_root=framework_root).read_text(encoding="utf-8")
+
+
 def _read_framework_text(*parts: str) -> str:
-    return _conversation_dir_path(*parts).read_text(encoding="utf-8")
+    return read_conversation_definition(*parts)
 
 
 def _truncate(text: str, budget_tokens: object) -> str:

--- a/system/daily_question.sh
+++ b/system/daily_question.sh
@@ -62,9 +62,42 @@ if [[ -z "$TOKEN" || -z "$CHAT_ID" ]]; then
   exit 1
 fi
 
+# The [QID] marker is what daily_question.sh keys the delivered message on
+# (and the answer-filing flow after it), so the parse has ONE definition used
+# by both the dry run and the real send.
+parse_question_id() {
+  python3 -c '
+import re
+import sys
+text = sys.stdin.read()
+m = re.search(r"\[([A-Z]\d+[a-z]*)\]", text)
+print(m.group(1) if m else "")
+'
+}
+
+# Arc-card attach (issue #118) — a PURE FILE READ, no AI on the daily path.
+# Prints the assembled message for a live card (unexpired and still in the
+# current queue) or nothing at all; the caller branches on empty-vs-nonempty,
+# which is the whole of the stale-plan fallback.
+arc_card_text() {
+  python3 "$SCRIPT_DIR/lifehug.py" arc-card "$1" --daily-text 2>/dev/null || true
+}
+
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "DRY RUN: would use configured Telegram delivery target"
-  python3 "$SCRIPT_DIR/ask.py" --dry-run
+  DRY_OUTPUT=$(python3 "$SCRIPT_DIR/ask.py" --dry-run)
+  printf '%s\n' "$DRY_OUTPUT"
+  DRY_QID=$(printf '%s\n' "$DRY_OUTPUT" | parse_question_id)
+  if [[ -n "$DRY_QID" ]]; then
+    DRY_ARC=$(arc_card_text "$DRY_QID")
+    echo
+    if [[ -n "$DRY_ARC" ]]; then
+      echo "==> arc card attach for ${DRY_QID} (would send):"
+      printf '%s\n' "$DRY_ARC"
+    else
+      echo "==> no live arc card for ${DRY_QID} — today's message format unchanged"
+    fi
+  fi
   exit 0
 fi
 
@@ -234,14 +267,7 @@ Reply with a model name to use a different one, or just say **go** to use the de
   exit 0
 fi
 
-QUESTION_ID=$(printf '%s\n' "$QUESTION_OUTPUT" | python3 -c '
-import re
-import sys
-text = sys.stdin.read()
-m = re.search(r"\[([A-Z]\d+[a-z]*)\]", text)
-print(m.group(1) if m else "")
-'
-)
+QUESTION_ID=$(printf '%s\n' "$QUESTION_OUTPUT" | parse_question_id)
 
 if [[ -z "$QUESTION_ID" ]]; then
   echo "ERROR: Could not parse question ID from ask.py output" >&2
@@ -249,9 +275,21 @@ if [[ -z "$QUESTION_ID" ]]; then
   exit 1
 fi
 
+# The day's pre-planned arc card, when one is live. The card's own text
+# carries the same [QID] marker format_question produces, so the message the
+# author sees — and every downstream parse of it — is unchanged in shape.
+# Reengagement picks and expired queues simply have no card: empty output,
+# today's format, no branch anywhere else in this script.
+ARC_TEXT=$(arc_card_text "$QUESTION_ID")
+if [[ -n "$ARC_TEXT" ]]; then
+  QUESTION_BODY="$ARC_TEXT"
+else
+  QUESTION_BODY="$QUESTION_OUTPUT"
+fi
+
 TEXT="📖 Lifehug — Daily Question
 
-${QUESTION_OUTPUT}
+${QUESTION_BODY}
 
 (Answer whenever you want — voice or text)"
 

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -61,7 +61,12 @@ QUEUED_MUTATION_COMMANDS = frozenset({
     "weekly-maintenance",
 })
 READ_ONLY_COMMANDS = frozenset({
-    "ai-status", "answer-ack-prompt", "answer-ack-status", "book-chapter", "book-status",
+    "ai-status", "answer-ack-prompt", "answer-ack-status",
+    # Issue #118: the daily attach is a PURE READ of state/arc_cards.json —
+    # it must never take the writer lock, because daily_question.sh calls it
+    # between picking and sending.
+    "arc-card",
+    "book-chapter", "book-status",
     "candidates-list", "candidates-review", "candidates-stats", "chapters-exercise",
     "connector-audit", "connector-report",
     "conversation-arc-prompt", "conversation-closing-prompt", "conversation-lint",
@@ -73,6 +78,10 @@ READ_ONLY_COMMANDS = frozenset({
 })
 DIRECT_MUTATION_COMMANDS = frozenset({
     "answer-ack-retry",
+    # Issue #118 (Conversation Interaction, Wave 2): both write
+    # state/arc_cards.json, so they take the writer lock like the rest of the
+    # weekly/monthly learning-loop family.
+    "arc-plan", "arc-thread-offers",
     "book-offers", "candidates-auto-promote", "candidates-promote",
     "candidates-promote-neighborhood", "candidates-update", "classify-story",
     "connector-auth", "connector-calibrate", "connector-dossier", "connector-excavate",
@@ -825,6 +834,41 @@ def cmd_answer_ack_retry(args: argparse.Namespace) -> int:
     if args.confirm_not_sent:
         flags.append("--confirm-not-sent")
     return run_python("answer_ack_delivery.py", flags)
+
+
+def cmd_arc_plan(args: argparse.Namespace) -> int:
+    flags = ["plan"]
+    if args.limit is not None:
+        flags += ["--limit", str(args.limit)]
+    if args.gap_max is not None:
+        flags += ["--gap-max", str(args.gap_max)]
+    if getattr(args, "model", None):
+        flags += ["--model", args.model]
+    if getattr(args, "dry_run", False):
+        flags.append("--dry-run")
+    if getattr(args, "emit_tasks", None):
+        flags += ["--emit-tasks", args.emit_tasks]
+    if getattr(args, "from_response", None):
+        flags += ["--from-response", args.from_response]
+    if getattr(args, "force", False):
+        flags.append("--force")
+    return run_python("arc_planner.py", flags)
+
+
+def cmd_arc_card(args: argparse.Namespace) -> int:
+    flags = ["card", args.question_id]
+    if getattr(args, "daily_text", False):
+        flags.append("--daily-text")
+    return run_python("arc_planner.py", flags)
+
+
+def cmd_arc_thread_offers(args: argparse.Namespace) -> int:
+    flags = ["thread-offers"]
+    if args.limit is not None:
+        flags += ["--limit", str(args.limit)]
+    if getattr(args, "dry_run", False):
+        flags.append("--dry-run")
+    return run_python("arc_planner.py", flags)
 
 
 def cmd_conversation_open(args: argparse.Namespace) -> int:
@@ -1885,6 +1929,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Retry an ambiguous send only after checking that Telegram did not receive it",
     )
     p.set_defaults(func=cmd_answer_ack_retry)
+
+    # Issue #118 (Wave 2): the weekly arc planner, the daily attach, and the
+    # monthly conversation-thread offers.
+    p = sub.add_parser("arc-plan", help="Plan one arc card per queued question (weekly)")
+    p.add_argument("--limit", type=int, default=None, help="Plan at most N queued questions")
+    p.add_argument("--gap-max", type=int, default=None,
+                   help="Max timeline_gap intents across the week (default 3)")
+    p.add_argument("--model", help="AI model override (config arc_plan_model → classify_model)")
+    p.add_argument("--dry-run", action="store_true", help="Print the plan; write nothing")
+    p.add_argument("--emit-tasks", metavar="DIR",
+                   help="Keyless: write deterministic cards and emit the prompt for agent completion")
+    p.add_argument("--from-response", metavar="PATH",
+                   help="Ingest an agent-written response; upgrades cards in place")
+    p.add_argument("--force", action="store_true",
+                   help="Replan model-planned cards for the same queue")
+    p.set_defaults(func=cmd_arc_plan)
+
+    p = sub.add_parser("arc-card", help="Read one live arc card (pure read; --daily-text for the daily attach)")
+    p.add_argument("question_id")
+    p.add_argument("--daily-text", action="store_true",
+                   help="Print the assembled daily message for a live card, else nothing")
+    p.set_defaults(func=cmd_arc_card)
+
+    p = sub.add_parser("arc-thread-offers", help="Monthly conversation-thread offers for ready neighborhoods")
+    p.add_argument("--limit", type=int, default=None, help="Max offers this month (default 1)")
+    p.add_argument("--dry-run", action="store_true")
+    p.set_defaults(func=cmd_arc_thread_offers)
 
     p = sub.add_parser("conversation-open", help="Open a new conversation session; prints its id and document path")
     p.add_argument("--mode", required=True, choices=["chat", "conversation"])

--- a/system/monthly_research.sh
+++ b/system/monthly_research.sh
@@ -63,6 +63,9 @@ GAP_LIMIT="${LIFEHUG_MONTHLY_GAP_LIMIT:-2}"
 SELF_TOPIC="${LIFEHUG_MONTHLY_SELF_TOPIC:-Who I am becoming}"
 SELF_OUTPUT="${LIFEHUG_MONTHLY_SELF_OUTPUT:-essay}"
 FOCUS_MIN_SCORE="${LIFEHUG_MONTHLY_FOCUS_MIN_SCORE:-15}"
+# Conversation-thread offers (issue #118): at most this many ignorable lines a
+# month, and an offered neighborhood stays quiet for a quarter afterwards.
+THREAD_OFFERS="${LIFEHUG_MONTHLY_THREAD_OFFERS:-1}"
 TARGETS_FILE="$(mktemp "${TMPDIR:-/tmp}/lifehug-monthly-targets.XXXXXX")"
 ROSTER_PREVIEW_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lifehug-roster-preview.XXXXXX")"
 trap 'rm -f "$TARGETS_FILE"; rm -rf "$ROSTER_PREVIEW_DIR"' EXIT
@@ -254,6 +257,9 @@ if [[ "$DRY_RUN" == "1" ]]; then
     run_step python3 "$SCRIPT_DIR/research_expand.py" --topic "$SELF_TOPIC" --type self --output "$SELF_OUTPUT" --dry-run
   fi
   echo
+  echo "==> preview conversation-thread offers"
+  run_step python3 "$SCRIPT_DIR/lifehug.py" arc-thread-offers --limit "$THREAD_OFFERS" --dry-run
+  echo
   echo "==> preview Focus recommendations"
   preview_focuses
   echo
@@ -344,6 +350,21 @@ run_step python3 "$SCRIPT_DIR/lifehug.py" compile
 # ~a year ago get re-inserted WITH last year's answer attached (10Q model).
 run_optional python3 "$SCRIPT_DIR/lifehug.py" perennials --generate-due
 
+# Conversation-thread offers (issue #118): research neighborhoods that already
+# have record to open from AND somewhere left to go become multi-session
+# conversation threads. Deterministic (no AI), capped, and never repeated
+# within a quarter — empty most months by design.
+set +e
+THREAD_OFFERS_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" arc-thread-offers --limit "$THREAD_OFFERS" 2>&1)
+THREAD_OFFERS_STATUS=$?
+set -e
+if [[ "$THREAD_OFFERS_STATUS" -ne 0 ]]; then
+  record_learning_failure "monthly_research" "arc_thread_offers" "$THREAD_OFFERS_STATUS" "$THREAD_OFFERS_OUT"
+  THREAD_OFFERS_OUT="⚠ conversation-thread offers FAILED (exit ${THREAD_OFFERS_STATUS})
+${THREAD_OFFERS_OUT}"
+fi
+echo "$THREAD_OFFERS_OUT"
+
 # Echo-style resurfacing (v71): send one old answer back verbatim with a
 # reflection question — reviewing past entries is itself the intervention
 # (CHI 2013). Deterministic per month; replies become reflection sources.
@@ -381,7 +402,7 @@ body = " ".join(body.split())[:900]
 message = (f"🪞 Lifehug — from your own archive\n\n"
            f"On {answered_date} you wrote ({f.stem}):\n\n“{body}”\n\n"
            f"Reading it now — what do you see that you couldn't see then? "
-           f"(Reply and it saves as a reflection on {f.stem})")
+           f"(Reply and we'll talk it through — it saves as a reflection on {f.stem})")
 if send_telegram(message):
     print(f"✓ Resurfaced {f.stem} ({answered_date}) with a reflection question")
 else:
@@ -401,6 +422,7 @@ mkdir -p "$REPORT_DIR"
     "Research neighborhoods:RESEARCH_OUT" \
     "Focus recommendations:FOCUSES_OUT" \
     "Entity rosters:ROSTER_OUT" \
+    "Conversation threads:THREAD_OFFERS_OUT" \
     "Resurfacing:RESURFACE_OUT" \
     "Progress:PROGRESS_OUT"; do
     title="${section%%:*}"; var="${section##*:}"
@@ -418,4 +440,13 @@ SUMMARY=$(python3 "$SCRIPT_DIR/lifehug.py" weekly-summary \
   --kind monthly --since "$START_TS" --report-path "$REPORT_FILE" 2>&1) \
   || SUMMARY="⚠ monthly summary generation failed — see $REPORT_FILE"
 
-telegram_notify "${SUMMARY}"
+# The month's conversation-thread offer (issue #118) rides along with the
+# summary: one ignorable line, in the register of an invitation.
+THREAD_OFFER_LINES=$(printf '%s\n' "$THREAD_OFFERS_OUT" | grep '^💬' || true)
+if [[ -n "$THREAD_OFFER_LINES" ]]; then
+  telegram_notify "${SUMMARY}
+
+${THREAD_OFFER_LINES}"
+else
+  telegram_notify "${SUMMARY}"
+fi

--- a/system/question_candidates.py
+++ b/system/question_candidates.py
@@ -831,8 +831,12 @@ def generate_due_perennials(dry_run: bool = False) -> list[tuple[str, str]]:
             continue
 
         year = answered_date[:4]
+        # Issue #118: the mechanism is unchanged (last year's answer attached);
+        # the closing line becomes a conversation opener rather than a bare
+        # re-ask — the perennial is an invitation to talk, not a form to fill.
         reask_text = (f"In {year} you answered this: \"{excerpt}\" — "
-                      f"a year on, here it is again: {original['text']}")
+                      f"a year on, here it is again: {original['text']} "
+                      f"Reply and we'll talk it through.")
         category = str(original["category"])
         new_id = next_question_id(bank_text, category)
         if not dry_run:

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 153,
+  "version": 154,
   "released": "2026-08-11",
-  "changelog": "v153: the post-answer moment becomes a CONVERSATION (issue #116, Wave 2 PR 3). Answering a question no longer produces two disconnected messages \u2014 a warm acknowledgment that cannot ask anything, followed by a rotation-picked question about something else. It now produces ONE message that receives what you said, pays it back with something you didn't have, and cues the next question in your own words: a short chat (~3 exchanges) that ends gracefully and, when it earned one, closes with a takeaway. Partial chats file cleanly and close silently \u2014 no nagging, ever. system/conversation_delivery.py orchestrates the turn through the issue #115 builders and the interactions/conversation/ behavior authority, enforcing the deterministic lints (one question, length cap, banned phrases) before anything is sent; state/conversation_deliveries.json makes delivery exactly-once (confirmed replays are no-ops, ambiguous is never auto-retried); and ANY definitive failure degrades to the previous acknowledgment + follow-up pair in the same run, so this is never silent and never worse than before. New config keys conversation_model / router_model / arc_plan_model; conversation-status and conversation-close upgraded in place (--expired runs the idle sweep) plus the new conversation-turn-retry operator door; engagement signal is recorded on each answered question at close.",
+  "changelog": "v154: the daily question stops being three unrelated prompts (issue #118, Conversation Interaction Wave 2). The WEEKLY loop now plans one arc card per queued question \u2014 an opening framing quoted from your own record plus 2-4 typed follow-up intents \u2014 and the daily loop simply attaches it, so the day's message opens where you actually left off while the daily path stays AI-free. The card's intents claim three gap seams that were previously display-only: unfilled five-slot scene probes, sibling questions in the same research neighborhood, and timeline gaps (the first non-display consumer of compute_gaps \u2014 always phrased as landmark anchors, never \"what year\"), plus studio format slots, a Mirror \"sit with\" tension on self-arc questions, and small demonstrated-knowledge summaries once a category has material. Cards live and die with the question queue, so a missed week degrades to today's message format instead of breaking. Keyless machines get deterministic cards immediately plus an agent task for the model pass. Monthly research now offers one conversation thread from a neighborhood that has record to open from and somewhere left to go (never twice in a quarter), and resurfaced/perennial questions close as an invitation to talk rather than a form to fill.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -187,6 +187,7 @@
     "system/conversation.py",
     "system/conversation_lints.py",
     "system/conversation_delivery.py",
-    "tests/test_conversation_delivery.py"
+    "tests/test_conversation_delivery.py",
+    "system/arc_planner.py"
   ]
 }

--- a/system/weekly_maintenance.sh
+++ b/system/weekly_maintenance.sh
@@ -162,6 +162,7 @@ if [[ "$DRY_RUN" == "1" ]]; then
   echo "==> (real run) lifehug.py mirror-compile — synthesizes wiki/self/mirror.md (skipped in dry run: costs an AI call)"
   run_step python3 "$SCRIPT_DIR/lifehug.py" candidates-auto-promote --dry-run
   run_step python3 "$SCRIPT_DIR/lifehug.py" planner-report --limit "$QUEUE_LIMIT"
+  run_step python3 "$SCRIPT_DIR/lifehug.py" arc-plan --dry-run --limit "$QUEUE_LIMIT" --gap-max "${LIFEHUG_WEEKLY_ARC_GAP_MAX:-3}"
   run_step python3 "$SCRIPT_DIR/research_expand.py" --gaps --dry-run
   run_step python3 "$SCRIPT_DIR/lifehug.py" progress
   SINCE_7D=$(python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc)-timedelta(days=7)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
@@ -275,6 +276,38 @@ run_learning_step "planner_queue" python3 "$SCRIPT_DIR/lifehug.py" planner-queue
 # shellcheck disable=SC2034
 QUEUE_OUT="$LAST_STEP_OUT"
 
+# Arc cards (issue #118): one card per question the queue just planned — an
+# opening framing plus 2–4 typed follow-up intents — so the daily loop can
+# ATTACH a plan instead of asking three unrelated questions. Runs DIRECTLY
+# after planner_queue so the cards are planned against the queue just written,
+# and they expire with it.
+#
+# PARITY SPEC (binding): the platform transports this step verbatim as
+# StepSpec("arcs", "arc_plan", llm=True) + LlmPurpose "arc_plan". Every cap,
+# gate, and fallback the platform needs must appear HERE first — a
+# platform-side gate absent from this step is a parity merge-blocker.
+ARC_GAP_MAX="${LIFEHUG_WEEKLY_ARC_GAP_MAX:-3}"
+# ARCS_OUT is read indirectly by the report section table below.
+# shellcheck disable=SC2034
+if [[ "$KEYLESS" == "1" ]]; then
+  echo
+  echo "==> keyless — writing deterministic arc cards and emitting the arc-plan task"
+  set +e
+  ARCS_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" arc-plan --limit "$QUEUE_LIMIT" --gap-max "$ARC_GAP_MAX" --emit-tasks "$AGENT_TASKS_DIR/arcs" 2>&1)
+  ARCS_STATUS=$?
+  set -e
+  if [[ "$ARCS_STATUS" -ne 0 ]]; then
+    record_learning_failure "weekly_maintenance" "arc_plan_emit" "$ARCS_STATUS" "$ARCS_OUT"
+  elif ! grep -q "^No queued questions" <<< "$ARCS_OUT"; then
+    ARCS_OUT="⏸ keyless — arc-plan task emitted, not a failure. Deterministic cards are already written; complete the model pass via the maintenance skill (--from-response).
+$ARCS_OUT"
+  fi
+  echo "$ARCS_OUT"
+else
+  run_learning_step "arc_plan" python3 "$SCRIPT_DIR/lifehug.py" arc-plan --limit "$QUEUE_LIMIT" --gap-max "$ARC_GAP_MAX"
+  ARCS_OUT="$LAST_STEP_OUT"
+fi
+
 run_step python3 "$SCRIPT_DIR/research_expand.py" --gaps --dry-run
 PROGRESS_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" progress 2>&1)
 echo "$PROGRESS_OUT"
@@ -320,6 +353,7 @@ mkdir -p "$REPORT_DIR"
     "Mirror:MIRROR_OUT" \
     "Candidate promotion:PROMOTE_OUT" \
     "Planner queue:QUEUE_OUT" \
+    "Arc cards:ARCS_OUT" \
     "Progress:PROGRESS_OUT" \
     "Learning failures:LEARNING_OUT" \
     "Focus recommendations:RECS_OUT" \

--- a/tests/test_arc_planner.py
+++ b/tests/test_arc_planner.py
@@ -1,0 +1,755 @@
+"""issue #118 — the weekly arc planner (Conversation Interaction, Wave 2 PR 5).
+
+The daily Chat's ~3 exchanges become a coherent, pre-planned mini-arc: the
+WEEKLY loop plans one arc card per queued question (opening framing + 2–4
+typed follow-up intents) and the daily loop merely ATTACHES it, staying
+AI-free by construction.
+
+The convergence property (owner-set) is the load-bearing acceptance criteria
+here: on a synthetic fixture vault carrying each gap type, every detectable
+gap must have a named consumer that turns it into a conversation input.
+
+Synthetic data only; NEVER references ~/Workspace/dave.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSTEM = ROOT / "system"
+sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
+
+from tempdirs import root_parent_tmp  # noqa: E402
+
+import arc_planner  # noqa: E402
+import book  # noqa: E402
+import conversation  # noqa: E402
+import question_planner  # noqa: E402
+import timeline  # noqa: E402
+
+
+def iso(moment: datetime) -> str:
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+NOW = datetime(2026, 8, 16, 9, 0, tzinfo=timezone.utc)
+
+
+class VaultFixture:
+    """A synthetic vault carrying every gap type the planner consumes."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        (root / "answers").mkdir(parents=True, exist_ok=True)
+        (root / "state" / "classifications").mkdir(parents=True, exist_ok=True)
+        (root / "wiki" / "self").mkdir(parents=True, exist_ok=True)
+
+    # -- writers ---------------------------------------------------------
+    def write_json(self, rel: str, data: object) -> None:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    def write_text(self, rel: str, text: str) -> None:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def answer(self, qid: str, body: str, answered_date: str = "2026-03-01") -> None:
+        self.write_text(
+            f"answers/{qid}.md",
+            f"---\nquestion_id: \"{qid}\"\nanswered_date: \"{answered_date}\"\n"
+            f"schema_version: 1\n---\n\n{body}\n",
+        )
+
+    def classification(self, qid: str, slots: dict[str, bool]) -> None:
+        self.write_json(f"state/classifications/{qid}.json",
+                        {"source_path": f"answers/{qid}.md", "scene_slots": slots})
+
+    def queue(self, items: list[dict], *, generated_at: str | None = None,
+              expires_at: str | None = None) -> None:
+        self.write_json("state/question_queue.json", {
+            "version": 3,
+            "generated_at": generated_at or iso(NOW - timedelta(hours=1)),
+            "expires_at": expires_at or iso(NOW + timedelta(days=8)),
+            "queue": items,
+        })
+
+    def bank(self, rows: list[tuple[str, str, bool]]) -> None:
+        """rows = [(qid, text, answered)] grouped into per-letter sections."""
+        by_letter: dict[str, list[tuple[str, str, bool]]] = {}
+        for qid, text, answered in rows:
+            by_letter.setdefault(qid[0], []).append((qid, text, answered))
+        names = {"A": "Origins (Childhood & Family)", "B": "Becoming",
+                 "C": "Relationships & People", "D": "Purpose & Calling"}
+        lines = ["# Life Hug — Question Bank", "", "Pass 1: Skeleton", "", "---", ""]
+        for letter, entries in sorted(by_letter.items()):
+            lines.append(f"## {letter}: {names.get(letter, letter)}")
+            for qid, text, answered in entries:
+                lines.append(f"- [{'x' if answered else ' '}] {qid}: {text}")
+            lines.append("")
+        self.write_text("question-bank.md", "\n".join(lines))
+
+
+def queue_item(qid: str, **overrides) -> dict:
+    item = {
+        "question_id": qid,
+        "category": qid[0],
+        "group": "main",
+        "focus": None,
+        "source": "question_bank",
+        "source_type": "bank",
+        "story_function": "scene",
+        "objective": None,
+        "status": "queued",
+        "reason": "focus main; scene story function; category coverage 20%",
+    }
+    item.update(overrides)
+    return item
+
+
+def timeline_payload(*, unplaced_events: int = 0, no_events_period: str | None = None,
+                     all_undated_period: str | None = None) -> dict:
+    """An assembled payload built with the REAL timeline.compute_gaps().
+
+    The planner consumes timeline_data()'s assembled payload; assembling one
+    here from the genuine gap function is what makes the convergence subtest
+    an assertion about the real seam rather than about a hand-written dict.
+    """
+    periods: list[dict] = []
+    event_lineup: dict[str, list[dict]] = {}
+    entity_lineup: dict[str, list[dict]] = {}
+    if no_events_period:
+        periods.append({"slug": no_events_period, "name": "The Denver Years", "chrono": 1})
+        event_lineup[no_events_period] = []
+        entity_lineup[no_events_period] = [{"title": "Marbles"}]
+    if all_undated_period:
+        periods.append({"slug": all_undated_period, "name": "The Ghana Years", "chrono": 2})
+        event_lineup[all_undated_period] = [{"description": "the move", "when_hint": ""}]
+        entity_lineup[all_undated_period] = [{"title": "Accra"}]
+    unplaced = [{"description": f"moment {n}"} for n in range(unplaced_events)]
+    gaps = timeline.compute_gaps(periods, entity_lineup, event_lineup, [], unplaced)
+    by_period: dict[str, list[dict]] = {}
+    global_gaps: list[dict] = []
+    for gap in gaps:
+        if gap.get("period"):
+            by_period.setdefault(gap["period"], []).append(gap)
+        else:
+            global_gaps.append(gap)
+    return {"gaps_by_period": by_period, "global_gaps": global_gaps}
+
+
+class BaseVaultTest(unittest.TestCase):
+    """A queue of four questions with material for every intent kind."""
+
+    prefix = "lifehug-118-arc-"
+
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix=self.prefix)
+        self.vault = self.tmp / "vault"
+        self.vault.mkdir()
+        self.fixture = VaultFixture(self.vault)
+        self.build_fixture()
+
+    def build_fixture(self):
+        f = self.fixture
+        f.bank([
+            ("A1", "What's your earliest memory?", True),
+            ("A2", "Tell me about where you grew up.", True),
+            ("A3", "Tell me about the winter you moved.", False),
+            ("B1", "When did you first feel agency over your life?", False),
+            ("C1", "Who believed in you before you believed in yourself?", False),
+            ("D1", "What moment made you choose this path?", False),
+        ])
+        f.answer("A1", "The diesel smell of my grandfather's truck on the farm road. "
+                       "I was maybe four, and the seat was too hot to touch.")
+        f.answer("A2", "A narrow house on Pearl Street with a cottonwood out front.",
+                 answered_date="2026-04-02")
+        # A1 has a partially-filled scene; A2 is fully unclassified.
+        f.classification("A1", {"what_happened": True, "when_and_where": True,
+                                "who_was_there": False, "thought_and_felt": False,
+                                "what_it_says_about_me": False})
+        f.write_text("wiki/self/mirror.md",
+                     "---\ntitle: Mirror\n---\n\n## Tensions I keep circling\n\n- one\n\n"
+                     "## What I seem to know about myself\n\n- two\n\n"
+                     "## Stated positions\n\n- three\n\n"
+                     "## Sit with\n\n"
+                     "- You call yourself private, yet you tell strangers everything — which is true?\n"
+                     "- Whose approval are you still working for?\n"
+                     "- What would you keep doing if no one ever saw it?\n")
+        f.write_json("state/neighborhoods.json", {"neighborhoods": [{
+            "id": "the-ghana-years", "title": "the Ghana years", "type": "time_period",
+            "target_output": "chapter", "status": "active",
+            "arc": [{"story_function": "scene", "question_id": "C1", "status": "promoted"},
+                    {"story_function": "meaning", "question_id": "cand-ghana-2", "status": "candidate"},
+                    {"story_function": "tension", "question_id": "A1", "status": "answered"}],
+        }]})
+        f.write_json("state/question_candidates.json", {"candidates": [
+            {"id": "cand-ghana-2", "neighborhood_id": "the-ghana-years", "status": "accepted",
+             "story_function": "meaning", "text": "What did leaving Accra cost you?"},
+            {"id": "cand-ghana-3", "neighborhood_id": "the-ghana-years", "status": "candidate",
+             "story_function": "scene", "text": "Describe the last evening in the compound."},
+        ]})
+        f.queue([
+            queue_item("A3", reason="scene story function; category coverage 40%"),
+            queue_item("B1", story_function="growth_edge"),        # self-arc
+            queue_item("C1", story_function="relationship"),        # neighborhood sibling
+            queue_item("D1", story_function="meaning", focus="etherfuse"),
+        ])
+
+    # -- helpers ---------------------------------------------------------
+    def plan(self, **kwargs):
+        kwargs.setdefault("timeline_payload", timeline_payload(unplaced_events=2,
+                                                               no_events_period="denver-years"))
+        kwargs.setdefault("vault_root", self.vault)
+        kwargs.setdefault("now", iso(NOW))
+        code, report = arc_planner.plan(**kwargs)
+        return code, report
+
+    def container(self) -> dict:
+        return conversation.load_arc_cards(vault_root=self.vault)
+
+    def cards_by_id(self) -> dict[str, dict]:
+        return {card["question_id"]: card for card in self.container()["cards"]}
+
+    def all_intents(self) -> list[dict]:
+        return [intent for card in self.container()["cards"] for intent in card["intents"]]
+
+
+class DeterministicPlanTests(BaseVaultTest):
+    """Every queued question gets a card, even with no model anywhere."""
+
+    def test_deterministic_cards_for_every_queued_item(self):
+        code, _ = self.plan()
+        self.assertEqual(code, 0)
+        container = self.container()
+        self.assertEqual(container["source"], "deterministic")
+        self.assertEqual(container["version"], conversation.ARC_CARDS_VERSION)
+        cards = container["cards"]
+        self.assertEqual([card["question_id"] for card in cards], ["A3", "B1", "C1", "D1"])
+        for card in cards:
+            self.assertGreaterEqual(len(card["intents"]), arc_planner.MIN_INTENTS, card)
+            self.assertLessEqual(len(card["intents"]), arc_planner.MAX_INTENTS, card)
+            self.assertEqual(card["planner"], "deterministic")
+        # With this much material the target band is reachable for every card.
+        for card in cards:
+            self.assertGreaterEqual(len(card["intents"]), arc_planner.TARGET_MIN_INTENTS, card)
+
+    def test_expiry_and_queue_stamps_are_copied_verbatim(self):
+        self.plan()
+        queue = arc_planner.load_queue(vault_root=self.vault)
+        container = self.container()
+        self.assertEqual(container["queue_generated_at"], queue["generated_at"])
+        self.assertEqual(container["expires_at"], queue["expires_at"])
+
+    def test_intent_vocabulary_closed(self):
+        self.plan()
+        for intent in self.all_intents():
+            self.assertIn(intent["kind"], conversation.ARC_INTENT_KINDS)
+        rogue = {"question_id": "A3", "intents": [{"kind": "vibe_check"}]}
+        clean, errors = arc_planner.validate_card(
+            rogue, allowed_ids={"A3"}, material={}, vault_root=self.vault)
+        self.assertIsNone(clean)
+        self.assertTrue(any("vibe_check" in error for error in errors), errors)
+
+    def test_scene_slot_names_match_book_five_slots(self):
+        self.assertEqual(arc_planner._five_slots(), tuple(book.FIVE_SLOTS))
+        self.plan()
+        named = {intent["slot"] for intent in self.all_intents()
+                 if intent["kind"] == "scene_slot"}
+        self.assertTrue(named)
+        self.assertTrue(named.issubset(set(book.FIVE_SLOTS)), named)
+
+    def test_unfilled_five_slot_probe_prefers_what_it_says_about_me(self):
+        self.plan()
+        card = self.cards_by_id()["A3"]
+        slots = [intent["slot"] for intent in card["intents"] if intent["kind"] == "scene_slot"]
+        self.assertTrue(slots)
+        self.assertEqual(slots[0], "what_it_says_about_me")
+
+
+class ConvergencePropertyTests(BaseVaultTest):
+    """Owner-set acceptance criteria: every detectable gap type has a named
+    consumer that turns it into a conversation input."""
+
+    def test_timeline_gap_consumer_fires_and_never_says_what_year(self):
+        self.plan(timeline_payload=timeline_payload(unplaced_events=3,
+                                                    all_undated_period="ghana-years"))
+        gap_intents = [intent for intent in self.all_intents() if intent["kind"] == "timeline_gap"]
+        self.assertTrue(gap_intents, "the timeline gaps produced no conversation input")
+        self.assertTrue({intent["gap_kind"] for intent in gap_intents}
+                        <= set(arc_planner.CONSUMED_GAP_KINDS))
+        blob = json.dumps(self.container()).lower()
+        self.assertNotIn(arc_planner.BANNED_PHRASE, blob)
+        self.assertTrue(any("landmark" in intent["note"] for intent in gap_intents))
+
+    def test_timeline_gap_capped_per_card_and_per_week(self):
+        self.plan(timeline_payload=timeline_payload(unplaced_events=2,
+                                                    no_events_period="denver-years",
+                                                    all_undated_period="ghana-years"),
+                  gap_max=2)
+        per_card = [sum(1 for intent in card["intents"] if intent["kind"] == "timeline_gap")
+                    for card in self.container()["cards"]]
+        self.assertLessEqual(max(per_card), 1, "at most one timeline_gap intent per card")
+        self.assertLessEqual(sum(per_card), 2, "the week-wide gap cap must hold")
+
+    def test_scene_slot_consumer_fires_for_unfilled_five_slot_scenes(self):
+        self.plan()
+        slot_intents = [intent for intent in self.all_intents() if intent["kind"] == "scene_slot"]
+        self.assertTrue(slot_intents)
+        for intent in slot_intents:
+            self.assertIn(intent["slot"], book.FIVE_SLOTS)
+
+    def test_sit_with_only_for_self_arc_items(self):
+        self.plan()
+        cards = self.cards_by_id()
+        self.assertIn("growth_edge", question_planner.SELF_FUNCTIONS)
+        b1_sit = [intent for intent in cards["B1"]["intents"] if intent["kind"] == "sit_with"]
+        self.assertEqual(len(b1_sit), 1, "the self-arc item must get a sit_with intent")
+        self.assertIn(b1_sit[0]["text"],
+                      arc_planner.collect_sit_with(vault_root=self.vault))
+        for qid in ("A3", "C1", "D1"):
+            self.assertFalse([i for i in cards[qid]["intents"] if i["kind"] == "sit_with"],
+                             f"{qid} is not a self-arc item")
+
+    def test_neighborhood_sibling_consumer_fires(self):
+        self.plan()
+        siblings = [intent for intent in self.cards_by_id()["C1"]["intents"]
+                    if intent["kind"] == "neighborhood_sibling"]
+        self.assertTrue(siblings, "a neighborhood with pending siblings produced no input")
+        self.assertEqual(siblings[0]["neighborhood_id"], "the-ghana-years")
+        self.assertIn(siblings[0]["candidate_id"], {"cand-ghana-2", "cand-ghana-3"})
+
+    def test_studio_slot_consumer_fires_or_no_ops_silently(self):
+        cards = [{
+            "format": "letter", "focus_id": "etherfuse",
+            "slots": [{"id": "opening_address", "label": "Opening address", "filled": False},
+                      {"id": "shared_history", "label": "Shared history", "filled": True}],
+        }]
+        self.plan(readiness_cards=cards)
+        studio = [intent for intent in self.cards_by_id()["D1"]["intents"]
+                  if intent["kind"] == "studio_slot"]
+        self.assertTrue(studio, "an unfilled format slot produced no input")
+        self.assertEqual(studio[0]["slot"], "opening_address")
+        self.assertEqual(studio[0]["format"], "letter")
+        # Documented silent no-op: no framework at all ⇒ no studio intents,
+        # and every other consumer still fires.
+        self.plan(readiness_cards=[])
+        self.assertFalse([i for i in self.all_intents() if i["kind"] == "studio_slot"])
+        self.assertTrue(self.container()["cards"])
+
+    def test_demonstrated_knowledge_requires_two_answers_and_real_receipts(self):
+        self.plan()
+        cards = self.cards_by_id()
+        a3 = [intent for intent in cards["A3"]["intents"]
+              if intent["kind"] == "demonstrated_knowledge_summary"]
+        self.assertTrue(a3, "category A has two answers on record")
+        material = arc_planner.collect_material([], vault_root=self.vault)
+        for receipt in a3[0]["receipts"]:
+            self.assertTrue(arc_planner.receipt_resolves(receipt, material, vault_root=self.vault))
+        for qid in ("B1", "C1", "D1"):  # categories with 0 answers
+            self.assertFalse([i for i in cards[qid]["intents"]
+                              if i["kind"] == "demonstrated_knowledge_summary"], qid)
+
+
+class OpeningTests(BaseVaultTest):
+    """The two-sentence rule and the receipts that make it honest."""
+
+    def test_deterministic_opening_quotes_the_record_verbatim(self):
+        self.plan()
+        card = self.cards_by_id()["A3"]
+        self.assertIsNotNone(card["opening"])
+        # The FRESHEST on-record answer in the category (A2, 2026-04-02) is
+        # the material — the most recent thing said is the most conversational.
+        self.assertIn("Pearl Street", card["opening"])
+        self.assertEqual(card["opening_receipts"], ["A2"])
+        body = (self.vault / "answers" / "A2.md").read_text(encoding="utf-8")
+        quote = card["opening"].split('"')[1]
+        self.assertIn(quote, " ".join(body.split()))
+
+    def test_opening_is_null_without_record_in_the_category(self):
+        self.plan()
+        for qid in ("B1", "C1", "D1"):
+            card = self.cards_by_id()[qid]
+            self.assertIsNone(card["opening"], f"{qid} has nothing on record to quote")
+            self.assertEqual(card["opening_receipts"], [])
+
+    def test_opening_receipts_must_resolve(self):
+        material = arc_planner.collect_material([], vault_root=self.vault)
+        fabricated = {
+            "question_id": "A3",
+            "opening": "You wrote about the summer in Lisbon.",
+            "opening_receipts": ["Z99"],
+            "intents": [{"kind": "scene_slot", "slot": "who_was_there"},
+                        {"kind": "scene_slot", "slot": "thought_and_felt"}],
+        }
+        clean, errors = arc_planner.validate_card(
+            fabricated, allowed_ids={"A3"}, material=material, vault_root=self.vault)
+        self.assertIsNotNone(clean, "the card survives; only the opening is dropped")
+        self.assertIsNone(clean["opening"])
+        self.assertEqual(clean["opening_receipts"], [])
+        self.assertTrue(any("Z99" in error for error in errors), errors)
+
+        real = dict(fabricated, opening="You wrote: \"The diesel smell…\"",
+                    opening_receipts=["A1"])
+        clean, errors = arc_planner.validate_card(
+            real, allowed_ids={"A3"}, material=material, vault_root=self.vault)
+        self.assertIsNotNone(clean["opening"])
+        self.assertEqual(errors, [])
+
+    def test_what_year_is_rejected_anywhere_in_a_card(self):
+        material = arc_planner.collect_material([], vault_root=self.vault)
+        card = {"question_id": "A3",
+                "intents": [{"kind": "timeline_gap", "gap_kind": "unplaced_events",
+                             "note": "ask What Year that happened"},
+                            {"kind": "scene_slot", "slot": "who_was_there"}]}
+        clean, errors = arc_planner.validate_card(
+            card, allowed_ids={"A3"}, material=material, vault_root=self.vault)
+        self.assertIsNone(clean)
+        self.assertTrue(any(arc_planner.BANNED_PHRASE in error for error in errors), errors)
+
+
+class DailyAttachTests(BaseVaultTest):
+    """The daily loop is a pure read: empty-vs-nonempty, marker preserved."""
+
+    def test_daily_text_contains_qid_marker_and_is_empty_without_live_card(self):
+        self.assertEqual(arc_planner.daily_text("A3", vault_root=self.vault, now=NOW), "",
+                         "no cards planned yet ⇒ nothing attaches")
+        self.plan()
+        text = arc_planner.daily_text("A3", vault_root=self.vault, now=NOW)
+        self.assertTrue(text)
+        self.assertIn("[A3]", text)
+        self.assertIn("Pearl Street", text)          # the framing, from the record
+        self.assertIn("Tell me about the winter you moved.", text)  # …then the question
+        # The marker is in ask.format_question's exact shape — daily_question.sh
+        # parses it with this regex and the answer-filing flow keys on it.
+        import re
+        self.assertEqual(re.search(r"\[([A-Z]\d+[a-z]*)\]", text).group(1), "A3")
+
+        # A card with no opening reads as "no attach" — today's format stands.
+        self.assertEqual(arc_planner.daily_text("B1", vault_root=self.vault, now=NOW), "")
+
+    def test_expiry_follows_queue_and_dead_cards_never_attach(self):
+        self.plan()
+        self.assertIsNotNone(arc_planner.live_card("A3", vault_root=self.vault, now=NOW))
+        after_expiry = NOW + timedelta(days=9)
+        self.assertIsNone(arc_planner.live_card("A3", vault_root=self.vault, now=after_expiry))
+        self.assertEqual(arc_planner.daily_text("A3", vault_root=self.vault, now=after_expiry), "")
+
+    def test_card_dies_when_its_question_leaves_the_queue(self):
+        self.plan()
+        self.fixture.queue([queue_item("D1", story_function="meaning")])
+        self.assertIsNone(arc_planner.live_card("A3", vault_root=self.vault, now=NOW))
+        self.assertEqual(arc_planner.daily_text("A3", vault_root=self.vault, now=NOW), "")
+
+    def test_a_sent_question_keeps_its_card_for_the_day(self):
+        self.plan()
+        items = arc_planner.load_queue(vault_root=self.vault)["queue"]
+        items[0]["status"] = "sent"
+        self.fixture.queue(items)
+        self.assertIsNotNone(arc_planner.live_card("A3", vault_root=self.vault, now=NOW))
+
+
+def model_response(question_ids: list[str]) -> str:
+    return json.dumps({"cards": [{
+        "question_id": qid,
+        "opening": "You wrote: \"A narrow house on Pearl Street with a cottonwood out front.\"",
+        "opening_receipts": ["A2"],
+        "intents": [{"kind": "scene_slot", "slot": "who_was_there", "note": "who else was there"},
+                    {"kind": "demonstrated_knowledge_summary", "receipts": ["A1", "A2"],
+                     "note": "summarize the two on record first"}],
+    } for qid in question_ids]})
+
+
+class ModelPassTests(BaseVaultTest):
+    """One prompt per run; invalid or absent output never costs the week."""
+
+    def test_model_cards_upgrade_the_deterministic_plan(self):
+        with mock.patch("ai_provider.call_ai", return_value=model_response(["A3", "B1"])):
+            code, report = self.plan()
+        self.assertEqual(code, 0)
+        container = self.container()
+        self.assertEqual(container["source"], "mixed")
+        cards = self.cards_by_id()
+        self.assertEqual(cards["A3"]["planner"], "model")
+        self.assertEqual(cards["B1"]["planner"], "model")
+        self.assertEqual(cards["C1"]["planner"], "deterministic")
+        self.assertTrue(any("2 card(s) planned by the model" in line for line in report), report)
+
+    def test_model_failure_falls_back_to_deterministic(self):
+        from ai_provider import AIUnavailableError
+        with mock.patch("ai_provider.call_ai", side_effect=AIUnavailableError("no route")), \
+             mock.patch.object(arc_planner, "_record_failure") as recorded:
+            code, report = self.plan()
+        self.assertEqual(code, 0)
+        cards = self.container()["cards"]
+        self.assertEqual(len(cards), 4, "the week still gets its cards")
+        self.assertEqual(self.container()["source"], "deterministic")
+        self.assertTrue(any("Model pass unavailable" in line for line in report), report)
+        recorded.assert_called_once()
+        self.assertEqual(recorded.call_args.args[0], "arc_plan_model")
+
+    def test_invalid_model_output_falls_back_without_writing_a_broken_file(self):
+        for raw in ("not json at all",
+                    json.dumps({"cards": [{"question_id": "A3",
+                                           "intents": [{"kind": "astrology"}]}]}),
+                    json.dumps({"cards": [{"question_id": "ZZ9",
+                                           "intents": [{"kind": "scene_slot"}]}]})):
+            with self.subTest(raw=raw[:30]), \
+                 mock.patch("ai_provider.call_ai", return_value=raw):
+                code, _ = self.plan()
+            self.assertEqual(code, 0)
+            self.assertEqual(self.container()["source"], "deterministic")
+            self.assertEqual(len(self.container()["cards"]), 4)
+
+    def test_one_prompt_per_run_not_per_card(self):
+        with mock.patch("ai_provider.call_ai", return_value=model_response(["A3"])) as call:
+            self.plan()
+        self.assertEqual(call.call_count, 1, "the weekly run makes exactly one model call")
+        prompt = call.call_args.args[0]
+        for qid in ("A3", "B1", "C1", "D1"):
+            self.assertIn(f"QUESTION [{qid}]", prompt)
+        # The definition file is carried verbatim, per the merged builder shape.
+        self.assertIn("# Arc templates — how arc cards are planned", prompt)
+        self.assertIn("INPUT (assembled at runtime", prompt)
+
+    def test_model_resolution_order(self):
+        with mock.patch.object(arc_planner, "load_config",
+                               return_value={"arc_plan_model": "m-arc", "classify_model": "m-classify"}):
+            self.assertEqual(arc_planner.resolve_model(), "m-arc")
+        with mock.patch.object(arc_planner, "load_config", return_value={"classify_model": "m-classify"}):
+            self.assertEqual(arc_planner.resolve_model(), "m-classify")
+        with mock.patch.object(arc_planner, "load_config", return_value={}):
+            import classify_story
+            self.assertEqual(arc_planner.resolve_model(), classify_story.DEFAULT_MODEL)
+        with mock.patch.object(arc_planner, "load_config", return_value={"arc_plan_model": "m-arc"}):
+            self.assertEqual(arc_planner.resolve_model("explicit"), "explicit")
+
+
+class KeylessTests(BaseVaultTest):
+    """Keyless: deterministic cards land NOW, the prompt goes out as a task."""
+
+    def test_emit_tasks_writes_cards_and_a_manifest(self):
+        out = self.tmp / "agent_tasks" / "arcs"
+        code, report = self.plan(emit_tasks_dir=out)
+        self.assertEqual(code, 0)
+        self.assertEqual(len(self.container()["cards"]), 4)
+        self.assertEqual(self.container()["source"], "deterministic")
+        manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["task"], "arcs")
+        self.assertIn("--from-response", manifest["ingest_command"])
+        self.assertEqual(manifest["items"][0]["response"], "arcs.response.json")
+        self.assertTrue((out / "arcs.prompt.md").is_file())
+        self.assertTrue(any("Emitted arc-plan task" in line for line in report), report)
+
+    def test_from_response_upgrades_deterministic_cards(self):
+        out = self.tmp / "agent_tasks" / "arcs"
+        self.plan(emit_tasks_dir=out)
+        self.assertTrue(all(card["planner"] == "deterministic"
+                            for card in self.container()["cards"]))
+        response = out / "arcs.response.json"
+        response.write_text(model_response(["A3", "C1"]), encoding="utf-8")
+
+        code, report = arc_planner.ingest_response(response, vault_root=self.vault, now=iso(NOW))
+        self.assertEqual(code, 0, report)
+        cards = self.cards_by_id()
+        self.assertEqual(cards["A3"]["planner"], "model")
+        self.assertEqual(cards["C1"]["planner"], "model")
+        self.assertEqual(cards["B1"]["planner"], "deterministic")
+        self.assertEqual(self.container()["source"], "mixed")
+        self.assertEqual(len(self.container()["cards"]), 4, "no card is lost in an upgrade")
+
+    def test_a_rerun_does_not_clobber_model_cards_unless_forced(self):
+        out = self.tmp / "agent_tasks" / "arcs"
+        self.plan(emit_tasks_dir=out)
+        response = out / "arcs.response.json"
+        response.write_text(model_response(["A3"]), encoding="utf-8")
+        arc_planner.ingest_response(response, vault_root=self.vault, now=iso(NOW))
+
+        self.plan(emit_tasks_dir=out)  # same queue, deterministic re-run
+        self.assertEqual(self.cards_by_id()["A3"]["planner"], "model")
+
+        self.plan(emit_tasks_dir=out, force=True)
+        self.assertEqual(self.cards_by_id()["A3"]["planner"], "deterministic")
+
+
+class ThreadOfferTests(BaseVaultTest):
+    """Monthly conversation-thread offers: one line, never twice a quarter."""
+
+    def test_conversation_ready_requires_somewhere_to_go_and_record_to_open_from(self):
+        ready = arc_planner.conversation_ready_neighborhoods(vault_root=self.vault)
+        self.assertEqual([n["id"] for n in ready], ["the-ghana-years"])
+
+        # Every slot answered ⇒ nowhere to go ⇒ not conversation-ready.
+        self.fixture.write_json("state/neighborhoods.json", {"neighborhoods": [{
+            "id": "the-ghana-years", "title": "the Ghana years", "status": "active",
+            "arc": [{"story_function": "tension", "question_id": "A1"}],
+        }]})
+        self.assertEqual(arc_planner.conversation_ready_neighborhoods(vault_root=self.vault), [])
+
+    def test_thread_offers_never_repeat_within_quarter(self):
+        lines, fresh = arc_planner.plan_thread_offers(vault_root=self.vault, now=NOW)
+        self.assertEqual(len(lines), 1)
+        self.assertIn("the Ghana years", lines[0])
+        self.assertEqual(fresh[0]["neighborhood_id"], "the-ghana-years")
+        self.assertEqual(fresh[0]["month"], "2026-08")
+        self.assertEqual(self.container()["thread_offers"], fresh)
+
+        next_month, _ = arc_planner.plan_thread_offers(
+            vault_root=self.vault, now=NOW + timedelta(days=31))
+        self.assertEqual(next_month, [], "an offered thread stays quiet for a quarter")
+
+        later, later_fresh = arc_planner.plan_thread_offers(
+            vault_root=self.vault, now=NOW + timedelta(days=arc_planner.THREAD_OFFER_QUIET_DAYS + 1))
+        self.assertEqual(len(later), 1, "after a quarter it may be offered again")
+        self.assertEqual(len(self.container()["thread_offers"]), 2)
+        self.assertEqual(later_fresh[0]["neighborhood_id"], "the-ghana-years")
+
+    def test_dry_run_offers_write_nothing(self):
+        lines, fresh = arc_planner.plan_thread_offers(vault_root=self.vault, now=NOW, dry_run=True)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(self.container()["thread_offers"], [])
+        self.assertTrue(fresh)
+
+    def test_offers_survive_a_weekly_replan(self):
+        arc_planner.plan_thread_offers(vault_root=self.vault, now=NOW)
+        self.plan()
+        self.assertEqual(len(self.container()["thread_offers"]), 1,
+                         "the weekly rewrite must not drop the month's offers")
+
+
+class DryRunTests(BaseVaultTest):
+    """Dry runs print the plan and write nothing at all."""
+
+    def test_plan_dry_run_writes_no_state(self):
+        code, report = self.plan(dry_run=True)
+        self.assertEqual(code, 0)
+        self.assertFalse((self.vault / "state" / "arc_cards.json").exists())
+        self.assertTrue(any("DRY RUN" in line for line in report), report)
+        self.assertTrue(any("[A3]" in line for line in report), report)
+        self.assertNotIn(arc_planner.BANNED_PHRASE, "\n".join(report).lower())
+
+    def test_empty_queue_is_not_an_error(self):
+        self.fixture.queue([])
+        code, report = self.plan()
+        self.assertEqual(code, 0)
+        self.assertEqual(report, ["No queued questions to plan arcs for."])
+
+
+class CommandSurfaceTests(unittest.TestCase):
+    """The CLI + shell seams — the weekly step is the platform's parity SPEC."""
+
+    def setUp(self):
+        self.weekly = (SYSTEM / "weekly_maintenance.sh").read_text(encoding="utf-8")
+        self.daily = (SYSTEM / "daily_question.sh").read_text(encoding="utf-8")
+        self.monthly = (SYSTEM / "monthly_research.sh").read_text(encoding="utf-8")
+        self.wrapper = (SYSTEM / "lifehug.py").read_text(encoding="utf-8")
+
+    @property
+    def weekly_real_run(self) -> str:
+        """The weekly script below its dry-run block (which exits early)."""
+        return self.weekly.split('if [[ "$DRY_RUN" == "1" ]]; then')[1].split("\nfi\n", 1)[1]
+
+    def test_weekly_plans_arcs_directly_after_the_planner_queue(self):
+        real = self.weekly_real_run
+        queue_at = real.index('run_learning_step "planner_queue"')
+        arcs_at = real.index("arc-plan")
+        research_at = real.index('research_expand.py" --gaps')
+        self.assertLess(queue_at, arcs_at, "arcs are planned against the queue just written")
+        self.assertLess(arcs_at, research_at)
+        self.assertIn('QUEUE_OUT="$LAST_STEP_OUT"', real)
+
+    def test_weekly_step_carries_the_knobs_the_platform_transports(self):
+        real = self.weekly_real_run
+        self.assertIn("LIFEHUG_WEEKLY_ARC_GAP_MAX", real)
+        self.assertIn('run_learning_step "arc_plan"', real)
+        self.assertIn("$AGENT_TASKS_DIR/arcs", real)
+        self.assertIn("Arc cards:ARCS_OUT", self.weekly)
+        # The keyless branch reports the emitted task as a pause, not a failure.
+        keyless_branch = real.split("ARC_GAP_MAX=")[1].split("run_step")[0]
+        self.assertIn("⏸ keyless", keyless_branch)
+        self.assertIn("arc_plan_emit", keyless_branch)
+
+    def test_weekly_dry_run_previews_the_arc_plan(self):
+        preview = self.weekly.split('if [[ "$DRY_RUN" == "1" ]]; then')[1].split("exit 0")[0]
+        self.assertIn("arc-plan --dry-run", preview)
+
+    def test_daily_attach_is_a_pure_read_that_keeps_the_marker(self):
+        # One definition of the attach, called from the dry run and the send.
+        self.assertIn('arc-card "$1" --daily-text', self.daily)
+        self.assertIn("arc_card_text() {", self.daily)
+        # The attach happens after the id parse and before the send.
+        parse_at = self.daily.index("Could not parse question ID")
+        attach_at = self.daily.index('ARC_TEXT=$(arc_card_text "$QUESTION_ID")')
+        send_at = self.daily.index("RESPONSE=$(send_message")
+        self.assertLess(parse_at, attach_at)
+        self.assertLess(attach_at, send_at)
+        self.assertIn("📖 Lifehug — Daily Question", self.daily)
+        self.assertIn("(Answer whenever you want — voice or text)", self.daily)
+        # Empty output ⇒ today's format, unchanged.
+        self.assertIn('QUESTION_BODY="$QUESTION_OUTPUT"', self.daily)
+
+    def test_daily_dry_run_shows_the_would_be_attach(self):
+        preview = self.daily.split('if [[ "$DRY_RUN" == "1" ]]; then')[1].split("exit 0")[0]
+        self.assertIn("arc_card_text", preview)
+        self.assertIn("no live arc card", preview)
+
+    def test_monthly_offers_threads_and_previews_them(self):
+        self.assertIn("arc-thread-offers", self.monthly)
+        self.assertIn("LIFEHUG_MONTHLY_THREAD_OFFERS", self.monthly)
+        preview = self.monthly.split('if [[ "$DRY_RUN" == "1" ]]; then')[1].split("exit 0")[0]
+        self.assertIn("arc-thread-offers", preview)
+        self.assertIn("Conversation threads:THREAD_OFFERS_OUT", self.monthly)
+
+    def test_monthly_resurfacing_closes_as_a_conversation_opener(self):
+        self.assertIn("Reply and we'll talk it through", self.monthly)
+
+    def test_wrapper_classifies_the_three_commands(self):
+        import lifehug
+        self.assertIn("arc-card", lifehug.READ_ONLY_COMMANDS)
+        self.assertIn("arc-plan", lifehug.DIRECT_MUTATION_COMMANDS)
+        self.assertIn("arc-thread-offers", lifehug.DIRECT_MUTATION_COMMANDS)
+
+    def test_wrapper_subcommands_exist_and_forward_flags(self):
+        result = subprocess.run(
+            [sys.executable, str(SYSTEM / "lifehug.py"), "arc-plan", "--help"],
+            capture_output=True, text=True, cwd=ROOT)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for flag in ("--limit", "--gap-max", "--model", "--dry-run", "--emit-tasks",
+                     "--from-response", "--force"):
+            self.assertIn(flag, result.stdout)
+        result = subprocess.run(
+            [sys.executable, str(SYSTEM / "lifehug.py"), "arc-card", "--help"],
+            capture_output=True, text=True, cwd=ROOT)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--daily-text", result.stdout)
+
+    def test_arc_planner_is_registered_as_a_framework_file(self):
+        version = json.loads((SYSTEM / "version.json").read_text(encoding="utf-8"))
+        self.assertIn("system/arc_planner.py", version["framework_files"])
+
+    def test_config_example_documents_the_model_key(self):
+        example = (ROOT / "config.yaml.example").read_text(encoding="utf-8")
+        self.assertIn("arc_plan_model", example)
+
+    def test_no_reference_to_the_private_vault_anywhere(self):
+        # The hard boundary: the private vault is never a fixture, a test
+        # target, or a dev-writable target. (This test file names the path
+        # exactly once, in its own docstring's prohibition, so the scan is
+        # against code lines only.)
+        private = "Workspace/" + "dave"  # assembled so this scan can scan itself
+        self.assertNotIn(private, (SYSTEM / "arc_planner.py").read_text(encoding="utf-8"))
+        body = Path(__file__).read_text(encoding="utf-8").split('"""', 2)[-1]
+        self.assertNotIn(private, body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v150_conversation_store.py
+++ b/tests/test_v150_conversation_store.py
@@ -558,11 +558,17 @@ class NoBehaviorChangeGuardTests(unittest.TestCase):
 
     def test_no_other_module_imports_conversation_or_conversation_lints(self):
         pattern = re.compile(r'^\s*(?:from|import)\s+conversation(?:_lints)?\b', re.MULTILINE)
+        # conversation_delivery.py (v153) is the sanctioned runtime consumer;
+        # arc_planner.py (issue #118, Wave 2) is the planning consumer: it reads
+        # the arc-card container and the interaction definition through this
+        # module's helpers rather than re-deriving either. The guard's point
+        # stands — no OTHER module may reach into the store.
         exempt = {
             "lifehug.py",
             "conversation.py",
             "conversation_lints.py",
-            "conversation_delivery.py",  # v153: the one sanctioned consumer
+            "conversation_delivery.py",
+            "arc_planner.py",
         }
         offenders = []
         for path in sorted(SYSTEM.glob("*.py")):


### PR DESCRIPTION
**Contract stage** — spec only, no implementation yet. Closes #118 when implemented and verified.

Contract: `docs/pr-specs/118-arc-planner.md` (Conversation Interaction, Wave 2 PR5; design §4/§11, owner-ratified 2026-08-11).

What the contract pins:
- `state/arc_cards.json` schema (closed six-kind intent vocabulary, nullable two-sentence-rule opening with resolvable receipts, queue-aligned expiry) + vault-contract registration
- `system/arc_planner.py` + `lifehug.py arc-plan` / `arc-card` CLI; weekly step directly after planner-queue with keyed, keyless (agent-task emit), and deterministic-fallback branches
- FIRST consumer of `timeline.compute_gaps()` — landmark-anchor phrasing, "what year" is a lint
- AI-free daily attach in `daily_question.sh`/`ask.py`; monthly neighborhood conversation-thread offers + resurfacing copy shift
- Convergence property (every detectable gap type emits a conversation input) stated as testable acceptance criteria
- Parity note: the weekly shell step is the SPEC the platform transports verbatim (`StepSpec("arcs","arc_plan", llm=True)`)

Notes for review:
- The version-bump CI check is expected red at contract stage; the implementation commit bumps `system/version.json` (main is v149 as of drafting).
- Assigned implementation tier per the wave plan: Opus (planner logic).

🤖 Generated with Claude Fable 5 via Claude Code