### PR TITLE
v150: fix file_answer_bg.sh filing invariants (main is red)

### DIFF
--- a/system/file_answer_bg.sh
+++ b/system/file_answer_bg.sh
@@ -51,34 +51,6 @@ send_msg() {
   printf '%s' "$1" | python3 "$SCRIPT_DIR/lifehug.py" notify || true
 }
 
-safe_autocommit() {
-  local label="${1:-File answer}"
-  local paths=()
-  while IFS= read -r path; do
-    [[ -n "$path" ]] && paths+=("$path")
-  done < <(python3 "$SCRIPT_DIR/vault_paths.py" git-paths --vault-root "$WORKSPACE")
-  local existing=()
-  for path in "${paths[@]}"; do
-    [[ -e "$path" ]] && existing+=("$path")
-  done
-  [[ ${#existing[@]} -eq 0 ]] && return 0
-  set +e
-  local git_out
-  git_out=$(
-    git add -- "${existing[@]}" &&
-    { git diff --cached --quiet ||
-      { git commit -m "${label} $(date +%Y-%m-%d)" &&
-        git pull --rebase --autostash &&
-        git push; }; } 2>&1
-  )
-  local git_status=$?
-  set -e
-  if [[ "$git_status" -ne 0 ]]; then
-    echo "warn: git autocommit failed" >&2
-    echo "$git_out" >&2
-  fi
-  return 0
-}
 
 # The outer invocation streams stdin directly into the queue; it never writes a
 # plaintext answer to /tmp. Only the lease-bound worker re-entry needs a local
@@ -130,6 +102,33 @@ record_learning_failure(
 PY
   fi
 fi
+
+safe_autocommit() {
+  local label="${1:-File answer}"
+  local paths=()
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && paths+=("$path")
+  done < <(python3 "$SCRIPT_DIR/vault_paths.py" git-paths --vault-root "$WORKSPACE")
+  local existing=()
+  for path in "${paths[@]}"; do
+    [[ -e "$path" ]] && existing+=("$path")
+  done
+  [[ ${#existing[@]} -eq 0 ]] && return 0
+  local git_out
+  git_out=$(
+    git add -- "${existing[@]}" &&
+    { git diff --cached --quiet ||
+      { git commit -m "${label} $(date +%Y-%m-%d)" &&
+        git pull --rebase --autostash &&
+        git push; }; } 2>&1
+  )
+  local git_status=$?
+  if [[ "$git_status" -ne 0 ]]; then
+    echo "warn: git autocommit failed" >&2
+    echo "$git_out" >&2
+  fi
+  return 0
+}
 
 # Run the actual filing — skip wiki compile (handled by hourly cron)
 OUT=$(python3 "$SCRIPT_DIR/lifehug.py" process-answer "$QID" --no-compile-wiki "$@" < "$BODY" 2>&1)

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 149,
+  "version": 150,
   "released": "2026-08-11",
-  "changelog": "v149: file_answer_bg.sh now auto-commits and pushes after successful filing (safe_autocommit pattern from weekly/monthly scripts). ingest-story gains --commit flag for the same behavior. Answers hit GitHub immediately instead of waiting for the next maintenance run.",
+  "changelog": "Fix file_answer_bg.sh filing invariants: remove set -e toggle (a failed pull could abort filing after the first autocommit), restore pull-position ordering (v117 contract).",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",


### PR DESCRIPTION
Main's CI went red at the v149 direct push: the new safe_autocommit() in file_answer_bg.sh broke two v117 filing-contract tests — its internal pull became the file's first pull occurrence (ordering contract), and its set -e toggle armed errexit for the rest of the script, meaning a failed pull after the first autocommit would drop an answer (the exact failure the contract guards).

Fix: remove the toggle (no-op in a set -u script), relocate the function below the guarded pull. test_v117_multi_writer: 16/16 green. bash -n clean. Version 149→150.

Unblocks the conversation-build merge train (#126/#127 inherit main's red).

🤖 Generated with Claude Fable 5 via Claude Code
Claude-Session: https://claude.ai/code/session_0116gPPwxxMvJ1CdyqwjJQFc