### PR TITLE
Conversation Interaction W1 PR2: session store + conversation builders (contract)

### DIFF
--- a/docs/pr-specs/115-conversation-store.md
+++ b/docs/pr-specs/115-conversation-store.md
@@ -1,0 +1,549 @@
+# Contract: conversation session store + builders (issue #115)
+
+Conversation Interaction build, Wave 1, PR 2 of 2. Owner-approved design
+2026-08-11 (the design's §11 Wave 1 item 2). Depends on PR 1 (issue #114,
+the `interactions/` scaffold) being merged or rebased under this branch —
+the builders read `interactions/conversation/interaction.yaml` and
+`evals/lints.yaml` from that PR. This contract is self-contained: all
+schemas, registration mechanics, and conventions are stated here.
+
+## Why
+
+The vault has no stored conversation object anywhere — no thread files, no
+turn transcripts. Before any conversation engine can exist (Wave 2), the
+durable session document, its vault-contract registration, and the pure
+prompt/context builders must exist and be tested. This PR is
+**infrastructure only: no behavior change to any live flow** — `ask.py`,
+`process_answer.py`, `answer_ack*.py`, `ingest_story.py`, delivery, and
+the viewer behave byte-identically after this PR. Everything here is
+reachable only via the new `conversation-*` subcommands and imports.
+
+## Binding facts
+
+- Repo version at `origin/main` is **149**; PR 1 (issue #114) is expected
+  to land as 150, making this PR **version 151**. Re-read
+  `system/version.json` at rebase time and take the next integer.
+- CI: `python3 -m unittest discover -s tests -p "test_*.py"` on py3.11 +
+  py3.14, **no pip install** (stdlib only — no PyYAML, no pytest
+  dependency; tests are unittest-style, which pytest also runs),
+  `scripts/ci/check_framework_files.py`, `scripts/ci/check_version_bump.py`.
+- **Vault-contract machinery** (all verified against the current code —
+  do not re-derive):
+  - `system/vault_contract.json`: `data_paths` entries have shape
+    `{"path", "kind": "file"|"directory", "required", "tracked",
+    "schema": {"format", "version_field", "supported"}}` (plus optional
+    `embedded_path`). `framework_paths` maps name → repo-relative path.
+  - `system/vault_paths.py` loads it at import: `_load_contract()`
+    validates entries; `_normalized_contract()` produces the exported
+    form (adds `external_path`, sorts, classifies) — and **hardcodes the
+    directory-kind framework paths as the set `{"system", "templates",
+    "connectors"}`** (in the `framework_paths` normalization dict
+    comprehension). Adding the `interactions` framework path requires
+    adding `"interactions"` to that set, or its exported kind will be
+    `file`.
+  - **Digest interlock**: import FAILS (`RuntimeError: Lifehug vault
+    contract identity digest does not match its content`) unless
+    `identity.content_digest` in the raw file equals
+    `_contract_digest(normalized_contract)` — the sha256 of the
+    NORMALIZED export, canonical JSON, with `content_digest` popped.
+    Because the check runs at module import, you cannot import
+    `vault_paths` to compute the new digest. Working recipe (any
+    equivalent is fine; the proof is that `import vault_paths` succeeds):
+    extract the two pure functions and run them over the edited raw file —
+
+    ```bash
+    python3 - <<'PY'
+    import ast, json, types
+    src = open('system/vault_paths.py').read()
+    tree = ast.parse(src)
+    keep = [n for n in tree.body
+            if isinstance(n, (ast.Import, ast.ImportFrom))
+            or (isinstance(n, ast.FunctionDef) and n.name in
+                ('_contract_digest', '_normalized_contract'))]
+    mod = types.ModuleType('vp')
+    exec(compile(ast.Module(body=keep, type_ignores=[]), 'vp', 'exec'),
+         mod.__dict__)
+    raw = json.load(open('system/vault_contract.json'))
+    print(mod._contract_digest(mod._normalized_contract(raw)))
+    PY
+    ```
+
+    Run this AFTER making the `vault_paths.py` code change (the
+    `interactions` directory-set addition changes the normalized form and
+    therefore the digest). Paste the printed digest into
+    `identity.content_digest`.
+  - `identity` currently reads `{"framework": "lifehug/lifehug",
+    "framework_version": 120, "revision": "vault-contract-v1", ...}` —
+    this PR is the first contract change since v120. Set
+    `framework_version` to this PR's landing version and `revision` to
+    `"vault-contract-v2"`. `contract_version` stays `1` (the FORMAT is
+    unchanged; only entries were added).
+  - **Test parity interlocks** in `tests/test_v120_vault_only.py` (all
+    must be updated):
+    - `EXPECTED_DATA_PATHS` (line ~37): a set of every data-path name —
+      add `"arc_cards"`, `"conversations"`, `"mirror_responses"`.
+    - `test_versioned_contract_is_the_exported_path_and_schema_authority`
+      asserts `exported["identity"]["framework_version"] == 120` — update
+      to the landing version.
+    - The same test asserts (line ~238) that
+      `set(re.findall(r'_data\("([^"]+)"\)', lifehug_core.py source)) ==
+      EXPECTED_DATA_PATHS` — so `system/lifehug_core.py` MUST gain exactly
+      one `_data("<name>")` accessor per new entry (see Deliverable 1).
+  - `tracked_vault_paths()` derives git-housekeeping roots from entries
+    with `"tracked": true` — the new entries below are tracked, so they
+    join canonical git housekeeping automatically; no other wiring.
+- **Builder convention** (the pattern to copy, verified):
+  `system/answer_ack.py` — module docstring documents a stdin JSON object;
+  `REQUIRED_FIELDS = {name: type}` dict; `build_prompt(payload) -> str`
+  pure function; `main()` reads stdin, validates presence + type, prints
+  the prompt to stdout, one-line error to stderr + exit 1 on empty stdin /
+  invalid JSON / missing or mis-typed field. CLI wiring:
+  `system/lifehug.py` `cmd_answer_ack_prompt` → `run_python(
+  "answer_ack.py", [])` + `sub.add_parser("answer-ack-prompt", help=...)`
+  (parser table ~line 1754; also add new names to the sorted command list
+  at ~line 64).
+- **Existing seams referenced (read-only this PR)**:
+  `system/process_answer.py:88 next_followup_id()` (the `A14 → A14b`
+  suffix chain — session filing reuses it in Wave 2);
+  `system/timeline.py:581 compute_gaps()` (arc planner consumer, Wave 2);
+  `lifehug_core.load_mission()` (mission block, if included in assembly).
+- **PR 1 artifacts consumed** (paths fixed by the #114 contract):
+  `interactions/conversation/interaction.yaml` — FLAT scalar YAML (dotted
+  keys: `knob.*`, `budget.*`, `role.*`, `load_order`, `version`), parsed
+  with `lifehug_core._parse_simple_yaml` (returns `dict[str, str]`; cast
+  numerics yourself); `interactions/conversation/evals/lints.yaml` — flat
+  scalar, `lint.<id>: on`, `banned.N: <phrase>`, `cap.turn_chars: 900`;
+  `interactions/conversation/context/manifest.md` — documents the
+  assembly order implemented here.
+- Synthetic data only in tests/fixtures. NEVER reference
+  `~/Workspace/dave` in test code (review rejection by itself).
+
+## Scope
+
+**In**: vault-contract + vault_paths + lifehug_core registrations; session
+document store (`state/conversations/`); arc-card and mirror-responses
+path registration + minimal typed read/write helpers;
+`system/conversation.py` (pure CRUD + assembly + prompt builders);
+`system/conversation_lints.py` (deterministic lint engine);
+`lifehug.py conversation-*` subcommands; tests; version bump.
+
+**Out** (explicitly): ANY model call or Telegram send (no
+`conversation_delivery.py` — Wave 2 item 3); no `process_answer.py` /
+`ingest_story.py` rewiring (Wave 2 items 3–4); no arc PLANNER (Wave 2
+item 5 — this PR only registers `state/arc_cards.json` and reads cards);
+no mirror inbound consumer (Wave 2 item 6 — registration only); no jobs.py
+command kind; no viewer changes (so no walkthrough); no engagement
+signals; no config keys (`conversation_model` etc. — Wave 2).
+
+## Deliverables
+
+### 1. Vault-contract registrations
+
+`system/vault_contract.json` `data_paths` gains three entries:
+
+```json
+"arc_cards": {
+  "path": "state/arc_cards.json",
+  "kind": "file",
+  "required": false,
+  "tracked": true,
+  "schema": {"format": "json", "version_field": "version", "supported": [1]}
+},
+"conversations": {
+  "path": "state/conversations",
+  "kind": "directory",
+  "required": false,
+  "tracked": true,
+  "schema": {"format": "json_family", "version_field": "session_version", "supported": [1]}
+},
+"mirror_responses": {
+  "path": "state/mirror_responses.json",
+  "kind": "file",
+  "required": false,
+  "tracked": true,
+  "schema": {"format": "json", "version_field": "version", "supported": [1]}
+}
+```
+
+(`json_family` follows the `task_family`/`job_family` naming precedent for
+directories of homogeneous records; schema formats are only strictly
+validated for `required` entries, so this is descriptive, but keep the
+precedent.) `framework_paths` gains `"interactions": "interactions"`, and
+`vault_paths._normalized_contract`'s directory-kind set gains
+`"interactions"`. Update `identity` (framework_version, revision
+`vault-contract-v2`, recomputed `content_digest` — recipe in Binding
+facts).
+
+`system/lifehug_core.py` gains, next to the existing block at ~line 147:
+
+```python
+ARC_CARDS_FILE = _data("arc_cards")
+CONVERSATIONS_DIR = _data("conversations")
+MIRROR_RESPONSES_FILE = _data("mirror_responses")
+```
+
+(Exactly one `_data("...")` literal per name — the regex parity test
+counts them.)
+
+Update `tests/test_v120_vault_only.py` per the Binding-facts interlocks.
+
+### 2. The session document (`state/conversations/<session_id>.json`)
+
+Exact schema (design §5, ratified; `session_version` added here as the
+durable-record version field, following `state/jobs`' `record_version`
+precedent):
+
+```json
+{
+  "session_version": 1,
+  "session_id": "…",
+  "mode": "chat|conversation",
+  "channel": "telegram|web|cli",
+  "interaction_version": "1.0.0",
+  "status": "open|idle|closed",
+  "arc": {"question_id": "A14b", "opening": "…",
+           "intents": ["scene_sensory", "who_else", "meaning"]},
+  "turns": [
+    {"role": "user|lifehug", "text": "…", "ts": "…",
+     "channel": "telegram|web|cli",
+     "router": {"intent": "…", "confidence": 0.94},
+     "model": "provider/model", "question_id": "A14b?"}
+  ],
+  "rolling_summary": "…",
+  "extracted": {"facts": [], "entities": [], "candidate_ideas": [],
+                 "mirror_responses": []},
+  "close": {"reason": "done|idle_timeout|exit_taken", "takeaway": "…",
+             "takeaway_delivered": true, "insight_receipts_count": 0,
+             "filed": ["A14b", "A14ba"]}
+}
+```
+
+Semantics the store must honor (all ratified):
+
+- `session_id`: opaque, unique, filesystem-safe; pin the format
+  `conv-YYYYMMDD-HHMMSS-<6 hex>` (UTC) so filenames sort chronologically.
+- Session-level `channel` = opening channel only; **each turn carries its
+  own channel** (a session can span Telegram + web).
+- `arc.question_id` keys the card; a chat session **opens at first
+  answer, not at delivery** — the arc card waits with the delivered
+  question and answer latency never burns the idle clock. A conversation
+  session opens at first inbound. (The store exposes open-with-arc; the
+  policy callers land in Wave 2.)
+- `router`, `model` per turn are optional (builders here never call
+  models; Wave 2 fills them).
+- `close` is absent until closed. `turns` may be empty on a just-opened
+  conversation session.
+- `extracted` consumers are Wave-2 wiring but the fields exist now:
+  `facts` → re-asserted into the rolling summary each turn (the
+  39%-degradation mitigation; in-session only); `entities` →
+  classification hints; `candidate_ideas` → candidate store (provenance
+  `conversation`); `mirror_responses` → mirror inbound path.
+- **Single-flight turn mint via compare-and-set**: appending a turn takes
+  an expected turn count (or expected last-turn id); on mismatch the
+  append fails cleanly (typed error / False) — so concurrent answers on
+  two surfaces mint exactly one turn. Same idiom as the existing
+  `mint_follow_up` CAS on the platform; here it is enforced by
+  re-reading the document and comparing before an atomic
+  write-temp-then-rename within `state/conversations/`.
+- Writes are atomic (temp file + `os.replace`) and go through
+  `vault_paths` containment (`lifehug_core.CONVERSATIONS_DIR`); the store
+  never touches git (commit/batching policy is Wave 2's
+  `conversation-close` job).
+
+### 3. `system/conversation.py` — pure builders (no model calls, no sends)
+
+Follow the `answer_ack.py` build/deliver split: this module is the "build"
+half only. Public surface (exact names; signatures may take
+keyword-only extras):
+
+**Session store CRUD** —
+- `open_session(mode, channel, *, arc=None, vault_root=None) -> dict`
+  (creates + persists the document, returns it)
+- `load_session(session_id, *, vault_root=None) -> dict`
+- `list_sessions(*, status=None, vault_root=None) -> list[dict]`
+  (metadata-only summaries: id, mode, status, channel, turn count,
+  opened/last ts)
+- `append_turn(session_id, turn, *, expected_turns, vault_root=None)
+  -> dict` (the CAS append; raises/returns typed failure on count
+  mismatch or closed session)
+- `close_session(session_id, close, *, vault_root=None) -> dict`
+  (validates `close.reason` vocabulary; idempotent — closing a closed
+  session with identical payload is a no-op, with different payload a
+  typed error)
+
+**Manifest + assembly** —
+- `load_interaction_manifest(*, framework_root=None) -> dict` — parses
+  `interactions/conversation/interaction.yaml` via
+  `lifehug_core._parse_simple_yaml`, casts `knob.*`/`budget.*` ints,
+  returns typed dict; resolves the file through the `interactions`
+  framework path registered in Deliverable 1.
+- `assemble_context(session, *, vault_root=None, blocks=None) -> str` —
+  deterministic, in the manifest order: identity → behavior → examples →
+  profile → record → session → turn_instructions. Stable blocks are the
+  PR-1 prompt files read from `interactions/conversation/prompt/`. The
+  `profile` and `record` blocks: when `blocks` (a dict of pre-fetched
+  block texts) is provided — the platform path — use it verbatim; when
+  not, assemble minimally from the vault deterministically (profile from
+  `profile.yaml`/roadmap focus names; record = the arc's
+  `question_id`-linked answer file if present, with provenance-ID
+  prefix `[<id>, <answered_date>]`). Truncate each block to its
+  `budget.*` (approximate: 4 chars/token). Honest freedom: RICH record
+  retrieval (topic-relevance ranking, timeline spans, entity lineups) is
+  Wave-2 scope — this PR pins the order, the budgets, the provenance-ID
+  format, and the seam (`blocks` injection), not the retrieval quality.
+  A parity test must assert the implemented order equals the
+  `load_order` key in interaction.yaml (doc-drift guard).
+
+**Prompt builders** (each pure; each has a stdin-JSON CLI path exactly
+like `answer_ack.py`: documented `REQUIRED_FIELDS`, validation, prompt to
+stdout, one-line stderr + exit 1 on bad input) —
+- `build_turn_prompt(payload) -> str` — payload: `session` (the
+  document), optional `blocks`; output = assembled context +
+  `turn-instructions.md` with its `{placeholder}` slots filled (mode,
+  current arc intent, turn position: opening / mid-arc / exit-friendly /
+  closing-candidate, length cap from lints config).
+- `build_router_prompt(payload) -> str` — payload: `message` (str),
+  `session_open` (bool), `pending_question_id` (str|null); output =
+  `router/router.md` with the message and state substituted. The five
+  intents `{answer, new_story, command, continue_session, out_of_scope}`
+  and the JSON output schema come from router.md — this builder never
+  restates them (single source).
+- `build_arc_prompt(payload) -> str` — payload: `question` (id, text,
+  category, focus), `record_summary` (str), `gap_inputs` (list of
+  strings, pre-computed — e.g. timeline-gap/scene-slot descriptions);
+  output = a planning prompt per `plan/arc-templates.md` asking for one
+  arc card (opening framing obeying the two-sentence rule + 2–4 intents).
+  The WEEKLY caller lands in Wave 2 item 5; this PR only builds the
+  prompt.
+- `build_closing_prompt(payload) -> str` — payload: `session`; output =
+  a prompt for the closing takeaway per behavior rule 8 (takeaway not
+  recap + specific appreciation + continuity line + optional
+  deposit-frame per `knob.deposit_framing` + named hook, then stop).
+
+**Arc-card + mirror-responses helpers** (minimal, typed) —
+- `load_arc_card(question_id, *, vault_root=None) -> dict | None` and
+  `save_arc_card(card, *, vault_root=None)` against
+  `state/arc_cards.json` shape
+  `{"version": 1, "cards": {"<question_id>": {"question_id", "opening",
+  "intents", "planned_at", "expires_at", "mode"}}}` (atomic write).
+- `append_mirror_response(entry, *, vault_root=None)` against
+  `state/mirror_responses.json` `{"version": 1, "responses": [...]}` —
+  storage only; `mirror.load_mirror_entries()` integration is Wave 2
+  item 6.
+
+### 4. `system/conversation_lints.py` — the deterministic lint engine
+
+One authoritative module (recurring-defect doctrine: the checks will run
+in CI evals AND at runtime in Wave 2 — never inline copies). Public
+surface:
+
+- `load_lints_config(*, framework_root=None) -> dict` — reads
+  `interactions/conversation/evals/lints.yaml` (flat subset). The yaml is
+  the config authority (banned phrases, caps, on/off); the module is the
+  engine.
+- `lint_turn(text, *, is_reply_to_substantive=False, config=None) ->
+  list[dict]` — findings `{"lint": "<id>", "detail": "…",
+  "span": [start, end]}`. Implemented lint ids (exactly these, matching
+  lints.yaml and behavior.md rule numbers):
+  - `one_question_per_turn` (rule 1): >1 `?`-terminated question →
+    finding. (Count question sentences, not raw `?` — handle quoted
+    questions the user asked being echoed inside receipts pragmatically;
+    document the heuristic in the module docstring.)
+  - `banned_phrases` (rules 4/5/12 + do-not-use list): case-insensitive
+    phrase list from lints.yaml (`banned.N` entries include at minimum:
+    "that must have been", "you haven't told me", "streak", "as an AI",
+    "I'm just an AI", "you should" as advice lead-in).
+  - `question_grammar_audit` (rule 3): classify each question as
+    `ted` (tell/describe/explain/walk-me-through openers), `cued`
+    (contains a quoted user phrase), `closed` (aux-verb-first yes/no),
+    `option_posing` (contains " or " between alternatives in the
+    question), `other`; findings flag `closed` and `option_posing`.
+  - `length_caps`: `cap.turn_chars` from config.
+  - `receipt_before_question` (rule 2, structural): when
+    `is_reply_to_substantive`, the text must not open with a question —
+    at least one non-question sentence precedes the first question.
+  - `year_question_detector` (rule 3): flags "what year", "which year",
+    "in what year" question forms.
+- `lint_transcript(turns, *, config=None) -> list[dict]` — maps
+  `lint_turn` over lifehug-role turns with the substantive-reply flag
+  derived from the preceding user turn (non-trivial length).
+
+Lints are heuristic by design — the contract pins the ids, the config
+source, and the obvious positive/negative cases in the test plan; exact
+regexes are implementer freedom. False-negative-lenient, false-positive-
+strict (a lint that flags good turns will be muted in Wave 2 — bias
+against that).
+
+### 5. `lifehug.py` subcommands
+
+Add to the sorted command list (~line 64) and parser table, wired via
+`run_python("conversation.py", ...)` / `run_python("conversation_lints.py",
+...)` like the answer-ack trio:
+
+- `conversation-open` (`--mode chat|conversation`, `--channel`,
+  `--question-id` optional → attaches the arc card if one exists) —
+  prints the created session id + document path
+- `conversation-status` (`[session_id]`) — metadata-only list/detail
+  (never prints turn text without an explicit `--full` flag; turn text is
+  private content, keep the default output metadata-only like
+  `answer-ack-status`)
+- `conversation-record-turn` (`session_id --role user|lifehug
+  --expected-turns N`, text on stdin) — the CAS append
+- `conversation-close` (`session_id --reason done|idle_timeout|exit_taken`,
+  takeaway on stdin optional) — store close only (no message send, no
+  commit — Wave 2)
+- `conversation-turn-prompt`, `conversation-router-prompt`,
+  `conversation-arc-prompt`, `conversation-closing-prompt` — stdin JSON →
+  prompt on stdout (the four builders)
+- `conversation-lint` (text on stdin, `--reply-to-substantive` flag) —
+  findings as JSON lines; exit 0 with findings printed (linting is
+  reporting, not failing — CI decides what fails)
+
+### 6. `system/version.json`
+
+Bump version (151 expected) + changelog (sized to impact: durable
+session-store + vault-contract v2 — real but not-yet-user-visible; a few
+sentences). Add `system/conversation.py` and
+`system/conversation_lints.py` to `framework_files`.
+
+## Implementation notes
+
+- Copy the `answer_ack.py` module shape wholesale (docstring format,
+  REQUIRED_FIELDS validation, error behavior) — it is the established
+  convention and the platform vendors these modules in Wave 3, so
+  discipline here is load-bearing.
+- All vault file access through `lifehug_core` `_data` paths /
+  `vault_paths` helpers — never hand-built paths (the v120 containment
+  boundary).
+- `_parse_simple_yaml(..., validate_ai_routing=False)` — do not opt into
+  AI-routing validation for interaction files.
+- Order of operations for the contract edit: (1) edit
+  `vault_paths._normalized_contract` directory set, (2) edit
+  `vault_contract.json` entries, (3) run the digest recipe, (4) paste
+  digest, (5) `python3 -c "import sys; sys.path.insert(0,'system');
+  import vault_paths"` must succeed.
+- Keep `conversation.py` importable with a cold vault (no
+  `state/conversations/` yet): `list_sessions` returns `[]`,
+  `load_arc_card` returns `None` — required-nothing degradation like
+  every other state module.
+- No behavior change means: no existing module imports the new ones
+  (`grep -rn "import conversation" system/*.py` shows only
+  `lifehug.py`'s subprocess dispatch strings and the new modules
+  themselves).
+
+## Test plan
+
+New test file `tests/test_v151_conversation_store.py` (rename to the
+actual landing version), unittest-style, using `tests/tempdirs.py`
+temp-vault conventions (see `tests/test_v120_vault_only.py`'s
+`make_vault` pattern). Subtests, explicitly named (state-machine-shaped
+change → the v130/v131 precedent applies):
+
+1. **Registration**: contract imports green; `EXPECTED_DATA_PATHS`
+   includes the three names; exported kinds/tracked flags match
+   Deliverable 1; `interactions` framework path exports kind
+   `directory`; digest self-consistent (the existing
+   `test_v120_vault_only` assertions, updated, already prove this — this
+   subtest just pins the three new entries' shapes).
+2. **Session lifecycle**: open (chat, with arc) → document on disk in
+   `state/conversations/`, schema fields exactly as Deliverable 2;
+   append user turn (CAS ok) → append with stale `expected_turns` fails
+   typed and the file holds exactly one turn; close with `reason: done` →
+   status closed, close block present; re-close idempotent; append after
+   close fails typed.
+3. **Assembly determinism**: same session + same blocks → byte-identical
+   context twice; block order matches interaction.yaml `load_order`
+   (parse the yaml in the test — the doc-drift guard); budgets truncate
+   (oversized fake block → truncated to budget).
+4. **Builders**: each of the four builders on a fixture payload — output
+   contains the expected file content markers (e.g. router prompt
+   contains all five intent names and the message; turn prompt ends with
+   the filled turn-instructions; closing prompt reflects
+   `knob.deposit_framing`); each CLI path: valid stdin JSON → prompt on
+   stdout, exit 0; empty stdin / missing field → exit 1, one stderr line
+   (subprocess invocation, same as `tests/test_answer_ack.py` does).
+5. **Lints**: per lint id, at least one flagged and one clean fixture —
+   e.g. two questions → `one_question_per_turn`; "That must have been so
+   hard." → `banned_phrases`; "Did you like it?" → grammar `closed`
+   flagged; "Was it the red one or the blue one?" → `option_posing`;
+   "What year did you move?" → `year_question_detector`; reply opening
+   with a question when `is_reply_to_substantive` →
+   `receipt_before_question`; a correct payout turn (receipt sentence +
+   one cued invitation quoting the user) → zero findings.
+6. **No-behavior-change guard**: source scan asserting no module under
+   `system/` other than `lifehug.py` and the two new modules references
+   `conversation` imports (regex over file contents, same style as the
+   `_data` parity assertion).
+
+Invocations (scoped — full local suite forbidden while sibling agents
+share the machine; CI is the full-suite arbiter):
+
+```
+python3 -m unittest tests.test_v151_conversation_store -v
+python3 -m unittest tests.test_v120_vault_only -v
+python3 -m unittest tests.test_lifehug_core tests.test_lifehug_wrapper -v
+```
+
+## Launch-and-verify
+
+No `serve_wiki.py` changes → no walkthrough (BUILDING.md §4). Runnable
+verification from a fresh checkout of the branch:
+
+```bash
+# 1. Contract + registrations healthy
+python3 -c "import sys; sys.path.insert(0,'system'); import vault_paths, lifehug_core; \
+  print(sorted(set(vault_paths.VAULT_DATA_PATHS) & {'arc_cards','conversations','mirror_responses'})); \
+  print(vault_paths.FRAMEWORK_PATHS['interactions'])"
+# expect: the three names; {'path': 'interactions', 'kind': 'directory', ...}
+
+# 2. A session, end to end, in a scratch vault (NEVER a real vault)
+export LIFEHUG_VAULT=/tmp/lifehug-verify-vault   # or the repo's env var per vault_paths.bootstrap docs
+python3 system/lifehug.py conversation-open --mode conversation --channel cli
+echo "The first thing I remember about the farm is the smell of diesel." | \
+  python3 system/lifehug.py conversation-record-turn <SESSION_ID> --role user --expected-turns 0
+python3 system/lifehug.py conversation-status <SESSION_ID>
+# expect: open, 1 turn, channel cli, no turn text in default output
+
+# 3. A prompt, no model anywhere
+python3 - <<'PY' | python3 system/lifehug.py conversation-router-prompt
+import json; print(json.dumps({"message": "what's the weather tomorrow?",
+  "session_open": False, "pending_question_id": None}))
+PY
+# expect: router.md text with the message embedded and all five intents; exit 0
+
+# 4. Lints catch and pass
+printf 'That must have been so hard. What year was that? Or was it later?' | \
+  python3 system/lifehug.py conversation-lint --reply-to-substantive
+# expect: findings incl. banned_phrases, year_question_detector, receipt ok,
+#         option_posing/one_question_per_turn per the text
+
+# 5. Scoped tests
+python3 -m unittest tests.test_v151_conversation_store tests.test_v120_vault_only -v
+```
+
+What to look at: the created `state/conversations/conv-*.json` document —
+its fields should read exactly like Deliverable 2's schema; that file IS
+the viewable artifact of this PR.
+
+## Definition of done
+
+- [ ] Registrations complete (contract v2, digest green on import,
+      `_data` accessors, parity tests updated)
+- [ ] `system/conversation.py` + `system/conversation_lints.py` per
+      Deliverables 3–4; `lifehug.py` subcommands per Deliverable 5
+- [ ] New test file green on py3.11 + py3.14 locally-scoped and in CI;
+      no live-flow behavior change (subtest 6 proves it)
+- [ ] `system/version.json` bumped; two new modules in `framework_files`;
+      `check_framework_files.py` green
+- [ ] AGENTS.md/CLAUDE.md untouched (no described behavior changes — the
+      routing-prose sharpening is Wave 2)
+- [ ] ADR: none new — ADR 0002 (from #114) already records the
+      vault-contract additions; update it only if the shipped schema
+      deviates from what it planned
+- [ ] Evidence comment on the PR: Launch-and-verify transcript (commands
+      + outputs) — no screenshots/GIFs needed (no UI surface)
+- [ ] Owner closeout comment drafted with judgment items: (1) session-doc
+      schema ratification (the durable shape), (2) `conv-*` session-id
+      format, (3) lint banned-phrase starter list
+- [ ] NEVER: labels, ready-for-review flips, or merges by the
+      implementing agent

--- a/system/conversation.py
+++ b/system/conversation.py
@@ -626,15 +626,33 @@ def build_turn_prompt(payload: dict) -> str:
     intents = arc.get("intents") or []
     template = _read_framework_text("prompt", "turn-instructions.md")
     length_cap = _lint_cap_turn_chars()
+    position = _turn_position(session, manifest)
     filled = (
         template
         .replace("{mode}", str(session.get("mode", "")))
-        .replace("{arc_intent}", _intent_label(intents[0]) if intents else "")
-        .replace("{turn_position}", _turn_position(session, manifest))
-        .replace("{previous_turn}", turns[-1]["text"] if turns else "")
-        .replace("{length_cap}", str(length_cap))
+        .replace("{arc_card_current_intent}", _intent_label(intents[0]) if intents else "(no arc card)")
+        .replace("{turn_position}", position)
+        .replace("{previous_turn_summary}", (turns[-1]["text"][:200] if turns else "(none — this is the opening)"))
+        .replace("{applicable_rule_hints}", _rule_hints_for_position(position))
     )
-    return f"{context}\n\n## TURN_INSTRUCTIONS\n\n{filled}"
+    return (
+        f"{context}\n\n## TURN_INSTRUCTIONS\n\n{filled}\n\n"
+        f"Hard length cap for this message: {length_cap} characters."
+    )
+
+
+def _rule_hints_for_position(position: str) -> str:
+    """Deterministic behavior.md rule hints per turn position (definition file
+    slot {applicable_rule_hints}; the mapping mirrors behavior.md's own
+    structure — opening leans on framing/grammar rules, middle on
+    respond-before-ask/register, closing on rule 8)."""
+    hints = {
+        "opening": "2 (respond-before-ask), 3 (question grammar), 5 (register), 7 (escalation)",
+        "middle": "1 (one question max), 2 (respond-before-ask), 5 (register), 6 (payout anatomy), 13 (back-off)",
+        "exit_door": "1 (one question max), 8 (closings — offer the door, do not push past it)",
+        "closing": "8 (closings: takeaway, appreciation, continuity, hook, stop)",
+    }
+    return hints.get(position, "1, 2, 5")
 
 
 def _lint_cap_turn_chars() -> int:
@@ -656,11 +674,14 @@ def build_router_prompt(payload: dict) -> str:
     session_open = payload["session_open"]
     pending_question_id = payload.get("pending_question_id")
     template = _read_framework_text("router", "router.md")
+    pending = "(none)" if pending_question_id is None else str(pending_question_id)
     return (
-        template
-        .replace("{message}", message)
-        .replace("{session_open}", str(session_open))
-        .replace("{pending_question_id}", "" if pending_question_id is None else str(pending_question_id))
+        f"{template}\n\n"
+        "## INPUT (assembled at runtime — classify this message)\n\n"
+        f"SESSION OPEN: {session_open}\n"
+        f"PENDING QUESTION: {pending}\n\n"
+        "MESSAGE:\n"
+        f"{message}\n"
     )
 
 
@@ -670,14 +691,14 @@ def build_arc_prompt(payload: dict) -> str:
     record_summary = payload["record_summary"]
     gap_inputs = payload["gap_inputs"]
     template = _read_framework_text("plan", "arc-templates.md")
+    gaps = "; ".join(str(item) for item in gap_inputs) or "(none)"
     return (
-        template
-        .replace("{question_id}", str(question.get("id", "")))
-        .replace("{question_text}", str(question.get("text", "")))
-        .replace("{question_category}", str(question.get("category", "")))
-        .replace("{question_focus}", str(question.get("focus", "")))
-        .replace("{record_summary}", record_summary)
-        .replace("{gap_inputs}", "; ".join(str(item) for item in gap_inputs))
+        f"{template}\n\n"
+        "## INPUT (assembled at runtime — plan one arc card for this question)\n\n"
+        f"QUESTION [{question.get('id', '')}] (category {question.get('category', '')}, "
+        f"focus {question.get('focus', '')}):\n{question.get('text', '')}\n\n"
+        f"RECORD SUMMARY:\n{record_summary}\n\n"
+        f"GAP INPUTS:\n{gaps}\n"
     )
 
 

--- a/system/conversation.py
+++ b/system/conversation.py
@@ -1,0 +1,870 @@
+#!/usr/bin/env python3
+"""Lifehug — Conversation session store + pure prompt/context builders.
+
+Infrastructure for the Conversation Interaction (issue #115, Wave 1 PR 2 of
+2). This module is the "build" half only, in the same shape as
+``answer_ack.py``: pure functions that read the vault and the
+``interactions/conversation/`` definition (issue #114) and either persist a
+durable session document or print a prompt. It never calls a model and never
+sends a message — Wave 2 wires the engine on top of this store.
+
+Session documents live one-per-file at ``state/conversations/<id>.json``
+(``session_version: 1``; see the PR contract, Deliverable 2, for the exact
+schema). ``session_id`` format: ``conv-YYYYMMDD-HHMMSS-<6 hex>`` (UTC) so
+filenames sort chronologically.
+
+Session store CRUD (each takes an optional ``vault_root`` override so tests
+can point at a synthetic temp vault without rebinding the process):
+
+    open_session(mode, channel, *, arc=None, vault_root=None) -> dict
+    load_session(session_id, *, vault_root=None) -> dict
+    list_sessions(*, status=None, vault_root=None) -> list[dict]
+    append_turn(session_id, turn, *, expected_turns, vault_root=None) -> dict
+    close_session(session_id, close, *, vault_root=None) -> dict
+
+``append_turn`` is a compare-and-set: it re-reads the document, and if the
+current turn count does not equal ``expected_turns`` it raises
+``TurnConflictError`` instead of writing — the same idiom the platform uses
+for follow-up-id minting, adapted to a full re-read/compare/atomic-replace
+since this store has no in-process lock. A closed session raises
+``SessionClosedError`` on any further append.
+
+Manifest + assembly:
+
+    load_interaction_manifest(*, framework_root=None) -> dict
+    assemble_context(session, *, vault_root=None, blocks=None) -> str
+
+Prompt builders (each pure; each has a stdin-JSON CLI path exactly like
+``answer_ack.py`` — see ``main()`` below):
+
+    build_turn_prompt(payload) -> str
+    build_router_prompt(payload) -> str
+    build_arc_prompt(payload) -> str
+    build_closing_prompt(payload) -> str
+
+Arc-card helpers (minimal, typed; storage only — the planner is Wave 2):
+
+    load_arc_card(question_id, *, vault_root=None) -> dict | None
+    save_arc_card(card, *, vault_root=None) -> None
+
+There is deliberately no ``append_mirror_response`` here (mid-flight
+cross-contract audit amendment M14): issue #119 ships the single mirror
+writer (``mirror.append_mirror_responses``); this PR only registers the
+``mirror_responses`` vault-contract data path.
+
+The ``state/arc_cards.json`` shape here is intentionally minimal (mid-flight
+audit amendment M1): this PR pins only the ``load_arc_card``/``save_arc_card``
+signatures and the top-level container fields; the arc-planning authority
+(#118 / platform PR #124) owns the generation-run bookkeeping
+(``generated_at``, ``queue_generated_at``, ``expires_at``, ``source``,
+``thread_offers``) and the card-intent object shape.
+
+Every vault read/write goes through ``vault_paths`` (never a hand-built
+path); every framework read (the ``interactions/`` definition) goes through
+``lifehug_core.INTERACTIONS_DIR`` / ``framework_path``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import secrets
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lifehug_core import (
+    INTERACTIONS_DIR,
+    REPO_DIR,
+    SYSTEM_DIR,
+    _parse_simple_yaml,
+    now_utc,
+    split_frontmatter,
+)
+from vault_paths import atomic_write_vault_text, read_vault_text, vault_data_path
+
+SESSION_VERSION = 1
+VALID_MODES = frozenset({"chat", "conversation"})
+VALID_CHANNELS = frozenset({"telegram", "web", "cli"})
+VALID_CLOSE_REASONS = frozenset({"done", "idle_timeout", "exit_taken"})
+VALID_ROLES = frozenset({"user", "lifehug"})
+SESSION_ID_RE = re.compile(r"^conv-\d{8}-\d{6}-[0-9a-f]{6}$")
+
+# The manifest's load_order for the STABLE + PER-USER + PER-SESSION blocks
+# assemble_context itself builds. `turn_instructions` is the 7th and final
+# load_order element, appended separately by build_turn_prompt (it needs
+# per-turn runtime state assemble_context doesn't take) — a doc-drift guard
+# test asserts (*ASSEMBLE_CONTEXT_BLOCK_ORDER, "turn_instructions") equals
+# interaction.yaml's load_order exactly.
+ASSEMBLE_CONTEXT_BLOCK_ORDER = (
+    "identity",
+    "behavior",
+    "examples",
+    "profile",
+    "record",
+    "session",
+)
+
+CHARS_PER_TOKEN = 4  # contract-pinned approximation for budget truncation
+
+
+class ConversationError(Exception):
+    """Base error for conversation-store operations."""
+
+
+class TurnConflictError(ConversationError):
+    """The expected turn count did not match — a concurrent writer won."""
+
+
+class SessionClosedError(ConversationError):
+    """The session is already closed; no further turns may be appended."""
+
+
+class InvalidCloseError(ConversationError):
+    """A close was attempted with a vocabulary or idempotency mismatch."""
+
+
+# --------------------------------------------------------------------------
+# Path resolution — every CRUD function accepts an optional vault_root
+# override (tests point at a synthetic temp vault); the default resolves to
+# the process-bound REPO_DIR via lifehug_core's precomputed constants.
+# --------------------------------------------------------------------------
+
+
+def _resolve_root(vault_root: str | Path | None) -> Path:
+    return REPO_DIR if vault_root is None else Path(vault_root)
+
+
+def _conversations_dir(root: Path) -> Path:
+    # Equivalent to lifehug_core.CONVERSATIONS_DIR when root is REPO_DIR (same
+    # vault_paths.vault_data_path call under the hood) — computed uniformly
+    # here so every CRUD function honors an explicit vault_root override.
+    return vault_data_path("conversations", vault_root=root, framework_system_dir=SYSTEM_DIR)
+
+
+def _arc_cards_path(root: Path) -> Path:
+    return vault_data_path("arc_cards", vault_root=root, framework_system_dir=SYSTEM_DIR)
+
+
+def _answers_dir(root: Path) -> Path:
+    return vault_data_path("answers", vault_root=root, framework_system_dir=SYSTEM_DIR)
+
+
+def _profile_path(root: Path) -> Path:
+    return vault_data_path("profile", vault_root=root, framework_system_dir=SYSTEM_DIR)
+
+
+def _roadmap_path(root: Path) -> Path:
+    return vault_data_path("roadmap", vault_root=root, framework_system_dir=SYSTEM_DIR)
+
+
+def _session_path(session_id: str, *, vault_root: str | Path | None = None) -> Path:
+    _validate_session_id(session_id)
+    root = _resolve_root(vault_root)
+    return _conversations_dir(root) / f"{session_id}.json"
+
+
+def _validate_session_id(session_id: str) -> None:
+    if not isinstance(session_id, str) or not SESSION_ID_RE.fullmatch(session_id):
+        raise ValueError(f"invalid session id: {session_id!r}")
+
+
+def _new_session_id(now: datetime | None = None) -> str:
+    moment = now or datetime.now(timezone.utc)
+    return f"conv-{moment.strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(3)}"
+
+
+def _read_json_at(path: Path, *, vault_root: Path, default: object) -> object:
+    try:
+        text = read_vault_text(path, vault_root=vault_root)
+    except FileNotFoundError:
+        return default
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return default
+
+
+def _write_json_at(path: Path, data: object, *, vault_root: Path) -> None:
+    atomic_write_vault_text(path, json.dumps(data, indent=2) + "\n", vault_root=vault_root)
+
+
+# --------------------------------------------------------------------------
+# Session store CRUD
+# --------------------------------------------------------------------------
+
+
+def open_session(
+    mode: str,
+    channel: str,
+    *,
+    arc: dict | None = None,
+    vault_root: str | Path | None = None,
+    session_id: str | None = None,
+    now: str | None = None,
+) -> dict:
+    """Create and persist a new session document; return it."""
+    if mode not in VALID_MODES:
+        raise ValueError(f"invalid mode: {mode!r}")
+    if channel not in VALID_CHANNELS:
+        raise ValueError(f"invalid channel: {channel!r}")
+    root = _resolve_root(vault_root)
+    sid = session_id or _new_session_id()
+    _validate_session_id(sid)
+    manifest = _safe_manifest()
+    doc = {
+        "session_version": SESSION_VERSION,
+        "session_id": sid,
+        "mode": mode,
+        "channel": channel,
+        "interaction_version": manifest.get("version", "0.0.0"),
+        "status": "open",
+        "arc": arc,
+        "turns": [],
+        "rolling_summary": "",
+        "extracted": {
+            "facts": [],
+            "entities": [],
+            "candidate_ideas": [],
+            "mirror_responses": [],
+        },
+    }
+    _write_json_at(_conversations_dir(root) / f"{sid}.json", doc, vault_root=root)
+    return doc
+
+
+def load_session(session_id: str, *, vault_root: str | Path | None = None) -> dict:
+    """Load one session document by id; raises FileNotFoundError if absent."""
+    root = _resolve_root(vault_root)
+    path = _session_path(session_id, vault_root=root)
+    text = read_vault_text(path, vault_root=root)
+    return json.loads(text)
+
+
+def list_sessions(
+    *,
+    status: str | None = None,
+    vault_root: str | Path | None = None,
+) -> list[dict]:
+    """Metadata-only summaries; [] on a cold vault (no state/conversations/ yet)."""
+    root = _resolve_root(vault_root)
+    directory = _conversations_dir(root)
+    if not directory.exists():
+        return []
+    summaries: list[dict] = []
+    for path in sorted(directory.glob("conv-*.json")):
+        try:
+            doc = json.loads(read_vault_text(path, vault_root=root))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        if status is not None and doc.get("status") != status:
+            continue
+        turns = doc.get("turns") or []
+        summaries.append({
+            "session_id": doc.get("session_id"),
+            "mode": doc.get("mode"),
+            "status": doc.get("status"),
+            "channel": doc.get("channel"),
+            "turn_count": len(turns),
+            "opened": turns[0]["ts"] if turns else None,
+            "last": turns[-1]["ts"] if turns else None,
+        })
+    summaries.sort(key=lambda entry: entry["session_id"] or "", reverse=True)
+    return summaries
+
+
+def append_turn(
+    session_id: str,
+    turn: dict,
+    *,
+    expected_turns: int,
+    vault_root: str | Path | None = None,
+    now: str | None = None,
+) -> dict:
+    """Compare-and-set turn append; typed failure on mismatch or a closed session."""
+    root = _resolve_root(vault_root)
+    doc = load_session(session_id, vault_root=root)
+    if doc.get("status") == "closed":
+        raise SessionClosedError(f"session {session_id} is closed")
+    turns = doc.get("turns") or []
+    if len(turns) != expected_turns:
+        raise TurnConflictError(
+            f"expected {expected_turns} turns, found {len(turns)} — a concurrent writer won"
+        )
+    role = turn.get("role")
+    if role not in VALID_ROLES:
+        raise ValueError(f"invalid turn role: {role!r}")
+    text = turn.get("text")
+    if not isinstance(text, str) or not text:
+        raise ValueError("turn text is required")
+    channel = turn.get("channel")
+    if channel not in VALID_CHANNELS:
+        raise ValueError(f"invalid turn channel: {channel!r}")
+    new_turn = {
+        "role": role,
+        "text": text,
+        "ts": turn.get("ts") or now or now_utc(),
+        "channel": channel,
+    }
+    for optional in ("router", "model", "question_id"):
+        if turn.get(optional) is not None:
+            new_turn[optional] = turn[optional]
+    doc["turns"] = [*turns, new_turn]
+    _write_json_at(_conversations_dir(root) / f"{session_id}.json", doc, vault_root=root)
+    return doc
+
+
+def close_session(
+    session_id: str,
+    close: dict,
+    *,
+    vault_root: str | Path | None = None,
+) -> dict:
+    """Store close only — no send, no commit (Wave 2). Idempotent on identical payload.
+
+    Mid-flight audit amendment M15: this stays intentionally minimal
+    (``close = {"reason": ...}`` plus an optional ``takeaway``) — issue #116
+    upgrades ``conversation-close`` in place to add sending and an
+    ``--expired`` sweep; this PR's surface does not grow extra flags.
+    """
+    if close.get("reason") not in VALID_CLOSE_REASONS:
+        raise ValueError(f"invalid close reason: {close.get('reason')!r}")
+    root = _resolve_root(vault_root)
+    doc = load_session(session_id, vault_root=root)
+    if doc.get("status") == "closed":
+        if doc.get("close") == close:
+            return doc
+        raise InvalidCloseError(
+            f"session {session_id} is already closed with a different close payload"
+        )
+    doc["status"] = "closed"
+    doc["close"] = close
+    _write_json_at(_conversations_dir(root) / f"{session_id}.json", doc, vault_root=root)
+    return doc
+
+
+# --------------------------------------------------------------------------
+# Arc-card helpers (storage only)
+#
+# Mid-flight audit amendment M1: state/arc_cards.json is NOT dict-keyed by
+# question_id with per-card expiry/mode (this PR's original contract shape).
+# The container is a single weekly-generation-run record the arc authority
+# (#118 / platform PR #124) owns: {version, generated_at, queue_generated_at,
+# expires_at, source, cards: [...], thread_offers: [...]}. This PR pins only
+# the load_arc_card/save_arc_card SIGNATURES and the container defaults —
+# cards is a plain list of typed card objects (each expected to carry a
+# "question_id" key so load/save can find it), never interpreted further
+# here.
+# --------------------------------------------------------------------------
+
+def _arc_cards_default() -> dict:
+    # A fresh dict/list on every call — never a shared module-level mutable
+    # (a `dict(SHARED_CONSTANT)` shallow copy would alias the "cards" list
+    # across every vault this process touches; the bug this factory avoids
+    # was caught by this PR's own upsert-without-duplicating test).
+    return {
+        "version": 1,
+        "generated_at": None,
+        "queue_generated_at": None,
+        "expires_at": None,
+        "source": None,
+        "cards": [],
+        "thread_offers": [],
+    }
+
+
+def load_arc_card(question_id: str, *, vault_root: str | Path | None = None) -> dict | None:
+    root = _resolve_root(vault_root)
+    data = _read_json_at(_arc_cards_path(root), vault_root=root, default=None)
+    if not isinstance(data, dict):
+        return None
+    cards = data.get("cards")
+    if not isinstance(cards, list):
+        return None
+    for card in cards:
+        if isinstance(card, dict) and card.get("question_id") == question_id:
+            return card
+    return None
+
+
+def save_arc_card(card: dict, *, vault_root: str | Path | None = None) -> None:
+    """Upsert one card into the cards list, matched by question_id."""
+    question_id = card.get("question_id")
+    if not question_id:
+        raise ValueError("arc card requires a question_id")
+    root = _resolve_root(vault_root)
+    path = _arc_cards_path(root)
+    data = _read_json_at(path, vault_root=root, default=None)
+    if not isinstance(data, dict):
+        data = _arc_cards_default()
+    for key, default in _arc_cards_default().items():
+        data.setdefault(key, default)
+    if not isinstance(data.get("cards"), list):
+        data["cards"] = []
+    cards = data["cards"]
+    for index, existing in enumerate(cards):
+        if isinstance(existing, dict) and existing.get("question_id") == question_id:
+            cards[index] = card
+            break
+    else:
+        cards.append(card)
+    _write_json_at(path, data, vault_root=root)
+
+
+# --------------------------------------------------------------------------
+# Manifest + assembly
+# --------------------------------------------------------------------------
+
+
+def _conversation_dir_path(*parts: str, framework_root: str | Path | None = None) -> Path:
+    base = Path(framework_root) / "interactions" / "conversation" if framework_root is not None \
+        else INTERACTIONS_DIR / "conversation"
+    return base.joinpath(*parts)
+
+
+def load_interaction_manifest(*, framework_root: str | Path | None = None) -> dict:
+    """Parse interaction.yaml's flat scalar subset; cast knob.*/budget.* numerics."""
+    path = _conversation_dir_path("interaction.yaml", framework_root=framework_root)
+    raw = _parse_simple_yaml(path, validate_ai_routing=False)
+    manifest: dict[str, object] = {}
+    for key, value in raw.items():
+        if key.startswith("knob.") or key.startswith("budget."):
+            manifest[key] = _cast_numeric(value)
+        else:
+            manifest[key] = value
+    return manifest
+
+
+def _cast_numeric(value: str) -> object:
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _safe_manifest() -> dict:
+    """Degrade to {} rather than raise — the framework tree may be absent.
+
+    The manifest is FRAMEWORK-scoped (interactions/), never vault-scoped —
+    unlike the CRUD helpers above it takes no vault_root.
+    """
+    try:
+        return load_interaction_manifest()
+    except (OSError, ValueError):
+        return {}
+
+
+def _read_framework_text(*parts: str) -> str:
+    return _conversation_dir_path(*parts).read_text(encoding="utf-8")
+
+
+def _truncate(text: str, budget_tokens: object) -> str:
+    if not isinstance(budget_tokens, int):
+        return text
+    limit = budget_tokens * CHARS_PER_TOKEN
+    return text if len(text) <= limit else text[:limit]
+
+
+def _assemble_profile_block(root: Path) -> str:
+    lines: list[str] = []
+    try:
+        lines.append(read_vault_text(_profile_path(root), vault_root=root).strip())
+    except FileNotFoundError:
+        pass
+    try:
+        roadmap = json.loads(read_vault_text(_roadmap_path(root), vault_root=root))
+    except (FileNotFoundError, json.JSONDecodeError):
+        roadmap = None
+    if isinstance(roadmap, dict):
+        focuses = roadmap.get("focuses")
+        if isinstance(focuses, list) and focuses:
+            names = [str(item.get("name", item)) if isinstance(item, dict) else str(item)
+                     for item in focuses]
+            lines.append("Active focuses: " + ", ".join(names))
+    return "\n".join(line for line in lines if line)
+
+
+def _assemble_record_block(session: dict, root: Path) -> str:
+    arc = session.get("arc") or {}
+    question_id = arc.get("question_id")
+    if not question_id:
+        return ""
+    answer_path = _answers_dir(root) / f"{question_id}.md"
+    try:
+        content = read_vault_text(answer_path, vault_root=root)
+    except FileNotFoundError:
+        return ""
+    metadata, body = split_frontmatter(content)
+    answered_date = metadata.get("answered_date", "unknown")
+    return f"[{question_id}, {answered_date}] {body.strip()}"
+
+
+#: The closed six-kind arc-card intent vocabulary (mid-flight audit amendment
+#: M10) — arc.intents holds typed objects shaped like {"kind": <one of
+#: these>, ...}, never plain strings.
+ARC_INTENT_KINDS = frozenset({
+    "scene_slot",
+    "neighborhood_sibling",
+    "timeline_gap",
+    "studio_slot",
+    "sit_with",
+    "demonstrated_knowledge_summary",
+})
+
+
+def _intent_label(intent: object) -> str:
+    """A short human/model-readable label for one typed arc-card intent."""
+    if isinstance(intent, dict):
+        return str(intent.get("kind", intent))
+    return str(intent)
+
+
+def _assemble_session_block(session: dict) -> str:
+    parts: list[str] = []
+    arc = session.get("arc")
+    if arc:
+        opening = arc.get("opening", "")
+        intents = arc.get("intents") or []
+        labels = ", ".join(_intent_label(intent) for intent in intents)
+        parts.append(f"Arc card: {opening} (intents: {labels})")
+    summary = session.get("rolling_summary")
+    if summary:
+        parts.append(f"Rolling summary: {summary}")
+    for turn in session.get("turns") or []:
+        parts.append(f"{turn.get('role')}: {turn.get('text')}")
+    return "\n".join(parts)
+
+
+def assemble_context(
+    session: dict,
+    *,
+    vault_root: str | Path | None = None,
+    blocks: dict[str, str] | None = None,
+) -> str:
+    """Deterministic identity->behavior->examples->profile->record->session context."""
+    root = _resolve_root(vault_root)
+    blocks = blocks or {}
+    manifest = _safe_manifest()
+    content = {
+        "identity": _read_framework_text("prompt", "identity.md"),
+        "behavior": _read_framework_text("prompt", "behavior.md"),
+        "examples": _read_framework_text("prompt", "examples.md"),
+        "profile": blocks.get("profile") if "profile" in blocks else _assemble_profile_block(root),
+        "record": blocks.get("record") if "record" in blocks else _assemble_record_block(session, root),
+        "session": _assemble_session_block(session),
+    }
+    rendered = []
+    for name in ASSEMBLE_CONTEXT_BLOCK_ORDER:
+        budget = manifest.get(f"budget.{name}")
+        text = _truncate(content[name], budget)
+        rendered.append(f"## {name.upper()}\n\n{text}")
+    return "\n\n".join(rendered)
+
+
+# --------------------------------------------------------------------------
+# Prompt builders — each pure; each has a stdin-JSON CLI path (see main()).
+# --------------------------------------------------------------------------
+
+
+def _validate_fields(payload: object, required: dict[str, type]) -> str | None:
+    if not isinstance(payload, dict):
+        return "payload must be a JSON object"
+    for field, expected_type in required.items():
+        if field not in payload:
+            return f"missing required field: {field}"
+        value = payload[field]
+        if expected_type is bool:
+            if not isinstance(value, bool):
+                return f"field {field!r} must be a boolean"
+        elif not isinstance(value, expected_type):
+            return f"field {field!r} must be a {expected_type.__name__}"
+    return None
+
+
+TURN_PROMPT_REQUIRED_FIELDS = {"session": dict}
+ROUTER_PROMPT_REQUIRED_FIELDS = {"message": str, "session_open": bool}
+ARC_PROMPT_REQUIRED_FIELDS = {"question": dict, "record_summary": str, "gap_inputs": list}
+CLOSING_PROMPT_REQUIRED_FIELDS = {"session": dict}
+
+
+def _turn_position(session: dict, manifest: dict) -> str:
+    turns = session.get("turns") or []
+    if not turns:
+        return "opening"
+    mode = session.get("mode")
+    if mode == "chat":
+        target = manifest.get("knob.chat_target_exchanges")
+        target = target if isinstance(target, int) else 3
+        exchanges_done = (len(turns) + 1) // 2  # this turn will start the next exchange
+        if exchanges_done >= target:
+            return "closing-candidate"
+        if exchanges_done == target - 1:
+            return "exit-friendly"
+        return "mid-arc"
+    cap = manifest.get("knob.conversation_turn_cap_exchanges")
+    cap = cap if isinstance(cap, int) else 25
+    if len(turns) >= cap * 2:
+        return "closing-candidate"
+    return "mid-arc"
+
+
+def build_turn_prompt(payload: dict) -> str:
+    """Assemble the context + filled turn-instructions.md for this turn."""
+    session = payload["session"]
+    blocks = payload.get("blocks")
+    manifest = _safe_manifest()
+    context = assemble_context(session, blocks=blocks)
+    turns = session.get("turns") or []
+    arc = session.get("arc") or {}
+    intents = arc.get("intents") or []
+    template = _read_framework_text("prompt", "turn-instructions.md")
+    length_cap = _lint_cap_turn_chars()
+    filled = (
+        template
+        .replace("{mode}", str(session.get("mode", "")))
+        .replace("{arc_intent}", _intent_label(intents[0]) if intents else "")
+        .replace("{turn_position}", _turn_position(session, manifest))
+        .replace("{previous_turn}", turns[-1]["text"] if turns else "")
+        .replace("{length_cap}", str(length_cap))
+    )
+    return f"{context}\n\n## TURN_INSTRUCTIONS\n\n{filled}"
+
+
+def _lint_cap_turn_chars() -> int:
+    """The turn length cap — evals/lints.yaml's cap.turn_chars is the single source."""
+    try:
+        import conversation_lints  # noqa: PLC0415
+        config = conversation_lints.load_lints_config()
+        cap = config.get("cap.turn_chars")
+        if isinstance(cap, int):
+            return cap
+    except (OSError, ValueError):
+        pass
+    return 1200
+
+
+def build_router_prompt(payload: dict) -> str:
+    """Substitute message/state into router.md — never restates its schema/intents."""
+    message = payload["message"]
+    session_open = payload["session_open"]
+    pending_question_id = payload.get("pending_question_id")
+    template = _read_framework_text("router", "router.md")
+    return (
+        template
+        .replace("{message}", message)
+        .replace("{session_open}", str(session_open))
+        .replace("{pending_question_id}", "" if pending_question_id is None else str(pending_question_id))
+    )
+
+
+def build_arc_prompt(payload: dict) -> str:
+    """Assemble a planning prompt for one arc card per plan/arc-templates.md."""
+    question = payload["question"]
+    record_summary = payload["record_summary"]
+    gap_inputs = payload["gap_inputs"]
+    template = _read_framework_text("plan", "arc-templates.md")
+    return (
+        template
+        .replace("{question_id}", str(question.get("id", "")))
+        .replace("{question_text}", str(question.get("text", "")))
+        .replace("{question_category}", str(question.get("category", "")))
+        .replace("{question_focus}", str(question.get("focus", "")))
+        .replace("{record_summary}", record_summary)
+        .replace("{gap_inputs}", "; ".join(str(item) for item in gap_inputs))
+    )
+
+
+def build_closing_prompt(payload: dict) -> str:
+    """Assemble the closing-takeaway prompt per behavior rule 8."""
+    session = payload["session"]
+    manifest = _safe_manifest()
+    deposit_framing = str(manifest.get("knob.deposit_framing", "off")).strip().lower() == "on"
+    lines = [
+        "=" * 70,
+        "LIFEHUG — CLOSING TAKEAWAY",
+        "=" * 70,
+        "",
+        f"Mode: {session.get('mode', '')}",
+        f"Rolling summary: {session.get('rolling_summary', '')}",
+        "",
+        "Write the closing message for this session (behavior rule 8):",
+        "  1. A takeaway — NOT a recap.",
+        "  2. Specific appreciation.",
+        "  3. A continuity line.",
+    ]
+    if deposit_framing:
+        lines.append("  4. An optional deposit-frame (knob.deposit_framing is ON).")
+    else:
+        lines.append("  4. Deposit-framing is OFF — do not use a deposit frame.")
+    lines.append("  5. A named hook for next time, then STOP — no trailing question.")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _read_stdin_json() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("Error: empty stdin — expected a JSON payload", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"Error: invalid JSON on stdin: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _run_prompt_builder(required: dict[str, type], builder) -> None:
+    payload = _read_stdin_json()
+    error = _validate_fields(payload, required)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        print(builder(payload))
+    except (OSError, ValueError, KeyError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    arc = None
+    if args.question_id:
+        card = load_arc_card(args.question_id)
+        arc = card if card else {"question_id": args.question_id, "opening": "", "intents": []}
+    doc = open_session(args.mode, args.channel, arc=arc)
+    path = _session_path(doc["session_id"])
+    print(f"{doc['session_id']} {path}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    if args.session_id:
+        try:
+            doc = load_session(args.session_id)
+        except FileNotFoundError:
+            print(f"Error: no such session: {args.session_id}", file=sys.stderr)
+            return 1
+        turns = doc.get("turns") or []
+        print(f"{doc['session_id']}: {doc.get('status')} ({doc.get('mode')}/{doc.get('channel')})")
+        print(f"turns: {len(turns)}")
+        if args.full:
+            for turn in turns:
+                print(f"  {turn.get('role')} [{turn.get('ts')}]: {turn.get('text')}")
+        return 0
+    sessions = list_sessions()
+    if not sessions:
+        print("No conversation sessions found.")
+        return 0
+    for summary in sessions:
+        print(
+            f"{summary['session_id']}: {summary['status']} "
+            f"({summary['mode']}/{summary['channel']}; turns={summary['turn_count']})"
+        )
+    return 0
+
+
+def cmd_record_turn(args: argparse.Namespace) -> int:
+    text = sys.stdin.read().strip()
+    if not text:
+        print("Error: turn text must be provided on stdin", file=sys.stderr)
+        return 1
+    turn = {"role": args.role, "text": text, "channel": args.channel}
+    try:
+        doc = append_turn(args.session_id, turn, expected_turns=args.expected_turns)
+    except (TurnConflictError, SessionClosedError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(f"{doc['session_id']}: {len(doc['turns'])} turn(s)")
+    return 0
+
+
+def cmd_close(args: argparse.Namespace) -> int:
+    takeaway = sys.stdin.read().strip() if not sys.stdin.isatty() else ""
+    close = {"reason": args.reason}
+    if takeaway:
+        close["takeaway"] = takeaway
+    try:
+        doc = close_session(args.session_id, close)
+    except (InvalidCloseError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(f"{doc['session_id']}: closed ({args.reason})")
+    return 0
+
+
+def cmd_turn_prompt(_args: argparse.Namespace) -> int:
+    _run_prompt_builder(TURN_PROMPT_REQUIRED_FIELDS, build_turn_prompt)
+    return 0
+
+
+def cmd_router_prompt(_args: argparse.Namespace) -> int:
+    _run_prompt_builder(ROUTER_PROMPT_REQUIRED_FIELDS, build_router_prompt)
+    return 0
+
+
+def cmd_arc_prompt(_args: argparse.Namespace) -> int:
+    _run_prompt_builder(ARC_PROMPT_REQUIRED_FIELDS, build_arc_prompt)
+    return 0
+
+
+def cmd_closing_prompt(_args: argparse.Namespace) -> int:
+    _run_prompt_builder(CLOSING_PROMPT_REQUIRED_FIELDS, build_closing_prompt)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Lifehug conversation session store + builders")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("open", help="Open a new session; prints its id and document path")
+    p.add_argument("--mode", required=True, choices=sorted(VALID_MODES))
+    p.add_argument("--channel", required=True, choices=sorted(VALID_CHANNELS))
+    p.add_argument("--question-id", default=None, help="Attach the arc card for this question, if one exists")
+    p.set_defaults(func=cmd_open)
+
+    p = sub.add_parser("status", help="Metadata-only list/detail (turn text needs --full)")
+    p.add_argument("session_id", nargs="?")
+    p.add_argument("--full", action="store_true", help="Also print turn text (private content)")
+    p.set_defaults(func=cmd_status)
+
+    p = sub.add_parser("record-turn", help="CAS-append one turn; text on stdin")
+    p.add_argument("session_id")
+    p.add_argument("--role", required=True, choices=sorted(VALID_ROLES))
+    p.add_argument("--channel", default="cli", choices=sorted(VALID_CHANNELS))
+    p.add_argument("--expected-turns", required=True, type=int)
+    p.set_defaults(func=cmd_record_turn)
+
+    p = sub.add_parser("close", help="Store close only; takeaway on stdin optional")
+    p.add_argument("session_id")
+    p.add_argument("--reason", required=True, choices=sorted(VALID_CLOSE_REASONS))
+    p.set_defaults(func=cmd_close)
+
+    p = sub.add_parser("turn-prompt", help="stdin JSON -> the turn prompt")
+    p.set_defaults(func=cmd_turn_prompt)
+
+    p = sub.add_parser("router-prompt", help="stdin JSON -> the router prompt")
+    p.set_defaults(func=cmd_router_prompt)
+
+    p = sub.add_parser("arc-prompt", help="stdin JSON -> the arc-planning prompt")
+    p.set_defaults(func=cmd_arc_prompt)
+
+    p = sub.add_parser("closing-prompt", help="stdin JSON -> the closing-takeaway prompt")
+    p.set_defaults(func=cmd_closing_prompt)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system/conversation_lints.py
+++ b/system/conversation_lints.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Lifehug — the deterministic conversation lint engine.
+
+One authoritative module for the checks that will run both in CI evals and
+at Wave-2 runtime (recurring-defect doctrine — never an inline copy).
+``interactions/conversation/evals/lints.yaml`` (issue #114) is the config
+authority (banned phrases, the length cap, on/off per lint id); this module
+is the engine that reads that config and applies it.
+
+Lints are heuristic by design, false-negative-lenient and false-positive-
+strict (a lint that flags a genuinely good turn will be muted in Wave 2 —
+bias against that). Two heuristics worth documenting explicitly:
+
+* **"Count question sentences, not raw '?'."** A receipt legitimately
+  quotes the user's own words, and the user's own words can themselves be
+  a question they once asked ("You once asked me, \"was it hard?\", and I
+  never really answered.") — that embedded, ECHOED question must not count
+  as one the model is asking. Before splitting into sentences, any
+  double-quoted span that itself contains a ``?`` is stripped. A quoted
+  span WITHOUT a ``?`` (a cued invitation quoting a non-question phrase,
+  e.g. "the old farmhouse") is left intact — it is what marks a question
+  as ``cued``, a good pattern.
+* **Sentence splitting** is a plain ``[^.!?]+[.!?]*`` regex scan — no NLP
+  dependency (the repo is deliberately stdlib-only). It is good enough for
+  the goldens this PR's tests exercise; goldens/real transcripts in the
+  eval-harness PR may expose sharper cases later.
+
+Public surface:
+
+    load_lints_config(*, framework_root=None) -> dict
+    lint_turn(text, *, is_reply_to_substantive=False, config=None) -> list[dict]
+    lint_transcript(turns, *, config=None) -> list[dict]
+
+Findings are ``{"lint": "<id>", "detail": "...", "span": [start, end]}``.
+Implemented lint ids (exactly matching lints.yaml and behavior.md rule
+numbers): ``one_question_per_turn`` (rule 1), ``banned_phrases`` (rules
+4/5/12 + the do-not-use list), ``question_grammar_audit`` (rule 3),
+``length_caps``, ``receipt_before_question`` (rule 2, structural),
+``year_question_detector`` (rule 3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from lifehug_core import INTERACTIONS_DIR, _parse_simple_yaml
+
+DEFAULT_CAP_TURN_CHARS = 1200
+SUBSTANTIVE_MIN_CHARS = 20  # heuristic floor for a "substantive" preceding user turn
+
+#: The closed grammar-classification vocabulary (question_grammar_audit).
+#: Only "closed" and "option_posing" produce findings; "ted"/"cued"/"other"
+#: are informational tags a question sentence may also carry.
+QUESTION_GRAMMAR_TAGS = frozenset({"ted", "cued", "closed", "option_posing", "other"})
+
+_QUOTED_SPAN_RE = re.compile(r'"[^"]*"')
+_QUOTED_QUESTION_RE = re.compile(r'"[^"]*\?[^"]*"')
+_SENTENCE_RE = re.compile(r'[^.!?]+[.!?]*')
+_TED_RE = re.compile(r'^\s*(tell me|describe|explain|walk me through)\b', re.IGNORECASE)
+_CLOSED_RE = re.compile(
+    r'^\s*(do|does|did|is|are|was|were|have|has|had|can|could|will|would|should|shall|may|might)\b',
+    re.IGNORECASE,
+)
+_OR_RE = re.compile(r'\bor\b', re.IGNORECASE)
+_YEAR_PATTERNS = ("what year", "which year", "in what year")
+
+
+def _conversation_evals_path(*parts: str, framework_root: str | Path | None = None) -> Path:
+    base = Path(framework_root) / "interactions" / "conversation" / "evals" if framework_root is not None \
+        else INTERACTIONS_DIR / "conversation" / "evals"
+    return base.joinpath(*parts)
+
+
+def load_lints_config(*, framework_root: str | Path | None = None) -> dict:
+    """Read evals/lints.yaml's flat subset: lint.<id>: on/off, cap.*, banned.N."""
+    path = _conversation_evals_path("lints.yaml", framework_root=framework_root)
+    raw = _parse_simple_yaml(path, validate_ai_routing=False)
+    config: dict[str, object] = {}
+    banned: list[str] = []
+    for key, value in raw.items():
+        if key.startswith("lint."):
+            config[key] = value.strip().lower() == "on"
+        elif key.startswith("cap."):
+            try:
+                config[key] = int(value)
+            except ValueError:
+                config[key] = value
+        elif key.startswith("banned."):
+            banned.append(value)
+        else:
+            config[key] = value
+    config["banned_phrases"] = banned
+    return config
+
+
+def _strip_echoed_questions(text: str) -> str:
+    return _QUOTED_QUESTION_RE.sub("", text)
+
+
+def _split_sentences(text: str) -> list[str]:
+    return [s for s in _SENTENCE_RE.findall(text) if s.strip()]
+
+
+def _is_question(sentence: str) -> bool:
+    return sentence.rstrip().endswith("?")
+
+
+def _classify_question(sentence: str) -> set[str]:
+    tags: set[str] = set()
+    if _TED_RE.search(sentence):
+        tags.add("ted")
+    if _QUOTED_SPAN_RE.search(sentence):
+        tags.add("cued")
+    if _CLOSED_RE.match(sentence.strip()):
+        tags.add("closed")
+    if _OR_RE.search(sentence):
+        tags.add("option_posing")
+    if not tags:
+        tags.add("other")
+    return tags
+
+
+def _span_of(text: str, needle: str) -> list[int]:
+    clean = needle.strip()
+    start = text.find(clean) if clean else -1
+    if start == -1:
+        return [0, len(text)]
+    return [start, start + len(clean)]
+
+
+def lint_turn(
+    text: str,
+    *,
+    is_reply_to_substantive: bool = False,
+    config: dict | None = None,
+) -> list[dict]:
+    """Deterministic findings for one lifehug-role turn's text."""
+    config = config if config is not None else load_lints_config()
+    findings: list[dict] = []
+
+    stripped = _strip_echoed_questions(text)
+    sentences = _split_sentences(stripped)
+    question_sentences = [s for s in sentences if _is_question(s)]
+
+    if config.get("lint.one_question_per_turn", True) and len(question_sentences) > 1:
+        findings.append({
+            "lint": "one_question_per_turn",
+            "detail": f"{len(question_sentences)} questions found in one turn",
+            "span": _span_of(text, question_sentences[-1]),
+        })
+
+    if config.get("lint.banned_phrases", True):
+        lowered = text.lower()
+        for phrase in config.get("banned_phrases", []):
+            idx = lowered.find(str(phrase).lower())
+            if idx != -1:
+                findings.append({
+                    "lint": "banned_phrases",
+                    "detail": f"banned phrase: {phrase!r}",
+                    "span": [idx, idx + len(phrase)],
+                })
+
+    if config.get("lint.question_grammar_audit", True):
+        for sentence in question_sentences:
+            tags = _classify_question(sentence)
+            if "closed" in tags:
+                findings.append({
+                    "lint": "question_grammar_audit",
+                    "detail": f"closed (yes/no) question: {sentence.strip()!r}",
+                    "span": _span_of(text, sentence),
+                })
+            if "option_posing" in tags:
+                findings.append({
+                    "lint": "question_grammar_audit",
+                    "detail": f"option-posing question: {sentence.strip()!r}",
+                    "span": _span_of(text, sentence),
+                })
+
+    if config.get("lint.length_caps", True):
+        cap = config.get("cap.turn_chars", DEFAULT_CAP_TURN_CHARS)
+        if isinstance(cap, int) and len(text) > cap:
+            findings.append({
+                "lint": "length_caps",
+                "detail": f"turn is {len(text)} chars, over the {cap}-char cap",
+                "span": [cap, len(text)],
+            })
+
+    if config.get("lint.receipt_before_question", True) and is_reply_to_substantive:
+        raw_sentences = _split_sentences(text)
+        if raw_sentences and _is_question(raw_sentences[0]):
+            findings.append({
+                "lint": "receipt_before_question",
+                "detail": "reply opens with a question instead of a receipt",
+                "span": _span_of(text, raw_sentences[0]),
+            })
+
+    if config.get("lint.year_question_detector", True):
+        lowered = text.lower()
+        for pattern in _YEAR_PATTERNS:
+            idx = lowered.find(pattern)
+            if idx != -1:
+                findings.append({
+                    "lint": "year_question_detector",
+                    "detail": f"'what year'-form question ({pattern!r})",
+                    "span": [idx, idx + len(pattern)],
+                })
+                break
+
+    return findings
+
+
+def lint_transcript(turns: list[dict], *, config: dict | None = None) -> list[dict]:
+    """Map lint_turn over lifehug-role turns; substantive-reply flag from the prior user turn."""
+    config = config if config is not None else load_lints_config()
+    findings: list[dict] = []
+    previous_user_text = ""
+    for index, turn in enumerate(turns):
+        role = turn.get("role")
+        text = turn.get("text") or ""
+        if role == "user":
+            previous_user_text = text
+            continue
+        if role != "lifehug":
+            continue
+        is_reply = len(previous_user_text.strip()) >= SUBSTANTIVE_MIN_CHARS
+        for finding in lint_turn(text, is_reply_to_substantive=is_reply, config=config):
+            findings.append({**finding, "turn_index": index})
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print deterministic conversation lint findings for stdin turn text"
+    )
+    parser.add_argument(
+        "--reply-to-substantive",
+        action="store_true",
+        help="Treat this turn as a reply to a substantive preceding user message",
+    )
+    args = parser.parse_args()
+    text = sys.stdin.read()
+    # Linting is reporting, not failing (contract, Deliverable 5) — always
+    # exit 0; an empty turn simply has zero findings.
+    for finding in lint_turn(text, is_reply_to_substantive=args.reply_to_substantive):
+        print(json.dumps(finding))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -63,7 +63,10 @@ QUEUED_MUTATION_COMMANDS = frozenset({
 READ_ONLY_COMMANDS = frozenset({
     "ai-status", "answer-ack-prompt", "answer-ack-status", "book-chapter", "book-status",
     "candidates-list", "candidates-review", "candidates-stats", "chapters-exercise",
-    "connector-audit", "connector-report", "daily-dry-run", "doctor",
+    "connector-audit", "connector-report",
+    "conversation-arc-prompt", "conversation-closing-prompt", "conversation-lint",
+    "conversation-router-prompt", "conversation-status", "conversation-turn-prompt",
+    "daily-dry-run", "doctor",
     "followups-prompt", "followups-status", "interview-pack", "next", "notify",
     "planner-report", "progress", "quality-stats", "roadmap", "serve",
     "source-findings", "source-scan", "status", "weekly-summary",
@@ -73,7 +76,12 @@ DIRECT_MUTATION_COMMANDS = frozenset({
     "book-offers", "candidates-auto-promote", "candidates-promote",
     "candidates-promote-neighborhood", "candidates-update", "classify-story",
     "connector-auth", "connector-calibrate", "connector-dossier", "connector-excavate",
-    "connector-fetch", "correct-source", "entity-roster", "fix", "focus-add",
+    "connector-fetch",
+    # New in issue #115 (Conversation Interaction, Wave 1 PR 2): the session
+    # store's own three mutators. No jobs.py command kind yet (Wave 2) — they
+    # take the writer lock directly like the rest of this family.
+    "conversation-close", "conversation-open", "conversation-record-turn",
+    "correct-source", "entity-roster", "fix", "focus-add",
     "focus-approve", "focus-dismiss", "focus-finish", "focus-new", "focus-set",
     "ingest", "ingest-story", "mirror-compile", "perennial-add", "perennials",
     "planner-clear", "planner-objective-add", "planner-objective-clear", "planner-queue",
@@ -813,6 +821,58 @@ def cmd_answer_ack_retry(args: argparse.Namespace) -> int:
     if args.confirm_not_sent:
         flags.append("--confirm-not-sent")
     return run_python("answer_ack_delivery.py", flags)
+
+
+def cmd_conversation_open(args: argparse.Namespace) -> int:
+    flags = ["open", "--mode", args.mode, "--channel", args.channel]
+    if args.question_id:
+        flags += ["--question-id", args.question_id]
+    return run_python("conversation.py", flags)
+
+
+def cmd_conversation_status(args: argparse.Namespace) -> int:
+    flags = ["status"]
+    if args.session_id:
+        flags.append(args.session_id)
+    if args.full:
+        flags.append("--full")
+    return run_python("conversation.py", flags)
+
+
+def cmd_conversation_record_turn(args: argparse.Namespace) -> int:
+    flags = [
+        "record-turn", args.session_id,
+        "--role", args.role,
+        "--expected-turns", str(args.expected_turns),
+    ]
+    if args.channel:
+        flags += ["--channel", args.channel]
+    return run_python("conversation.py", flags)
+
+
+def cmd_conversation_close(args: argparse.Namespace) -> int:
+    return run_python("conversation.py", ["close", args.session_id, "--reason", args.reason])
+
+
+def cmd_conversation_turn_prompt(_args: argparse.Namespace) -> int:
+    return run_python("conversation.py", ["turn-prompt"])
+
+
+def cmd_conversation_router_prompt(_args: argparse.Namespace) -> int:
+    return run_python("conversation.py", ["router-prompt"])
+
+
+def cmd_conversation_arc_prompt(_args: argparse.Namespace) -> int:
+    return run_python("conversation.py", ["arc-prompt"])
+
+
+def cmd_conversation_closing_prompt(_args: argparse.Namespace) -> int:
+    return run_python("conversation.py", ["closing-prompt"])
+
+
+def cmd_conversation_lint(args: argparse.Namespace) -> int:
+    flags = ["--reply-to-substantive"] if args.reply_to_substantive else []
+    return run_python("conversation_lints.py", flags)
 
 
 def cmd_daily_dry_run(_args: argparse.Namespace) -> int:
@@ -1801,6 +1861,45 @@ def build_parser() -> argparse.ArgumentParser:
         help="Retry an ambiguous send only after checking that Telegram did not receive it",
     )
     p.set_defaults(func=cmd_answer_ack_retry)
+
+    p = sub.add_parser("conversation-open", help="Open a new conversation session; prints its id and document path")
+    p.add_argument("--mode", required=True, choices=["chat", "conversation"])
+    p.add_argument("--channel", required=True, choices=["telegram", "web", "cli"])
+    p.add_argument("--question-id", default=None, help="Attach the arc card for this question, if one exists")
+    p.set_defaults(func=cmd_conversation_open)
+
+    p = sub.add_parser("conversation-status", help="Metadata-only conversation session list/detail")
+    p.add_argument("session_id", nargs="?")
+    p.add_argument("--full", action="store_true", help="Also print turn text (private content)")
+    p.set_defaults(func=cmd_conversation_status)
+
+    p = sub.add_parser("conversation-record-turn", help="CAS-append one conversation turn; text on stdin")
+    p.add_argument("session_id")
+    p.add_argument("--role", required=True, choices=["user", "lifehug"])
+    p.add_argument("--channel", default=None, choices=["telegram", "web", "cli"])
+    p.add_argument("--expected-turns", required=True, type=int)
+    p.set_defaults(func=cmd_conversation_record_turn)
+
+    p = sub.add_parser("conversation-close", help="Store a conversation close only; takeaway on stdin optional")
+    p.add_argument("session_id")
+    p.add_argument("--reason", required=True, choices=["done", "idle_timeout", "exit_taken"])
+    p.set_defaults(func=cmd_conversation_close)
+
+    p = sub.add_parser("conversation-turn-prompt", help="stdin JSON -> the conversation turn prompt")
+    p.set_defaults(func=cmd_conversation_turn_prompt)
+
+    p = sub.add_parser("conversation-router-prompt", help="stdin JSON -> the conversation router prompt")
+    p.set_defaults(func=cmd_conversation_router_prompt)
+
+    p = sub.add_parser("conversation-arc-prompt", help="stdin JSON -> the arc-card planning prompt")
+    p.set_defaults(func=cmd_conversation_arc_prompt)
+
+    p = sub.add_parser("conversation-closing-prompt", help="stdin JSON -> the closing-takeaway prompt")
+    p.set_defaults(func=cmd_conversation_closing_prompt)
+
+    p = sub.add_parser("conversation-lint", help="Print deterministic lint findings for stdin turn text")
+    p.add_argument("--reply-to-substantive", action="store_true")
+    p.set_defaults(func=cmd_conversation_lint)
 
     p = sub.add_parser("daily-dry-run", help="Validate daily delivery config without sending")
     p.set_defaults(func=cmd_daily_dry_run)

--- a/system/lifehug_core.py
+++ b/system/lifehug_core.py
@@ -184,10 +184,14 @@ REPORTS_DIR = _data("reports")
 AGENT_TASKS_DIR = _data("agent_tasks")
 JOBS_DIR = _data("jobs")
 COMPILE_NEEDED_FILE = _data("compile_needed")
+ARC_CARDS_FILE = _data("arc_cards")
+CONVERSATIONS_DIR = _data("conversations")
+MIRROR_RESPONSES_FILE = _data("mirror_responses")
 
 TEMPLATES_DIR = framework_path("templates", framework_system_dir=SYSTEM_DIR)
 MISSION_FILE = framework_path("mission", framework_system_dir=SYSTEM_DIR)
 CONNECTORS_DIR = framework_path("connectors", framework_system_dir=SYSTEM_DIR)
+INTERACTIONS_DIR = framework_path("interactions", framework_system_dir=SYSTEM_DIR)
 
 QUESTION_ID_RE = r"[A-Z]\d+[a-z]*"
 QUESTION_LINE_RE = re.compile(

--- a/system/vault_contract.json
+++ b/system/vault_contract.json
@@ -2,9 +2,9 @@
   "contract_version": 1,
   "identity": {
     "framework": "lifehug/lifehug",
-    "framework_version": 120,
-    "revision": "vault-contract-v1",
-    "content_digest": "sha256:335369282eb9b1c3f205eb784c1f8b17cdbb6681e04baeabdcbc356b3d27a635"
+    "framework_version": 150,
+    "revision": "vault-contract-v2",
+    "content_digest": "sha256:b5c2c3362d4f4f8b71735a2a4e2f48e23b61ea77ee66e7939702142ee4691d76"
   },
   "special_file_policy": {
     "regular_files": "allow",
@@ -29,7 +29,8 @@
     "mission": "system/mission.md",
     "research": "system/research.md",
     "version": "system/version.json",
-    "connectors": "system/connectors"
+    "connectors": "system/connectors",
+    "interactions": "interactions"
   },
   "data_paths": {
     "question_bank": {
@@ -120,6 +121,27 @@
     "reports": {"path": "state/reports", "kind": "directory", "required": false, "tracked": true, "schema": {"format": "markdown_family", "version_field": null, "supported": []}},
     "agent_tasks": {"path": "state/agent_tasks", "kind": "directory", "required": false, "tracked": false, "schema": {"format": "task_family", "version_field": null, "supported": []}},
     "jobs": {"path": "state/jobs", "kind": "directory", "required": false, "tracked": false, "schema": {"format": "job_family", "version_field": "record_version", "supported": [2]}},
-    "compile_needed": {"path": "state/.compile-needed", "kind": "file", "required": false, "tracked": false, "schema": {"format": "sentinel", "version_field": null, "supported": []}}
+    "compile_needed": {"path": "state/.compile-needed", "kind": "file", "required": false, "tracked": false, "schema": {"format": "sentinel", "version_field": null, "supported": []}},
+    "arc_cards": {
+      "path": "state/arc_cards.json",
+      "kind": "file",
+      "required": false,
+      "tracked": true,
+      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+    },
+    "conversations": {
+      "path": "state/conversations",
+      "kind": "directory",
+      "required": false,
+      "tracked": true,
+      "schema": {"format": "json_family", "version_field": "session_version", "supported": [1]}
+    },
+    "mirror_responses": {
+      "path": "state/mirror_responses.json",
+      "kind": "file",
+      "required": false,
+      "tracked": true,
+      "schema": {"format": "json", "version_field": "version", "supported": [1]}
+    }
   }
 }

--- a/system/vault_paths.py
+++ b/system/vault_paths.py
@@ -94,7 +94,7 @@ def _normalized_contract(value: dict[str, object]) -> dict[str, object]:
     normalized["framework_paths"] = {
         name: {
             "path": path,
-            "kind": "directory" if name in {"system", "templates", "connectors"} else "file",
+            "kind": "directory" if name in {"system", "templates", "connectors", "interactions"} else "file",
             "classification": "framework",
         }
         for name, path in framework_paths.items()

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 151,
+  "version": 152,
   "released": "2026-08-11",
-  "changelog": "v150: the conversation surface (chats around the daily question, long inbound conversations) becomes a designed Interaction instead of three disconnected mechanisms. New `interactions/` pattern directory documents the definition/runtime/seat split any AI-driven surface will follow; the full `interactions/conversation/` skeleton ships its behavior contract, context recipe, router/deflection templates, provider overlays, eval fixtures (lints, rubrics, seven personas), and arc-planning spec, plus all four research phases behind it (what makes conversations great, the payout turn, elicitation craft, the interaction architecture) committed in full for anyone who wants the why, not just the what. README gains the Interaction/Chat/Conversation/Arc card/Session nomenclature and a truthfully-labeled daily-loop diagram noting the Chat engine ships in the next waves. ADR 0002 records the pattern. system/mission.md carries a draft refresh (owner ratifies in review) weaving in the direction to honor and increase the value of your life and relationships. No behavior change: nothing here is loaded by any live flow yet \u2014 the loader and builders land in the next PR (issue #115).",
+  "changelog": "v150: the Conversation Interaction's durable session store lands (issue #115, Wave 1 PR 2 of 2) \u2014 vault-contract v2 registers arc_cards, conversations, and mirror_responses data paths plus the interactions framework path; system/conversation.py adds session CRUD (open/load/list/append-turn-CAS/close), deterministic context assembly, and four pure prompt builders (turn/router/arc/closing); system/conversation_lints.py adds the deterministic lint engine (one-question-per-turn, banned phrases, question-grammar audit, length caps, receipt-before-question, year-question detection); eight new conversation-* lifehug.py subcommands expose all of it. Infrastructure only \u2014 no live-flow behavior change; nothing here is reachable except through the new subcommands and imports.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -183,6 +183,8 @@
     "tests/v119_job_pill_evidence.py",
     "tests/walkthrough_answers.py",
     "tests/walkthrough_lib.py",
-    "wiki/SCHEMA.md"
+    "wiki/SCHEMA.md",
+    "system/conversation.py",
+    "system/conversation_lints.py"
   ]
 }

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -38,12 +38,14 @@ EXPECTED_DATA_PATHS = {
     "agent_tasks",
     "answer_scores",
     "answers",
+    "arc_cards",
     "artifact_sources",
     "book_offers",
     "classifications",
     "compile_needed",
     "config",
     "connectors_state",
+    "conversations",
     "correction_sources",
     "coverage",
     "entity_rosters",
@@ -53,6 +55,7 @@ EXPECTED_DATA_PATHS = {
     "learning_failures",
     "legacy_focus_recommendations",
     "manual_sources",
+    "mirror_responses",
     "neighborhoods",
     "outputs",
     "perennials",
@@ -185,7 +188,7 @@ class VaultContractTests(unittest.TestCase):
         self.assertEqual(vault_paths.FRAMEWORK_PATHS, exported["framework_paths"])
         self.assertEqual(list(exported["data_paths"]), sorted(exported["data_paths"]))
         self.assertEqual(list(exported["framework_paths"]), sorted(exported["framework_paths"]))
-        self.assertEqual(exported["identity"]["framework_version"], 120)
+        self.assertEqual(exported["identity"]["framework_version"], 150)
         self.assertEqual(
             exported["identity"]["content_digest"],
             vault_paths._contract_digest(exported),

--- a/tests/test_v150_conversation_store.py
+++ b/tests/test_v150_conversation_store.py
@@ -1,0 +1,574 @@
+"""v150 / issue #115 — conversation session store + pure prompt/context builders.
+
+Conversation Interaction build, Wave 1 PR 2 of 2. Registers state/arc_cards,
+state/conversations/, and state/mirror_responses in the vault contract
+(v2), then exercises system/conversation.py's session CRUD + assembly +
+prompt builders and system/conversation_lints.py's deterministic lint
+engine. Infrastructure only — subtest 6 proves no live flow imports either
+new module.
+
+Synthetic data only; NEVER references ~/Workspace/dave.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSTEM = ROOT / "system"
+sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
+
+from tempdirs import root_parent_tmp  # noqa: E402
+import conversation  # noqa: E402
+import conversation_lints  # noqa: E402
+import vault_paths  # noqa: E402
+
+EXPECTED_NEW_DATA_PATHS = {"arc_cards", "conversations", "mirror_responses"}
+
+
+class RegistrationTests(unittest.TestCase):
+    """Subtest 1: contract imports green; the three new entries' shapes."""
+
+    def test_new_data_paths_registered_with_contract_shapes(self):
+        exported = vault_paths.exported_contract()
+        data_paths = exported["data_paths"]
+        self.assertTrue(EXPECTED_NEW_DATA_PATHS.issubset(set(data_paths)))
+
+        arc_cards = data_paths["arc_cards"]
+        self.assertEqual(arc_cards["external_path"], "state/arc_cards.json")
+        self.assertEqual(arc_cards["classification"], "durable_data")
+        self.assertFalse(arc_cards.get("required", False))
+
+        conversations = data_paths["conversations"]
+        self.assertEqual(conversations["external_path"], "state/conversations")
+        self.assertEqual(conversations["classification"], "durable_data")
+
+        mirror_responses = data_paths["mirror_responses"]
+        self.assertEqual(mirror_responses["external_path"], "state/mirror_responses.json")
+        self.assertEqual(mirror_responses["classification"], "durable_data")
+
+        # kind is derivable from vault_paths.VAULT_DATA_PATHS (pre-normalization
+        # entries keep "kind" verbatim from the raw contract).
+        self.assertEqual(vault_paths.VAULT_DATA_PATHS["arc_cards"]["kind"], "file")
+        self.assertEqual(vault_paths.VAULT_DATA_PATHS["conversations"]["kind"], "directory")
+        self.assertEqual(vault_paths.VAULT_DATA_PATHS["mirror_responses"]["kind"], "file")
+        for name in EXPECTED_NEW_DATA_PATHS:
+            self.assertTrue(vault_paths.VAULT_DATA_PATHS[name]["tracked"])
+
+    def test_interactions_framework_path_is_a_directory(self):
+        self.assertEqual(
+            vault_paths.FRAMEWORK_PATHS["interactions"],
+            {"path": "interactions", "kind": "directory", "classification": "framework"},
+        )
+
+    def test_digest_is_self_consistent(self):
+        self.assertEqual(
+            vault_paths.VAULT_CONTRACT["identity"]["content_digest"],
+            vault_paths._contract_digest(vault_paths.VAULT_CONTRACT),
+        )
+
+    def test_lifehug_core_gained_exactly_one_data_accessor_per_new_name(self):
+        core = (SYSTEM / "lifehug_core.py").read_text(encoding="utf-8")
+        found = re.findall(r'_data\("([^"]+)"\)', core)
+        for name in EXPECTED_NEW_DATA_PATHS:
+            self.assertEqual(found.count(name), 1, name)
+
+
+class ConversationStoreTests(unittest.TestCase):
+    """Subtest 2: session lifecycle (open/append CAS/close, cold-vault degradation)."""
+
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v150-conversation-")
+        self.vault = self.tmp / "vault"
+        self.vault.mkdir()
+
+    def test_cold_vault_degrades_to_empty_not_an_error(self):
+        self.assertEqual(conversation.list_sessions(vault_root=self.vault), [])
+        self.assertIsNone(conversation.load_arc_card("A14b", vault_root=self.vault))
+
+    def test_open_creates_the_document_with_the_exact_schema_shape(self):
+        arc = {
+            "question_id": "A14b",
+            "opening": "Last time you mentioned the diesel smell on the farm.",
+            "intents": [{"kind": "scene_slot", "focus": "kitchen"}],
+        }
+        doc = conversation.open_session("chat", "cli", arc=arc, vault_root=self.vault)
+
+        self.assertRegex(doc["session_id"], r"^conv-\d{8}-\d{6}-[0-9a-f]{6}$")
+        path = self.vault / "state" / "conversations" / f"{doc['session_id']}.json"
+        self.assertTrue(path.is_file())
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(on_disk, doc)
+
+        self.assertEqual(doc["session_version"], 1)
+        self.assertEqual(doc["mode"], "chat")
+        self.assertEqual(doc["channel"], "cli")
+        self.assertIn("interaction_version", doc)
+        self.assertEqual(doc["status"], "open")
+        self.assertEqual(doc["arc"], arc)
+        self.assertEqual(doc["turns"], [])
+        self.assertEqual(doc["rolling_summary"], "")
+        self.assertEqual(
+            doc["extracted"],
+            {"facts": [], "entities": [], "candidate_ideas": [], "mirror_responses": []},
+        )
+        self.assertNotIn("close", doc)
+
+    def test_append_turn_cas_and_stale_expected_turns_fails_typed(self):
+        doc = conversation.open_session("conversation", "cli", vault_root=self.vault)
+        sid = doc["session_id"]
+
+        appended = conversation.append_turn(
+            sid,
+            {"role": "user", "text": "The diesel smell, mostly.", "channel": "cli"},
+            expected_turns=0,
+            vault_root=self.vault,
+        )
+        self.assertEqual(len(appended["turns"]), 1)
+        self.assertEqual(appended["turns"][0]["role"], "user")
+        self.assertEqual(appended["turns"][0]["channel"], "cli")
+        self.assertIn("ts", appended["turns"][0])
+
+        with self.assertRaises(conversation.TurnConflictError):
+            conversation.append_turn(
+                sid,
+                {"role": "lifehug", "text": "Tell me more.", "channel": "cli"},
+                expected_turns=0,  # stale — one turn already landed
+                vault_root=self.vault,
+            )
+        reloaded = conversation.load_session(sid, vault_root=self.vault)
+        self.assertEqual(len(reloaded["turns"]), 1, "the failed CAS must not have written")
+
+    def test_close_idempotent_mismatch_and_append_after_close(self):
+        doc = conversation.open_session("chat", "cli", vault_root=self.vault)
+        sid = doc["session_id"]
+
+        closed = conversation.close_session(sid, {"reason": "done"}, vault_root=self.vault)
+        self.assertEqual(closed["status"], "closed")
+        self.assertEqual(closed["close"], {"reason": "done"})
+
+        # idempotent: identical payload, no-op
+        again = conversation.close_session(sid, {"reason": "done"}, vault_root=self.vault)
+        self.assertEqual(again, closed)
+
+        # different payload against an already-closed session: typed error
+        with self.assertRaises(conversation.InvalidCloseError):
+            conversation.close_session(sid, {"reason": "idle_timeout"}, vault_root=self.vault)
+
+        # append after close: typed error
+        with self.assertRaises(conversation.SessionClosedError):
+            conversation.append_turn(
+                sid,
+                {"role": "user", "text": "one more thing", "channel": "cli"},
+                expected_turns=0,
+                vault_root=self.vault,
+            )
+
+    def test_list_sessions_metadata_only_and_status_filter(self):
+        open_doc = conversation.open_session("chat", "telegram", vault_root=self.vault)
+        conversation.append_turn(
+            open_doc["session_id"],
+            {"role": "user", "text": "hi there", "channel": "telegram"},
+            expected_turns=0,
+            vault_root=self.vault,
+        )
+        closed_doc = conversation.open_session("conversation", "web", vault_root=self.vault)
+        conversation.close_session(closed_doc["session_id"], {"reason": "done"}, vault_root=self.vault)
+
+        all_sessions = {s["session_id"]: s for s in conversation.list_sessions(vault_root=self.vault)}
+        self.assertEqual(set(all_sessions), {open_doc["session_id"], closed_doc["session_id"]})
+        self.assertEqual(all_sessions[open_doc["session_id"]]["turn_count"], 1)
+        self.assertEqual(all_sessions[open_doc["session_id"]]["status"], "open")
+        self.assertEqual(all_sessions[open_doc["session_id"]]["channel"], "telegram")
+        self.assertIsNotNone(all_sessions[open_doc["session_id"]]["opened"])
+        self.assertIsNone(all_sessions[closed_doc["session_id"]]["opened"])  # zero turns
+
+        closed_only = conversation.list_sessions(status="closed", vault_root=self.vault)
+        self.assertEqual([s["session_id"] for s in closed_only], [closed_doc["session_id"]])
+
+    def test_invalid_mode_channel_and_role_raise(self):
+        with self.assertRaises(ValueError):
+            conversation.open_session("bogus", "cli", vault_root=self.vault)
+        with self.assertRaises(ValueError):
+            conversation.open_session("chat", "bogus", vault_root=self.vault)
+        doc = conversation.open_session("chat", "cli", vault_root=self.vault)
+        with self.assertRaises(ValueError):
+            conversation.append_turn(
+                doc["session_id"],
+                {"role": "bogus", "text": "x", "channel": "cli"},
+                expected_turns=0,
+                vault_root=self.vault,
+            )
+
+
+class ArcCardStoreTests(unittest.TestCase):
+    """Arc-card storage per mid-flight audit amendment M1: cards is a LIST,
+    not dict-keyed by question_id; the container carries generation-run
+    bookkeeping this PR does not interpret (that's #118 / platform PR #124).
+    """
+
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v150-arc-cards-")
+        self.vault = self.tmp / "vault"
+        self.vault.mkdir()
+
+    def test_save_then_load_round_trips_and_cards_is_a_list(self):
+        card = {
+            "question_id": "A14b",
+            "opening": "Last time...",
+            "intents": [{"kind": "timeline_gap"}, {"kind": "sit_with"}],
+        }
+        conversation.save_arc_card(card, vault_root=self.vault)
+        on_disk = json.loads(
+            (self.vault / "state" / "arc_cards.json").read_text(encoding="utf-8")
+        )
+        self.assertIsInstance(on_disk["cards"], list)
+        self.assertIn("generated_at", on_disk)
+        self.assertIn("queue_generated_at", on_disk)
+        self.assertIn("expires_at", on_disk)
+        self.assertIn("source", on_disk)
+        self.assertIn("thread_offers", on_disk)
+
+        loaded = conversation.load_arc_card("A14b", vault_root=self.vault)
+        self.assertEqual(loaded, card)
+        self.assertIsNone(conversation.load_arc_card("nonexistent", vault_root=self.vault))
+
+    def test_save_upserts_by_question_id_without_duplicating(self):
+        conversation.save_arc_card({"question_id": "A1", "intents": []}, vault_root=self.vault)
+        conversation.save_arc_card({"question_id": "A2", "intents": []}, vault_root=self.vault)
+        conversation.save_arc_card(
+            {"question_id": "A1", "intents": [{"kind": "studio_slot"}]}, vault_root=self.vault
+        )
+        on_disk = json.loads(
+            (self.vault / "state" / "arc_cards.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(len(on_disk["cards"]), 2)
+        updated = conversation.load_arc_card("A1", vault_root=self.vault)
+        self.assertEqual(updated["intents"], [{"kind": "studio_slot"}])
+
+    def test_no_append_mirror_response_function_exists(self):
+        """M14: #119 ships the single mirror writer; this PR only registers
+        the vault-contract path."""
+        self.assertFalse(hasattr(conversation, "append_mirror_response"))
+
+
+class AssemblyDeterminismTests(unittest.TestCase):
+    """Subtest 3: same session + same blocks -> byte-identical context twice;
+    block order matches interaction.yaml's load_order; budgets truncate.
+    """
+
+    def _sample_session(self) -> dict:
+        return {
+            "session_version": 1,
+            "session_id": "conv-20260811-090000-abc123",
+            "mode": "chat",
+            "channel": "cli",
+            "interaction_version": "1.0.0",
+            "status": "open",
+            "arc": {
+                "question_id": "A14b",
+                "opening": "Last time you mentioned the diesel smell.",
+                "intents": [{"kind": "scene_slot"}, {"kind": "demonstrated_knowledge_summary"}],
+            },
+            "turns": [
+                {"role": "user", "text": "It was the tractor, mostly.", "ts": "2026-08-11T09:00:00Z", "channel": "cli"},
+            ],
+            "rolling_summary": "The user has been describing the family farm.",
+            "extracted": {"facts": [], "entities": [], "candidate_ideas": [], "mirror_responses": []},
+        }
+
+    def test_assembly_is_byte_identical_across_two_calls(self):
+        session = self._sample_session()
+        blocks = {"profile": "Name: Dave.", "record": "[A9, 2026-01-01] The tractor story."}
+        first = conversation.assemble_context(session, blocks=blocks)
+        second = conversation.assemble_context(session, blocks=blocks)
+        self.assertEqual(first, second)
+        self.assertIn("Name: Dave.", first)
+        self.assertIn("The tractor story.", first)
+
+    def test_block_order_matches_interaction_yaml_load_order(self):
+        manifest = conversation.load_interaction_manifest()
+        load_order = manifest["load_order"].split("|")
+        self.assertEqual(load_order, [*conversation.ASSEMBLE_CONTEXT_BLOCK_ORDER, "turn_instructions"])
+
+    def test_oversized_block_is_truncated_to_its_budget(self):
+        session = self._sample_session()
+        oversized = "x" * 50_000
+        blocks = {"profile": oversized, "record": ""}
+        context = conversation.assemble_context(session, blocks=blocks)
+        self.assertNotIn(oversized, context)
+        manifest = conversation.load_interaction_manifest()
+        budget_chars = manifest["budget.profile"] * conversation.CHARS_PER_TOKEN
+        self.assertIn("x" * budget_chars, context)
+        self.assertNotIn("x" * (budget_chars + 1), context)
+
+
+class BuilderTests(unittest.TestCase):
+    """Subtest 4: each of the four builders on a fixture payload, plus CLI paths."""
+
+    def _sample_session(self) -> dict:
+        return {
+            "session_version": 1,
+            "session_id": "conv-20260811-090000-abc123",
+            "mode": "chat",
+            "channel": "cli",
+            "interaction_version": "1.0.0",
+            "status": "open",
+            "arc": {
+                "question_id": "A14b",
+                "opening": "Last time you mentioned the diesel smell.",
+                "intents": [{"kind": "scene_slot"}],
+            },
+            "turns": [
+                {"role": "user", "text": "It was the tractor, mostly.", "ts": "2026-08-11T09:00:00Z", "channel": "cli"},
+            ],
+            "rolling_summary": "",
+            "extracted": {"facts": [], "entities": [], "candidate_ideas": [], "mirror_responses": []},
+        }
+
+    def test_build_turn_prompt_fills_placeholders(self):
+        session = self._sample_session()
+        prompt = conversation.build_turn_prompt({"session": session, "blocks": {"profile": "", "record": ""}})
+        self.assertIn("chat", prompt)
+        self.assertIn("scene_slot", prompt)
+        self.assertIn("It was the tractor, mostly.", prompt)
+        self.assertNotIn("{mode}", prompt)
+        self.assertNotIn("{arc_intent}", prompt)
+        self.assertNotIn("{turn_position}", prompt)
+        self.assertNotIn("{previous_turn}", prompt)
+        self.assertNotIn("{length_cap}", prompt)
+
+    def test_build_router_prompt_contains_message_and_all_five_intents(self):
+        prompt = conversation.build_router_prompt({
+            "message": "what's the weather tomorrow?",
+            "session_open": False,
+            "pending_question_id": None,
+        })
+        self.assertIn("what's the weather tomorrow?", prompt)
+        for intent in ("answer", "new_story", "command", "continue_session", "out_of_scope"):
+            self.assertIn(intent, prompt)
+
+    def test_build_arc_prompt_embeds_question_and_gap_inputs(self):
+        prompt = conversation.build_arc_prompt({
+            "question": {"id": "A22", "text": "Who taught you to drive?", "category": "A", "focus": "Family"},
+            "record_summary": "Previously discussed the farm truck.",
+            "gap_inputs": ["timeline gap: 1985-1987", "sibling: A21"],
+        })
+        self.assertIn("A22", prompt)
+        self.assertIn("Who taught you to drive?", prompt)
+        self.assertIn("Previously discussed the farm truck.", prompt)
+        self.assertIn("timeline gap: 1985-1987", prompt)
+
+    def test_build_closing_prompt_reflects_deposit_framing_off_by_default(self):
+        session = self._sample_session()
+        prompt = conversation.build_closing_prompt({"session": session})
+        self.assertIn("OFF", prompt)
+        self.assertIn("takeaway", prompt.lower())
+
+    def test_build_closing_prompt_reflects_deposit_framing_when_on(self):
+        session = self._sample_session()
+        on_manifest = dict(conversation.load_interaction_manifest())
+        on_manifest["knob.deposit_framing"] = "on"
+        with mock.patch.object(conversation, "load_interaction_manifest", return_value=on_manifest):
+            prompt = conversation.build_closing_prompt({"session": session})
+        self.assertIn("ON", prompt)
+
+    # ---- CLI paths (subprocess, same style as tests/test_answer_ack.py) ----
+
+    def _run_cli(self, subcommand: str, stdin_text: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SYSTEM / "conversation.py"), subcommand],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_turn_prompt_cli_valid_payload_exits_0(self):
+        payload = {"session": self._sample_session()}
+        result = self._run_cli("turn-prompt", json.dumps(payload))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertIn("chat", result.stdout)
+
+    def test_turn_prompt_cli_empty_stdin_exits_1_one_line_stderr(self):
+        result = self._run_cli("turn-prompt", "")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(len(result.stderr.strip().splitlines()), 1)
+
+    def test_router_prompt_cli_missing_field_exits_1(self):
+        result = self._run_cli("router-prompt", json.dumps({"message": "hi"}))
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+
+    def test_arc_prompt_cli_invalid_json_exits_1(self):
+        result = self._run_cli("arc-prompt", "{not json")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+
+    def test_closing_prompt_cli_valid_payload_exits_0(self):
+        payload = {"session": self._sample_session()}
+        result = self._run_cli("closing-prompt", json.dumps(payload))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("takeaway", result.stdout.lower())
+
+
+class LintTests(unittest.TestCase):
+    """Subtest 5: per lint id, at least one flagged and one clean fixture."""
+
+    def test_one_question_per_turn_flags_two_questions(self):
+        findings = conversation_lints.lint_turn("Did you like it? What year was that?")
+        self.assertTrue(any(f["lint"] == "one_question_per_turn" for f in findings))
+
+    def test_one_question_per_turn_clean_on_a_single_question(self):
+        findings = conversation_lints.lint_turn("What comes to mind first?")
+        self.assertFalse(any(f["lint"] == "one_question_per_turn" for f in findings))
+
+    def test_banned_phrases_flags_configured_phrase(self):
+        findings = conversation_lints.lint_turn("That must have been so hard.")
+        self.assertTrue(any(f["lint"] == "banned_phrases" for f in findings))
+
+    def test_banned_phrases_clean_without_any_phrase(self):
+        findings = conversation_lints.lint_turn("Thank you for telling me that.")
+        self.assertFalse(any(f["lint"] == "banned_phrases" for f in findings))
+
+    def test_question_grammar_audit_flags_closed_question(self):
+        findings = conversation_lints.lint_turn("Did you like it?")
+        self.assertTrue(any(
+            f["lint"] == "question_grammar_audit" and "closed" in f["detail"] for f in findings
+        ))
+
+    def test_question_grammar_audit_flags_option_posing(self):
+        findings = conversation_lints.lint_turn("Was it the red one or the blue one?")
+        self.assertTrue(any(
+            f["lint"] == "question_grammar_audit" and "option" in f["detail"] for f in findings
+        ))
+
+    def test_question_grammar_audit_clean_on_a_ted_question(self):
+        findings = conversation_lints.lint_turn("Tell me what happened next.")
+        self.assertFalse(any(f["lint"] == "question_grammar_audit" for f in findings))
+
+    def test_length_caps_flags_an_oversized_turn(self):
+        findings = conversation_lints.lint_turn("x" * 2000)
+        self.assertTrue(any(f["lint"] == "length_caps" for f in findings))
+
+    def test_length_caps_clean_under_the_cap(self):
+        findings = conversation_lints.lint_turn("A short warm reply.")
+        self.assertFalse(any(f["lint"] == "length_caps" for f in findings))
+
+    def test_receipt_before_question_flags_opening_with_a_question(self):
+        findings = conversation_lints.lint_turn(
+            "What happened next?", is_reply_to_substantive=True
+        )
+        self.assertTrue(any(f["lint"] == "receipt_before_question" for f in findings))
+
+    def test_receipt_before_question_clean_when_receipt_precedes(self):
+        findings = conversation_lints.lint_turn(
+            "That tractor story really landed. What happened next?",
+            is_reply_to_substantive=True,
+        )
+        self.assertFalse(any(f["lint"] == "receipt_before_question" for f in findings))
+
+    def test_receipt_before_question_not_checked_when_not_substantive_reply(self):
+        findings = conversation_lints.lint_turn(
+            "What happened next?", is_reply_to_substantive=False
+        )
+        self.assertFalse(any(f["lint"] == "receipt_before_question" for f in findings))
+
+    def test_year_question_detector_flags_what_year(self):
+        findings = conversation_lints.lint_turn("What year did you move?")
+        self.assertTrue(any(f["lint"] == "year_question_detector" for f in findings))
+
+    def test_year_question_detector_clean_without_year_phrasing(self):
+        findings = conversation_lints.lint_turn("When did you move?")
+        self.assertFalse(any(f["lint"] == "year_question_detector" for f in findings))
+
+    def test_correct_payout_turn_has_zero_findings(self):
+        text = 'The smell of diesel really landed for me. What do you remember about "the old farmhouse" now?'
+        findings = conversation_lints.lint_turn(text, is_reply_to_substantive=True)
+        self.assertEqual(findings, [])
+
+    def test_echoed_quoted_question_does_not_count_toward_one_question_per_turn(self):
+        text = 'You once asked me, "was it hard?", and I never really answered. What comes to mind now?'
+        findings = conversation_lints.lint_turn(text, is_reply_to_substantive=True)
+        self.assertFalse(any(f["lint"] == "one_question_per_turn" for f in findings))
+
+    def test_lint_transcript_maps_over_lifehug_turns_only(self):
+        turns = [
+            {"role": "user", "text": "It was a long story about the farm and the diesel smell that day."},
+            {"role": "lifehug", "text": "Did you like it?"},
+            {"role": "user", "text": "no"},
+            {"role": "lifehug", "text": "Thanks for sharing that."},
+        ]
+        findings = conversation_lints.lint_transcript(turns)
+        self.assertTrue(any(f["turn_index"] == 1 and f["lint"] == "question_grammar_audit" for f in findings))
+        self.assertFalse(any(f["turn_index"] == 3 for f in findings))
+
+    def test_lints_config_loads_the_pinned_cap(self):
+        config = conversation_lints.load_lints_config()
+        self.assertEqual(config["cap.turn_chars"], 1200)
+        self.assertIn("that must have been", config["banned_phrases"])
+
+    # ---- CLI path ----
+
+    def test_lint_cli_prints_json_lines_and_always_exits_0(self):
+        result = subprocess.run(
+            [sys.executable, str(SYSTEM / "conversation_lints.py"), "--reply-to-substantive"],
+            input="That must have been so hard. What year was that? Or was it later?",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        self.assertTrue(lines)
+        findings = [json.loads(line) for line in lines]
+        lint_ids = {f["lint"] for f in findings}
+        self.assertIn("banned_phrases", lint_ids)
+        self.assertIn("year_question_detector", lint_ids)
+
+    def test_lint_cli_empty_stdin_exits_0_with_no_findings(self):
+        result = subprocess.run(
+            [sys.executable, str(SYSTEM / "conversation_lints.py")],
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+
+class NoBehaviorChangeGuardTests(unittest.TestCase):
+    """Subtest 6: no module under system/ other than lifehug.py and the two
+    new modules references a `conversation` import — proves this PR is
+    reachable only through the new conversation-* subcommands and direct
+    imports of the new modules themselves.
+    """
+
+    def test_no_other_module_imports_conversation_or_conversation_lints(self):
+        pattern = re.compile(r'^\s*(?:from|import)\s+conversation(?:_lints)?\b', re.MULTILINE)
+        exempt = {"lifehug.py", "conversation.py", "conversation_lints.py"}
+        offenders = []
+        for path in sorted(SYSTEM.glob("*.py")):
+            if path.name in exempt:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if pattern.search(text):
+                offenders.append(path.name)
+        self.assertEqual(offenders, [])
+
+    def test_lifehug_py_only_references_the_new_modules_as_dispatch_strings(self):
+        text = (SYSTEM / "lifehug.py").read_text(encoding="utf-8")
+        self.assertNotRegex(text, r'^\s*(?:from|import)\s+conversation(?:_lints)?\b')
+        self.assertIn('"conversation.py"', text)
+        self.assertIn('"conversation_lints.py"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v150_conversation_store.py
+++ b/tests/test_v150_conversation_store.py
@@ -570,5 +570,27 @@ class NoBehaviorChangeGuardTests(unittest.TestCase):
         self.assertIn('"conversation_lints.py"', text)
 
 
+
+
+class BuilderSlotRegressionTests(unittest.TestCase):
+    """No builder may emit an unfilled {slot} from a definition file (the
+    fixture-vs-real-file seam defect caught at the #126/#127 rebase)."""
+
+    def test_turn_prompt_has_no_unfilled_slots(self):
+        import re
+        session = BuilderTests()._sample_session()
+        session["turns"] = [{"role": "user", "text": "we drove the blue truck", "ts": "2026-08-11T00:00:00Z", "channel": "telegram"}]
+        prompt = conversation.build_turn_prompt({"session": session})
+        leftovers = re.findall(r"\{[a-z_]+\}", prompt)
+        allowed = {"{placeholder}"}  # the file's own meta-sentence about slots
+        self.assertFalse([m for m in leftovers if m not in allowed], leftovers)
+
+    def test_router_and_arc_prompts_embed_inputs(self):
+        rp = conversation.build_router_prompt({"message": "slot-guard probe", "session_open": True})
+        self.assertIn("slot-guard probe", rp)
+        ap = conversation.build_arc_prompt({"question": {"id": "Z9", "text": "probe?", "category": "A", "focus": "my-life"}, "record_summary": "rs", "gap_inputs": []})
+        self.assertIn("Z9", ap)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Contract stage — implementation to follow per docs/BUILDING.md.**

Closes #115 on merge of the implemented PR.

Contract: `docs/pr-specs/115-conversation-store.md` — session documents (`state/conversations/`), vault-contract v2 registrations (`arc_cards`, `conversations`, `mirror_responses` + `interactions` framework path; the digest-recompute recipe in the contract is verified against the live contract), `system/conversation.py` pure builders, `system/conversation_lints.py`, and `lifehug.py conversation-*` subcommands. No behavior change to any live flow.

Notes:
- Depends on #114's scaffold (reads `interaction.yaml` + `evals/lints.yaml` from that branch's tree) — implement after #114 merges, or rebase onto it.
- The `version bump present` CI context is expected red at contract stage — the implementation commit bumps `system/version.json` (expected v151; re-read at rebase time).
- ADR: none new — ADR 0002 (from #114) records the planned vault-contract additions this PR lands.

🤖 Generated with Claude Fable 5 via Claude Code

Claude-Session: https://claude.ai/code/session_0116gPPwxxMvJ1CdyqwjJQFc