### PR TITLE
v161: day-rollover session close (Chats-per-Focus design §D, #136)

### DIFF
--- a/docs/pr-specs/136-day-rollover-close.md
+++ b/docs/pr-specs/136-day-rollover-close.md
@@ -1,0 +1,220 @@
+# Contract: day-rollover-close (issue #136)
+
+PR 1 of the **Chats-per-Focus reshape** (owner ideation 2026-08-12, ratified
+direction) — the OSS-first day-rollover close, written here as the
+platform's parity spec. Design scope: §D (Day-scoped session policy +
+transitions) + the relevant §G item 1 text of the Chats-per-Focus design
+draft. This document is self-contained; the platform-side sibling PR (design
+§G item 2) transports the same shell step verbatim into `workflow.py`.
+
+## Context (from the design)
+
+Owner ideation (2026-08-12, ratified direction): the product's surfaces
+reorganize around the chat metaphor the conversation build made real. Three
+unifying moves:
+
+1. **The day owns the surface** — today's chat lives on the Today page until
+   the daily loop replaces it. No invented timers (2h idle / 15-min sweep
+   demote to janitor duty). Endings are conversational events (exit door,
+   transition), never silent timeouts.
+2. **The Focus owns the thread** — a Focus is a contact. James is a thread;
+   Dottie is a thread; the Seattle years are a thread. A new question about
+   James RESUMES the James thread. The `/answers` page becomes **Chats**:
+   scroll past threads, click one, read the whole history — including
+   pre-conversation-era answers rendered as chat turns.
+3. **The user owns transitions** — "Something else" tab starts an off-topic
+   conversation; starting a new conversation ends the previous one (its
+   takeaway lands in-thread, visible on return — the peak-end payout gets
+   witnessed because closes happen at moments the user caused).
+
+Owner's explicit ask: "I can go back and scroll through the chats, click on
+them, and open up a chat for a past answer."
+
+Principles applied (from the interaction doctrine): conversation is the
+product's voice, the archive whispers; prove memory ambiently; autonomy-by-
+default; honest surfaces, no unwitnessed endings; one owner of identity — the
+session owns the box, the Focus owns the thread, **the day owns the
+surface**.
+
+This PR is scoped to the last of those: the day-scoped session policy that
+makes "the day owns the surface" true in the delivery flow, so downstream
+UI work (the sibling platform PRs) can build the Chats page against a close
+lifecycle that is event-driven, not timer-driven.
+
+## Design §D — Day-scoped session policy + transitions
+
+- **Closes become events, never timers**: (1) user transition — Rest, or
+  starting a new conversation while one is open (previous closes with
+  takeaway appended in-thread); (2) **day rollover** — the daily delivery
+  flow closes the vault's open sessions (reason `day_rollover`, takeaway
+  appended, visible later in the thread) BEFORE minting the day's question.
+  OSS-first per parity: the shell (`daily_question.sh`) gains the close step
+  as the spec; the platform transports it in the delivery workflow
+  (`workflow.py`) exactly as cadence steps are transported today.
+- **The 15-min sweep demotes to janitor**: policy constant change only — it
+  closes sessions idle > 36h (safety net for abandoned conversation-mode
+  sessions), no user-facing role. Terraform/scheduler untouched.
+- `interaction.yaml` knobs updated (OSS): chat/conversation idle knobs
+  raised to day-scale with a doc note that the day rollover + user
+  transitions are the real lifecycle.
+- Dots/pending semantics unchanged (dots only between send and reply —
+  decided previously).
+
+## Design §G item 1 — this PR's work item, verbatim
+
+> **PR 1 — OSS: day-rollover close (the parity spec)** [Sonnet]:
+> `daily_question.sh` gains a pre-question step closing open sessions via
+> the existing `conversation-close --expired` machinery generalized to
+> `--day-rollover` (closes ALL open sessions with reason `day_rollover` +
+> takeaway); `interaction.yaml` knob updates; version bump; the shell step
+> is written as the platform's transport spec per doctrine.
+
+Sequencing note (from the design's §G closing paragraph): "PR 1 → (release +
+pin bump rides the next routine bump — the day-rollover transport in PR 2 is
+gated on the pin carrying PR 1; the body reversal + chats UI are NOT
+pin-gated and can land first) → PR 2 → PR 3."
+
+## Binding facts (origin/main at implementation time = cb4dfb2, v160)
+
+Re-verify at implementation time if this contract is ever replayed.
+
+- The merged `conversation-close` machinery lives across three layers, all
+  three touched by this contract:
+  - `system/conversation.py` — `VALID_CLOSE_REASONS` (currently
+    `{"done", "idle_timeout", "exit_taken"}`), the store's `close_session`.
+  - `system/conversation_delivery.py` — the engine: `is_idle_expired`/
+    `idle_timeout_minutes` (continuation checks, e.g.
+    `find_open_session_for_channel`), `find_expired_open_sessions`/
+    `close_expired_sessions` (the `--expired` sweep's discovery/close pair,
+    also run inline at the top of every post-answer turn), `close_session_now`
+    (the >=2-user-turns takeaway rule, silent below), and the module's own
+    `close` CLI subcommand (`--expired`/`--reason`).
+  - `system/lifehug.py` — the operational CLI wrapper
+    (`conversation-close`, in `DIRECT_MUTATION_COMMANDS`): `--expired`
+    branches to `_enqueue_expired_conversation_closes`, which uses
+    `conversation_delivery.find_expired_open_sessions` for AI-free discovery
+    and enqueues one durable `conversation-close` job per session
+    (`jobs.py`, identity `conversation-close:<session_id>` dedupes retries),
+    waiting via `_queue_and_wait`/`wait_for_job_embedded_safe` (embedded-safe:
+    drains inline when called from inside an already-running job, so this is
+    safe to call from `daily_question.sh`, which itself runs inside the
+    `daily` job).
+  - `system/jobs.py` — `_build_conversation_close` mirrors
+    `VALID_CLOSE_REASONS` in a hardcoded set (documented reason: it can't
+    import `conversation.py` — see `_SESSION_ID_RE`'s comment) and must stay
+    in lockstep.
+- `system/compile_and_commit.sh` is the existing precedent for this exact
+  shape: it calls `lifehug.py conversation-close --expired --vault-root
+  "$WORKSPACE"` as a pre-step, non-fatal, before its own sentinel-gated
+  compile. This PR's `daily_question.sh` step mirrors that precedent with
+  `--day-rollover` in place of `--expired`.
+- `interactions/conversation/interaction.yaml` is the flat-scalar-only
+  config (`lifehug_core._parse_simple_yaml`; no nesting, no lists — comments
+  after `#` on any line, blank lines and full-line comments skipped).
+  `conversation.load_interaction_manifest` casts every `knob.*`/`budget.*`
+  value to numeric. Current lifecycle knobs: `chat_idle_timeout_minutes:
+  120`, `conversation_idle_timeout_minutes: 30` (owner-accepted defaults,
+  2026-08-11).
+- Test seams: `tests/test_conversation_delivery.py` (`EngineTestCase`,
+  in-process, injected collaborators, synthetic temp vault via
+  `tempdirs.root_parent_tmp`) already asserts the pre-change knob values
+  (`test_idle_timeout_knobs_come_from_interaction_yaml`) and a 5-hour idle
+  sweep close (`test_idle_timeout_files_partial_chat_silently`) — both need
+  updating to the new day-scale/janitor semantics, not just extending.
+  `tests/test_conversation_close.py` (`VaultSubprocessTestCase`, real
+  subprocess against a synthetic on-disk vault with a real local git repo)
+  has the CLI-level enqueue precedent
+  (`test_sweep_enqueues_only_idle_expired_open_sessions_with_stable_identity`).
+
+## Deliverables
+
+1. **`system/daily_question.sh`**: a pre-question step, placed after the
+   wiki-compile step and before the pass-transition/`ask.py` pick, that
+   calls `python3 "$SCRIPT_DIR/lifehug.py" conversation-close
+   --day-rollover` (non-fatal, `record_learning_failure` on nonzero exit —
+   same idiom as the compile step immediately above it). This exact
+   invocation (flag, placement) is THE PLATFORM'S TRANSPORT SPEC — the
+   sibling platform PR mirrors it verbatim in `workflow.py`. The
+   `LIFEHUG_DAILY_DRY_RUN=1` preview branch gains one added line
+   (`conversation-close --day-rollover --dry-run`, a pure read) — every
+   other line in that branch is unchanged.
+2. **`conversation-close --day-rollover`** (generalizes the merged
+   machinery, all three layers):
+   - `conversation.VALID_CLOSE_REASONS` gains `"day_rollover"`; `jobs.py`'s
+     mirrored validation set follows.
+   - `conversation_delivery.py` gains pure discovery
+     (`find_open_sessions` — every OPEN session id, no idle filter) and a
+     synchronous engine entry point (`close_all_open_sessions` — mirrors
+     `close_expired_sessions` minus the janitor filter, reason
+     `"day_rollover"`); its own `close` CLI gains `--day-rollover`.
+   - `lifehug.py`'s `conversation-close` CLI gains `--day-rollover` (+
+     `--dry-run`, meaningful only alongside it) and
+     `_enqueue_day_rollover_conversation_closes`, the enqueue-durable-job
+     twin of `_enqueue_expired_conversation_closes` — same per-session job,
+     same identity (`conversation-close:<session_id>`, deliberately shared
+     dedup key with the janitor sweep), reason `"day_rollover"` instead of
+     `"idle_timeout"`.
+   - The takeaway criterion is NOT re-decided: `close_session_now`'s
+     existing >=2-user-turns rule governs every reason equally — a
+     day-rollover close earns a takeaway (appended in-thread, per design
+     §D) under the same rule an idle-timeout or explicit close does; fewer
+     turns close silently.
+3. **`--expired` re-reads a new janitor knob**: `is_janitor_expired`
+   (mode-independent, `knob.janitor_idle_hours`, default 36) replaces
+   `is_idle_expired` inside `find_expired_open_sessions`/
+   `close_expired_sessions` only — `is_idle_expired`/`idle_timeout_minutes`
+   stay exactly as they are for continuation checks (`find_open_session_for_channel`
+   and the inline per-turn sweep call site are unaffected by the rename;
+   only the *values* they read change, per point 4). The `--expired` flag
+   itself, its CLI surface, and its job-enqueue shape are unchanged — only
+   its threshold source changes, per design §D ("The 15-min sweep demotes
+   to janitor").
+4. **`interaction.yaml`**: `chat_idle_timeout_minutes` and
+   `conversation_idle_timeout_minutes` raised to `1440` (day-scale); new
+   `knob.janitor_idle_hours: 36`; a doc comment recording that day rollover
+   + user transitions are the real lifecycle and the sweep is a janitor.
+   Flat scalar keys only, per the parser's documented subset — no nesting,
+   no lists.
+5. **Tests** (scoped unittest, synthetic vaults only):
+   - Day rollover closes every open session regardless of idle age, and is
+     idempotent (a second pass closes nothing).
+   - The takeaway rule (>=2 user turns) is honored identically under
+     `day_rollover` as under any other reason.
+   - `--expired`/the janitor sweep reads `knob.janitor_idle_hours` (a
+     5-hour-idle session — which used to trip the old 120-minute chat
+     knob — must NOT close under the new 36h janitor; a 37-hour-idle
+     session must).
+   - The existing knob-value test
+     (`test_idle_timeout_knobs_come_from_interaction_yaml`) updated to the
+     new 1440-minute values.
+   - `daily_question.sh`'s dry-run preview gains exactly the one new line
+     (text-level assertion, matching this repo's established convention for
+     shell "parity SPEC" tests — see `tests/test_arc_planner.py`'s
+     `CommandSurfaceTests`).
+6. **Version bump**: `system/version.json`, next free integer, changelog
+   entry naming this issue.
+
+## Out of scope (sibling PRs)
+
+- The platform transport of this shell step into `workflow.py` (design §G
+  item 2, platform PR 2) — gated on the OSS pin carrying this PR.
+- The body-reversal endpoint, `focus_context` fold, and janitor-constant
+  transport on the platform side (also PR 2).
+- The Chats list/thread-view UI (design §B/§C, platform PR 3).
+- The Today box's `[Today] [＋]` tab strip (design §E) — a platform/web
+  concern, not this repo's.
+
+## Launch-and-verify
+
+```bash
+cd system
+python3 -m unittest tests.test_conversation_delivery tests.test_conversation_close -v
+python3 ../scripts/ci/check_framework_files.py
+python3 ../scripts/ci/check_version_bump.py --base <base-sha> --head <head-sha>
+bash -n daily_question.sh
+LIFEHUG_DAILY_DRY_RUN=1 LIFEHUG_VAULT_ROOT=<synthetic-vault> bash daily_question.sh
+```
+
+The dry-run transcript's shape is unchanged except for one new
+`conversation-close --day-rollover --dry-run` line between the "would use
+configured Telegram delivery target" line and the `ask.py --dry-run` output.

--- a/interactions/conversation/interaction.yaml
+++ b/interactions/conversation/interaction.yaml
@@ -10,11 +10,21 @@ load_order: identity|behavior|examples|profile|record|session|turn_instructions
 role.router: haiku-class
 role.worker: sonnet-class
 role.planner: sonnet-class
-# lifecycle knobs (owner-accepted defaults, 2026-08-11)
+# lifecycle knobs (owner-accepted defaults, 2026-08-11; idle knobs raised to
+# day-scale 2026-08-12 per the Chats-per-Focus design §D: day rollover
+# (daily_question.sh's --day-rollover pre-question step) plus user
+# transitions (Rest / starting a new conversation) are the real close
+# lifecycle now — chat_idle_timeout_minutes/conversation_idle_timeout_minutes
+# below are only a generous "still counts as the current open session"
+# ceiling for continuation checks, never a UX trigger. The idle SWEEP
+# ("--expired") no longer reads these: it is a mode-independent 36h-class
+# janitor for abandoned conversation-mode sessions, knob.janitor_idle_hours,
+# with no user-facing role.
 knob.chat_target_exchanges: 3
-knob.chat_idle_timeout_minutes: 120
-knob.conversation_idle_timeout_minutes: 30
+knob.chat_idle_timeout_minutes: 1440
+knob.conversation_idle_timeout_minutes: 1440
 knob.conversation_turn_cap_exchanges: 25
+knob.janitor_idle_hours: 36
 knob.deposit_framing: off
 knob.grief_deferral_days: 60
 knob.router_confidence_threshold: 0.7

--- a/system/conversation.py
+++ b/system/conversation.py
@@ -95,7 +95,7 @@ from vault_paths import atomic_write_vault_text, read_vault_text, vault_data_pat
 SESSION_VERSION = 1
 VALID_MODES = frozenset({"chat", "conversation"})
 VALID_CHANNELS = frozenset({"telegram", "web", "cli"})
-VALID_CLOSE_REASONS = frozenset({"done", "idle_timeout", "exit_taken"})
+VALID_CLOSE_REASONS = frozenset({"done", "idle_timeout", "exit_taken", "day_rollover"})
 VALID_ROLES = frozenset({"user", "lifehug"})
 SESSION_ID_RE = re.compile(r"^conv-\d{8}-\d{6}-[0-9a-f]{6}$")
 

--- a/system/conversation_delivery.py
+++ b/system/conversation_delivery.py
@@ -1452,6 +1452,23 @@ def is_idle_expired(session: dict, *, manifest: dict, now: datetime | None = Non
     return reference - moment >= timedelta(minutes=idle_timeout_minutes(session, manifest))
 
 
+def is_janitor_expired(session: dict, *, manifest: dict, now: datetime | None = None) -> bool:
+    """Mode-independent safety net for abandoned conversation-mode sessions
+    (design §D, Chats-per-Focus, 2026-08-12): day rollover + user
+    transitions are the real close lifecycle now, not a timer — this sweep
+    is a 36h-class janitor, no user-facing role. ``knob.janitor_idle_hours``
+    replaces the old per-mode idle knobs for ``--expired``/the inline
+    per-turn sweep; ``chat_idle_timeout_minutes``/``conversation_idle_timeout_minutes``
+    (``is_idle_expired`` above) stay in force for "is this open session still
+    current" continuation checks, raised to day-scale."""
+    moment = _last_activity(session)
+    if moment is None:
+        return False
+    reference = now or _now()
+    hours = _knob(manifest, "knob.janitor_idle_hours", 36)
+    return reference - moment >= timedelta(hours=hours)
+
+
 def _filed_question_ids(session: dict) -> tuple[str, ...]:
     filed: list[str] = []
     for turn in session.get("turns") or []:
@@ -1892,7 +1909,7 @@ def find_expired_open_sessions(
     manifest: dict | None = None,
     now: datetime | None = None,
 ) -> list[str]:
-    """Session ids for every OPEN session past its idle timeout.
+    """Session ids for every OPEN session past the janitor threshold.
 
     Pure discovery — deterministic, AI-free, no closing, no send: distinct
     from ``close_expired_sessions`` (which actually closes each one,
@@ -1901,6 +1918,12 @@ def find_expired_open_sessions(
     what to enqueue as durable jobs, keeping the discovery step itself free
     of AI calls; ``close_expired_sessions`` stays exactly as PR3 shipped it
     (the inline per-turn sweep's synchronous close, unchanged).
+
+    "Expired" is the janitor's 36h-class ``knob.janitor_idle_hours``
+    threshold as of design §D (Chats-per-Focus, 2026-08-12) — day rollover
+    and user transitions are the real close lifecycle now; this sweep is
+    only the safety net for abandoned conversation-mode sessions, no longer
+    a user-facing timer.
     """
     vault_root = vault_root if vault_root is not None else VAULT_ROOT
     manifest = manifest if manifest is not None else _manifest()
@@ -1914,7 +1937,7 @@ def find_expired_open_sessions(
             session = conversation.load_session(session_id, vault_root=vault_root)
         except (OSError, ValueError):
             continue
-        if is_idle_expired(session, manifest=manifest, now=reference):
+        if is_janitor_expired(session, manifest=manifest, now=reference):
             ids.append(str(session_id))
     return ids
 
@@ -1931,11 +1954,15 @@ def close_expired_sessions(
     status_resolver: Callable[..., object] | None = None,
     prompt_builder: Callable[[dict], str] | None = None,
 ) -> list[CloseOutcome]:
-    """Lazy sweep: close every open session past its idle timeout.
+    """Lazy sweep: close every open session past the janitor threshold.
 
     No daemon and no cron change in this PR — the sweep runs at the top of
     every post-answer turn and on demand via ``conversation-close --expired``
-    (the same subcommand #119's jobs builder enqueues).
+    (the same subcommand #119's jobs builder enqueues). Design §D
+    (2026-08-12) demotes this from a user-facing idle timer to a 36h-class
+    janitor (``is_janitor_expired`` / ``knob.janitor_idle_hours``) — day
+    rollover (``close_all_open_sessions`` below) and user transitions are
+    the real close lifecycle.
     """
     state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
     vault_root = vault_root if vault_root is not None else VAULT_ROOT
@@ -1951,7 +1978,7 @@ def close_expired_sessions(
             session = conversation.load_session(session_id, vault_root=vault_root)
         except (OSError, ValueError):
             continue
-        if not is_idle_expired(session, manifest=manifest, now=reference):
+        if not is_janitor_expired(session, manifest=manifest, now=reference):
             continue
         try:
             outcomes.append(
@@ -1971,6 +1998,75 @@ def close_expired_sessions(
             )
         except Exception:  # noqa: BLE001 — one bad session never stalls the sweep
             _diagnostic("idle_sweep", "close_failed", str(session_id))
+    return outcomes
+
+
+def find_open_sessions(*, vault_root: str | Path | None = None) -> list[str]:
+    """Every OPEN session id, regardless of idle age.
+
+    Day rollover's pure discovery (design §D, Chats-per-Focus, 2026-08-12):
+    the day owns the surface, not a timer — a session opened seconds ago
+    still closes at rollover. Deterministic, AI-free, no closing, no send;
+    distinct from ``find_expired_open_sessions`` (janitor-filtered).
+    ``lifehug.py``'s ``conversation-close --day-rollover`` uses THIS to
+    decide what to enqueue as durable jobs, mirroring how
+    ``find_expired_open_sessions`` feeds ``--expired``.
+    """
+    vault_root = vault_root if vault_root is not None else VAULT_ROOT
+    ids: list[str] = []
+    for summary in conversation.list_sessions(status="open", vault_root=vault_root):
+        session_id = summary.get("session_id")
+        if session_id:
+            ids.append(str(session_id))
+    return ids
+
+
+def close_all_open_sessions(
+    *,
+    vault_root: str | Path | None = None,
+    state_path: Path | None = None,
+    scores_path: Path | None = None,
+    candidates_path: Path | None = None,
+    ai_call: Callable[[str, str], str] | None = None,
+    telegram_send: Callable[[str], TelegramSendResult] | None = None,
+    status_resolver: Callable[..., object] | None = None,
+    prompt_builder: Callable[[dict], str] | None = None,
+) -> list[CloseOutcome]:
+    """Day rollover: close EVERY open session — no idle filter (design §D).
+
+    Mirrors ``close_expired_sessions`` exactly, minus the janitor filter;
+    the closing-takeaway criterion is unchanged (>=2 user turns earns a
+    takeaway, appended in-thread; fewer closes silently — ``close_session_now``'s
+    existing rule, not re-decided here). This is the synchronous engine
+    entry point for ``conversation-close --day-rollover``; ``lifehug.py``'s
+    CLI wrapper enqueues one durable job per session instead of calling this
+    directly, for operational parity with how ``--expired`` is transported
+    (``_enqueue_expired_conversation_closes``).
+    """
+    state_path = state_path if state_path is not None else DELIVERY_STATE_FILE
+    vault_root = vault_root if vault_root is not None else VAULT_ROOT
+    scores_path = scores_path if scores_path is not None else ANSWER_SCORES_FILE
+    manifest = _manifest()
+    outcomes: list[CloseOutcome] = []
+    for session_id in find_open_sessions(vault_root=vault_root):
+        try:
+            outcomes.append(
+                close_session_now(
+                    session_id,
+                    reason="day_rollover",
+                    state_path=state_path,
+                    vault_root=vault_root,
+                    scores_path=scores_path,
+                    candidates_path=candidates_path,
+                    ai_call=ai_call,
+                    telegram_send=telegram_send,
+                    status_resolver=status_resolver,
+                    prompt_builder=prompt_builder,
+                    manifest=manifest,
+                )
+            )
+        except Exception:  # noqa: BLE001 — one bad session never stalls rollover
+            _diagnostic("day_rollover", "close_failed", str(session_id))
     return outcomes
 
 
@@ -2073,6 +2169,17 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 
 def cmd_close(args: argparse.Namespace) -> int:
+    if args.day_rollover:
+        outcomes = close_all_open_sessions()
+        if not outcomes:
+            print("No open conversation sessions for day rollover.")
+            return 0
+        for outcome in outcomes:
+            print(
+                f"{outcome.session_id}: closed ({outcome.reason}; "
+                f"{'silent' if outcome.silent else 'takeaway sent'}; {outcome.detail})"
+            )
+        return 0
     if args.expired:
         outcomes = close_expired_sessions()
         if not outcomes:
@@ -2122,9 +2229,18 @@ def main() -> int:
     p.add_argument("--full", action="store_true", help="Also print turn text (private content)")
     p.set_defaults(func=cmd_status)
 
-    p = sub.add_parser("close", help="Close one session now, or sweep every expired one")
+    p = sub.add_parser(
+        "close", help="Close one session now, sweep the janitor, or roll over the day"
+    )
     p.add_argument("session_id", nargs="?")
-    p.add_argument("--expired", action="store_true", help="Close every idle-expired session")
+    p.add_argument(
+        "--expired", action="store_true",
+        help="Close every session past the janitor threshold (knob.janitor_idle_hours)",
+    )
+    p.add_argument(
+        "--day-rollover", action="store_true",
+        help="Close every open session regardless of idle age (design §D day rollover)",
+    )
     p.add_argument("--reason", default="done", choices=sorted(conversation.VALID_CLOSE_REASONS))
     p.set_defaults(func=cmd_close)
 

--- a/system/daily_question.sh
+++ b/system/daily_question.sh
@@ -85,6 +85,10 @@ arc_card_text() {
 
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "DRY RUN: would use configured Telegram delivery target"
+  # Day-rollover preview (design §D): one deterministic line, no mutation —
+  # mirrors the real pre-question step below (same --day-rollover flag),
+  # added with --dry-run so this preview stays a pure read.
+  python3 "$SCRIPT_DIR/lifehug.py" conversation-close --day-rollover --dry-run
   DRY_OUTPUT=$(python3 "$SCRIPT_DIR/ask.py" --dry-run)
   printf '%s\n' "$DRY_OUTPUT"
   DRY_QID=$(printf '%s\n' "$DRY_OUTPUT" | parse_question_id)
@@ -219,6 +223,26 @@ COMPILE_STATUS=$?
 set -e
 if [[ "$COMPILE_STATUS" -ne 0 ]]; then
   record_learning_failure "daily_question" "wiki_compile" "$COMPILE_STATUS" "$COMPILE_OUT"
+fi
+
+# Day-rollover pre-step (design §D, Chats-per-Focus, 2026-08-12): close
+# EVERY open conversation session — no idle filter, the day owns the
+# surface, not a timer — before minting today's question. Runs BEFORE the
+# pass-transition check and ask.py's pick so no session survives into a new
+# day's context. THE PLATFORM'S TRANSPORT SPEC: mirror this invocation
+# verbatim (same flag, same placement — after compile, before pick) in
+# workflow.py's delivery flow. Non-fatal, same idiom as the compile step
+# above: a rollover failure must never cost the author their daily question.
+set +e
+ROLLOVER_OUT=$(python3 "$SCRIPT_DIR/lifehug.py" conversation-close --day-rollover 2>&1)
+ROLLOVER_STATUS=$?
+set -e
+if [[ "$ROLLOVER_STATUS" -ne 0 ]]; then
+  echo "warn: day-rollover close failed (continuing)" >&2
+  echo "$ROLLOVER_OUT" >&2
+  record_learning_failure "daily_question" "day_rollover_close" "$ROLLOVER_STATUS" "$ROLLOVER_OUT"
+else
+  echo "$ROLLOVER_OUT"
 fi
 
 AWAITING=$(python3 - <<'PY'

--- a/system/jobs.py
+++ b/system/jobs.py
@@ -618,15 +618,20 @@ def _validated_file_answer_args(raw: object) -> list[str]:
 def _build_conversation_close(payload: dict) -> tuple[Invocation, ...]:
     """One durable close: PR3's close + #119's filing/compile/commit steps,
     all inside ``lifehug.py conversation-close <session_id>`` (never
-    ``--expired`` here — that flag is the deterministic sweep's own
-    discovery entry point, invoked directly, never enqueued as a job).
-    ``reason`` passes through to the close (contract §2a) — the idle-sweep
-    enqueues "idle_timeout"; default "done" covers any other producer."""
+    ``--expired``/``--day-rollover`` here — those flags are deterministic
+    sweeps' own discovery entry points, invoked directly, never enqueued as
+    a job themselves). ``reason`` passes through to the close (contract
+    §2a) — the janitor sweep enqueues "idle_timeout", the daily rollover
+    sweep enqueues "day_rollover" (design §D, Chats-per-Focus); default
+    "done" covers any other producer."""
     _expect_payload(payload, required={"session_id"}, optional={"reason"})
     reason = _optional_text(payload, "reason", maximum=32) or "done"
     # Mirrors conversation.VALID_CLOSE_REASONS — see _SESSION_ID_RE's comment
-    # above for why this can't just import conversation.py.
-    if reason not in {"done", "idle_timeout", "exit_taken"}:
+    # above for why this can't just import conversation.py. "day_rollover"
+    # added alongside the day-owns-the-surface close event (design §D,
+    # Chats-per-Focus) — the daily flow's --day-rollover sweep enqueues one
+    # of these per open session, exactly like --expired's "idle_timeout".
+    if reason not in {"done", "idle_timeout", "exit_taken", "day_rollover"}:
         raise ValueError("invalid close reason")
     return (_cli("conversation-close", _session_id(payload), "--reason", reason),)
 

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -1085,6 +1085,51 @@ def _enqueue_expired_conversation_closes() -> int:
     return 0 if all(ok for _sid, ok in outcomes) else 1
 
 
+def _enqueue_day_rollover_conversation_closes(*, dry_run: bool = False) -> int:
+    """Day rollover (design §D, Chats-per-Focus, 2026-08-12): close EVERY
+    open session, not just idle-expired ones — the day owns the surface, no
+    timer. Same enqueue-durable-job discovery/wait shape as
+    ``_enqueue_expired_conversation_closes`` above (deliberately mirrored:
+    ``daily_question.sh`` calls this pre-question, exactly as
+    ``compile_and_commit.sh`` calls the idle sweep pre-compile), reason
+    ``day_rollover`` instead of ``idle_timeout``. Shares the SAME job
+    identity (``conversation-close:<session_id>``) as the idle sweep — a
+    session that is both janitor-expired and rolled over only ever gets one
+    close job, deduped.
+
+    ``--dry-run`` (the daily script's ``LIFEHUG_DAILY_DRY_RUN`` preview)
+    lists what WOULD close without enqueuing or mutating anything —
+    deterministic, AI-free, one line regardless of vault state.
+    """
+    import conversation_delivery  # noqa: PLC0415
+
+    session_ids = conversation_delivery.find_open_sessions(vault_root=REPO_DIR)
+    if not session_ids:
+        print(
+            "DRY RUN: no open conversation sessions for day rollover."
+            if dry_run else
+            "No open conversation sessions for day rollover."
+        )
+        return 0
+    if dry_run:
+        print(
+            f"DRY RUN: day rollover would close {len(session_ids)} open "
+            f"session(s): {', '.join(session_ids)}"
+        )
+        return 0
+    outcomes: list[tuple[str, bool]] = []
+    for session_id in session_ids:
+        rc = _queue_and_wait(
+            "conversation-close",
+            {"session_id": session_id, "reason": "day_rollover"},
+            identity=f"conversation-close:{session_id}",
+        )
+        outcomes.append((session_id, rc == 0))
+    for session_id, ok in outcomes:
+        print(f"{session_id}: {'closed' if ok else 'close job failed'}")
+    return 0 if all(ok for _sid, ok in outcomes) else 1
+
+
 def cmd_conversation_close(args: argparse.Namespace) -> int:
     # v153 (issue #116): the same subcommand now closes for real — closing
     # takeaway when the session earned one, silence when it did not.
@@ -1093,6 +1138,10 @@ def cmd_conversation_close(args: argparse.Namespace) -> int:
     # engagement timing), one wiki compile, one commit. --expired stays
     # #116's idle-sweep entry point, upgraded to ENQUEUE a durable job per
     # session (deterministic, AI-free discovery) rather than closing inline.
+    # --day-rollover (design §D, 2026-08-12): the daily flow's pre-question
+    # step, same enqueue shape as --expired, no idle filter.
+    if args.day_rollover:
+        return _enqueue_day_rollover_conversation_closes(dry_run=args.dry_run)
     if args.expired:
         return _enqueue_expired_conversation_closes()
     flags = ["close", args.session_id, "--reason", args.reason]
@@ -2207,11 +2256,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_conversation_record_turn)
 
     p = sub.add_parser("conversation-close",
-                       help="Close one conversation session now, or sweep every idle-expired one")
+                       help="Close one conversation session now, sweep the janitor, or roll over the day")
     p.add_argument("session_id", nargs="?")
     p.add_argument("--expired", action="store_true",
-                   help="Close every session past its idle timeout (the sweep)")
-    p.add_argument("--reason", default="done", choices=["done", "idle_timeout", "exit_taken"])
+                   help="Close every session past the janitor threshold (36h-class safety net)")
+    p.add_argument("--day-rollover", action="store_true",
+                   help="Close every open session regardless of idle age (design §D day rollover)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="With --day-rollover: list sessions that would close, without closing them")
+    p.add_argument("--reason", default="done",
+                   choices=["done", "idle_timeout", "exit_taken", "day_rollover"])
     p.set_defaults(func=cmd_conversation_close)
 
     p = sub.add_parser("conversation-turn-retry", help="Retry a definitively unsent conversation turn")

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 160,
+  "version": 161,
   "released": "2026-08-12",
-  "changelog": "v160: fix duplicate '\u2705 Filed' notice after conversation turns (issue #133) \u2014 file_answer_bg.sh's duplicate-notice suppression now recognizes the v153 turn-confirmed marker alongside the legacy acknowledgment marker.",
+  "changelog": "v161: day-rollover session close (issue #136, Chats-per-Focus design \u00a7D) \u2014 daily_question.sh gains a pre-question step closing every open conversation session (reason day_rollover, no idle filter) via the generalized conversation-close --day-rollover; the idle sweep (--expired) demotes to a mode-independent 36h janitor (knob.janitor_idle_hours); interaction.yaml's chat/conversation idle knobs raised to day-scale (1440 minutes).",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_conversation_close.py
+++ b/tests/test_conversation_close.py
@@ -371,6 +371,91 @@ class ConversationCloseCommandTests(VaultSubprocessTestCase):
         self.assertNotIn(fresh["session_id"], enqueued_ids)
         self.assertNotIn(closed["session_id"], enqueued_ids)
 
+    def test_day_rollover_enqueues_every_open_session_with_stable_identity(self):
+        """Design §D (2026-08-12): --day-rollover has NO idle filter — a
+        session opened moments ago still gets swept, unlike --expired."""
+        fresh = conversation.open_session(
+            "chat", "telegram", arc={"question_id": "A1"}, vault_root=self.vault,
+        )
+        also_fresh = conversation.open_session(
+            "conversation", "telegram", vault_root=self.vault,
+        )
+        closed = conversation.open_session(
+            "chat", "telegram", arc={"question_id": "A1"},
+            session_id="conv-20200101-000000-bbbbbb", vault_root=self.vault,
+        )
+        conversation.close_session(closed["session_id"], {"reason": "done"}, vault_root=self.vault)
+
+        calls: list[tuple[str, dict, str | None]] = []
+
+        def fake_queue_and_wait(command, payload, *, identity=None):
+            calls.append((command, payload, identity))
+            return 0
+
+        with mock.patch.object(lifehug, "REPO_DIR", self.vault), \
+             mock.patch.object(lifehug, "_queue_and_wait", side_effect=fake_queue_and_wait):
+            rc = lifehug._enqueue_day_rollover_conversation_closes()
+
+        self.assertEqual(rc, 0)
+        enqueued_ids = {p["session_id"] for _c, p, _i in calls}
+        self.assertEqual(enqueued_ids, {fresh["session_id"], also_fresh["session_id"]})
+        self.assertNotIn(closed["session_id"], enqueued_ids)
+        for command, payload, identity in calls:
+            self.assertEqual(command, "conversation-close")
+            self.assertEqual(payload["reason"], "day_rollover")
+            self.assertEqual(identity, f"conversation-close:{payload['session_id']}")
+
+    def test_day_rollover_dry_run_lists_without_enqueuing_or_closing(self):
+        """--dry-run is a pure read: nothing enqueued, nothing closed."""
+        session_id = self.open_session(question_id="A2")
+
+        calls: list[tuple[str, dict, str | None]] = []
+
+        def fake_queue_and_wait(command, payload, *, identity=None):
+            calls.append((command, payload, identity))
+            return 0
+
+        with mock.patch.object(lifehug, "REPO_DIR", self.vault), \
+             mock.patch.object(lifehug, "_queue_and_wait", side_effect=fake_queue_and_wait):
+            rc = lifehug._enqueue_day_rollover_conversation_closes(dry_run=True)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, [])
+        self.assertEqual(
+            conversation.load_session(session_id, vault_root=self.vault)["status"], "open",
+        )
+
+    def test_day_rollover_dry_run_cli_is_a_single_deterministic_line(self):
+        """The daily script's LIFEHUG_DAILY_DRY_RUN preview depends on this
+        being ONE line, present regardless of vault state (empty or not)."""
+        empty = self.run_script("lifehug.py", "conversation-close", "--day-rollover", "--dry-run")
+        self.assertEqual(empty.returncode, 0, empty.stderr)
+        empty_lines = [line for line in empty.stdout.splitlines() if line.strip()]
+        self.assertEqual(len(empty_lines), 1, empty.stdout)
+        self.assertIn("DRY RUN", empty_lines[0])
+
+        self.open_session(question_id="A2")
+        nonempty = self.run_script("lifehug.py", "conversation-close", "--day-rollover", "--dry-run")
+        self.assertEqual(nonempty.returncode, 0, nonempty.stderr)
+        nonempty_lines = [line for line in nonempty.stdout.splitlines() if line.strip()]
+        self.assertEqual(len(nonempty_lines), 1, nonempty.stdout)
+        self.assertIn("DRY RUN", nonempty_lines[0])
+
+    # NOTE: an end-to-end subprocess run of --day-rollover (real job worker,
+    # no mocks) is deliberately NOT exercised here. --day-rollover shares
+    # its enqueue/wait shape with --expired verbatim, and `conversation-close`
+    # is a DIRECT_MUTATION_COMMANDS entry (lifehug.py:main takes the writer
+    # lock for the WHOLE call before either sweep runs); the sweep then
+    # enqueues + waits on a NESTED conversation-close job that needs the
+    # same writer lock, which the kicked worker subprocess cannot acquire
+    # until the outer process releases it. This is pre-existing behavior
+    # inherited unchanged from --expired (issue #119) — no test in this
+    # suite exercises --expired end-to-end via subprocess either, for the
+    # same reason. In-process coverage (the mocked-enqueue test above, and
+    # ``close_all_open_sessions``'s own idempotence test in
+    # tests/test_conversation_delivery.py::DayRolloverTests) proves the
+    # discovery/close/idempotence contract without tripping this seam.
+
 
 class JobsConversationCloseCommandTests(unittest.TestCase):
     """Scope §2 — the jobs.py command-registry contract."""

--- a/tests/test_conversation_delivery.py
+++ b/tests/test_conversation_delivery.py
@@ -442,7 +442,25 @@ class CloseTests(EngineTestCase):
         telegram = mock.Mock(side_effect=AssertionError("no-nag: nothing may be sent"))
         ai = mock.Mock(side_effect=AssertionError("no closing generation"))
 
-        later = datetime.now(timezone.utc) + timedelta(hours=5)
+        # Design §D (2026-08-12): the sweep is a 36h-class janitor now, not
+        # the old 120-minute chat knob — 5 hours idle must NOT trip it.
+        soon = datetime.now(timezone.utc) + timedelta(hours=5)
+        untouched = engine.close_expired_sessions(
+            now=soon,
+            vault_root=self.vault,
+            state_path=self.state_path,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            ai_call=ai,
+            telegram_send=telegram,
+            status_resolver=ready_status,
+        )
+        self.assertEqual(untouched, [])
+        self.assertEqual(
+            conversation.load_session(session_id, vault_root=self.vault)["status"], "open",
+        )
+
+        later = datetime.now(timezone.utc) + timedelta(hours=37)
         outcomes = engine.close_expired_sessions(
             now=later,
             vault_root=self.vault,
@@ -594,16 +612,135 @@ class CloseTests(EngineTestCase):
         telegram.assert_not_called()
 
     def test_idle_timeout_knobs_come_from_interaction_yaml(self):
+        # Design §D (2026-08-12): raised to day-scale (1440 min-class) —
+        # day rollover + user transitions are the real lifecycle now, these
+        # are only a generous "still counts as current" continuation
+        # ceiling, not a UX trigger.
         manifest = engine._manifest()
         chat = {"mode": "chat", "session_id": "conv-20260811-120000-abcdef", "turns": []}
         talk = {"mode": "conversation", "session_id": "conv-20260811-120000-abcdef", "turns": []}
-        self.assertEqual(engine.idle_timeout_minutes(chat, manifest), 120)
-        self.assertEqual(engine.idle_timeout_minutes(talk, manifest), 30)
+        self.assertEqual(engine.idle_timeout_minutes(chat, manifest), 1440)
+        self.assertEqual(engine.idle_timeout_minutes(talk, manifest), 1440)
         opened = datetime(2026, 8, 11, 12, 0, 0, tzinfo=timezone.utc)
         self.assertFalse(engine.is_idle_expired(chat, manifest=manifest,
-                                                now=opened + timedelta(minutes=119)))
+                                                now=opened + timedelta(minutes=1439)))
         self.assertTrue(engine.is_idle_expired(chat, manifest=manifest,
-                                               now=opened + timedelta(minutes=121)))
+                                               now=opened + timedelta(minutes=1441)))
+
+    def test_janitor_knob_comes_from_interaction_yaml(self):
+        manifest = engine._manifest()
+        self.assertEqual(manifest.get("knob.janitor_idle_hours"), 36)
+        stale = {"mode": "chat", "session_id": "conv-20260811-120000-abcdef", "turns": []}
+        opened = datetime(2026, 8, 11, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertFalse(engine.is_janitor_expired(stale, manifest=manifest,
+                                                    now=opened + timedelta(hours=35)))
+        self.assertTrue(engine.is_janitor_expired(stale, manifest=manifest,
+                                                   now=opened + timedelta(hours=37)))
+
+
+class DayRolloverTests(EngineTestCase):
+    """Design §D (Chats-per-Focus, 2026-08-12): day rollover closes EVERY
+    open session — no idle filter, the day owns the surface, not a timer."""
+
+    def test_closes_every_open_session_regardless_of_idle_age(self):
+        fresh_chat = conversation.open_session("chat", "telegram", vault_root=self.vault)
+        fresh_talk = conversation.open_session("conversation", "telegram", vault_root=self.vault)
+        already_closed = conversation.open_session(
+            "chat", "telegram", session_id="conv-20200101-000000-bbbbbb",
+            vault_root=self.vault,
+        )
+        conversation.close_session(already_closed["session_id"], {"reason": "done"},
+                                    vault_root=self.vault)
+
+        ids = engine.find_open_sessions(vault_root=self.vault)
+        self.assertEqual(set(ids), {fresh_chat["session_id"], fresh_talk["session_id"]})
+
+        telegram = mock.Mock(side_effect=AssertionError("no-nag: nothing may be sent"))
+        outcomes = engine.close_all_open_sessions(
+            vault_root=self.vault,
+            state_path=self.state_path,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            ai_call=mock.Mock(side_effect=AssertionError("no closing generation")),
+            telegram_send=telegram,
+            status_resolver=ready_status,
+        )
+
+        self.assertEqual({o.session_id for o in outcomes},
+                         {fresh_chat["session_id"], fresh_talk["session_id"]})
+        for outcome in outcomes:
+            self.assertEqual(outcome.reason, "day_rollover")
+            self.assertTrue(outcome.silent)  # zero user turns -> silent, no nag
+        for session_id in (fresh_chat["session_id"], fresh_talk["session_id"]):
+            self.assertEqual(
+                conversation.load_session(session_id, vault_root=self.vault)["status"],
+                "closed",
+            )
+        telegram.assert_not_called()
+        # The already-closed session is untouched (still closed with its
+        # original reason).
+        self.assertEqual(
+            conversation.load_session(already_closed["session_id"],
+                                      vault_root=self.vault)["close"]["reason"],
+            "done",
+        )
+
+        # Idempotent: nothing left open, a second pass closes nothing.
+        self.assertEqual(engine.find_open_sessions(vault_root=self.vault), [])
+        self.assertEqual(
+            engine.close_all_open_sessions(
+                vault_root=self.vault, state_path=self.state_path,
+                scores_path=self.scores_path, candidates_path=self.candidates_path,
+            ),
+            [],
+        )
+
+    def test_takeaway_rule_honored_two_plus_user_turns_earns_a_close_message(self):
+        self.run_turn(answer_text=ANSWER)
+        self.run_turn(answer_text=SECOND_ANSWER)
+        session_id = self.only_session()["session_id"]
+
+        outcomes = engine.close_all_open_sessions(
+            vault_root=self.vault,
+            state_path=self.state_path,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            ai_call=lambda _p, _m: json.dumps({"message": CLOSING_MESSAGE}),
+            telegram_send=self._send(),
+            prompt_builder=lambda payload: "SYNTHETIC CLOSING PROMPT",
+        )
+
+        self.assertEqual(len(outcomes), 1)
+        self.assertEqual(outcomes[0].reason, "day_rollover")
+        self.assertTrue(outcomes[0].takeaway_delivered)
+        self.assertEqual(self.sent[-1], CLOSING_MESSAGE)
+        session = conversation.load_session(session_id, vault_root=self.vault)
+        self.assertEqual(session["close"]["reason"], "day_rollover")
+        self.assertEqual(session["close"]["takeaway"], CLOSING_MESSAGE)
+        self.assertTrue(session["close"]["takeaway_delivered"])
+
+    def test_below_the_takeaway_threshold_closes_silently(self):
+        self.run_turn()  # one answer only
+        session_id = self.only_session()["session_id"]
+        telegram = mock.Mock(side_effect=AssertionError("no-nag"))
+
+        outcomes = engine.close_all_open_sessions(
+            vault_root=self.vault,
+            state_path=self.state_path,
+            scores_path=self.scores_path,
+            candidates_path=self.candidates_path,
+            status_resolver=ready_status,
+            telegram_send=telegram,
+        )
+
+        self.assertEqual(len(outcomes), 1)
+        self.assertTrue(outcomes[0].silent)
+        self.assertFalse(outcomes[0].takeaway_delivered)
+        telegram.assert_not_called()
+        session = conversation.load_session(session_id, vault_root=self.vault)
+        self.assertEqual(session["close"]["reason"], "day_rollover")
+        self.assertEqual(session["close"]["takeaway"], "")
 
 
 class PrivacyTests(EngineTestCase):

--- a/tests/test_lifehug_wrapper.py
+++ b/tests/test_lifehug_wrapper.py
@@ -162,6 +162,49 @@ class LifehugWrapperTests(unittest.TestCase):
         self.assertIn("COMPILE_STATUS=$?", script)
         self.assertIn('if [[ "$COMPILE_STATUS" -ne 0 ]]', script)
 
+    def test_daily_day_rollover_runs_after_compile_and_before_pick(self):
+        """Design §D (Chats-per-Focus, 2026-08-12): THE PLATFORM'S TRANSPORT
+        SPEC — daily_question.sh's day-rollover pre-step, pinned at text
+        level like every other shell "parity SPEC" (see
+        tests/test_arc_planner.py::CommandSurfaceTests)."""
+        script = (SYSTEM / "daily_question.sh").read_text(encoding="utf-8")
+
+        compile_status_at = script.index("COMPILE_STATUS=$?")
+        rollover_at = script.index("conversation-close --day-rollover", compile_status_at)
+        awaiting_at = script.index("awaiting_pass_transition")
+        pick_at = script.index('QUESTION_OUTPUT=$(python3 "$SCRIPT_DIR/ask.py" --dry-run)')
+        self.assertLess(compile_status_at, rollover_at)
+        self.assertLess(rollover_at, awaiting_at)
+        self.assertLess(rollover_at, pick_at)
+        self.assertIn(
+            'record_learning_failure "daily_question" "day_rollover_close"', script,
+        )
+        self.assertIn("ROLLOVER_STATUS=$?", script)
+        self.assertIn('if [[ "$ROLLOVER_STATUS" -ne 0 ]]', script)
+
+    def test_daily_dry_run_previews_day_rollover_as_one_new_line(self):
+        """The dry-run transcript's shape is unchanged except for one new
+        line: a --dry-run (pure read) call of the same --day-rollover flag,
+        placed before the existing ask.py --dry-run preview."""
+        script = (SYSTEM / "daily_question.sh").read_text(encoding="utf-8")
+        preview = script.split('if [[ "$DRY_RUN" == "1" ]]; then')[1].split("exit 0")[0]
+        self.assertIn("conversation-close --day-rollover --dry-run", preview)
+        rollover_at = preview.index("conversation-close --day-rollover --dry-run")
+        ask_dry_run_at = preview.index('ask.py" --dry-run')
+        self.assertLess(rollover_at, ask_dry_run_at)
+
+    def test_conversation_close_cli_has_day_rollover_and_dry_run_flags(self):
+        wrapper = load_wrapper()
+        parser = subparser(wrapper.build_parser(), "conversation-close")
+        flags = {opt for action in parser._actions for opt in action.option_strings}
+        self.assertIn("--day-rollover", flags)
+        self.assertIn("--dry-run", flags)
+        self.assertIn("--expired", flags)
+        self.assertEqual(
+            option_choices(parser, "--reason"),
+            {"done", "idle_timeout", "exit_taken", "day_rollover"},
+        )
+
     def test_weekly_reports_recent_learning_failures(self):
         script = (SYSTEM / "weekly_maintenance.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
PR 1 of the **Chats-per-Focus reshape** (owner ideation 2026-08-12, ratified direction) — the OSS-first day-rollover close, written here as the platform's parity spec. Closes #136. Spec: `docs/pr-specs/136-day-rollover-close.md` (copies the design's Context + §D + the relevant §G item 1 text, self-contained).

## What changed

**`daily_question.sh`** gains a pre-question step (after wiki compile, before `ask.py`'s pick) that closes EVERY open conversation session — no idle filter, the day owns the surface, not a timer — via `lifehug.py conversation-close --day-rollover`. This exact invocation (flag + placement) is **the platform's transport spec**: the sibling platform PR mirrors it verbatim in `workflow.py`, per doctrine. Non-fatal (`record_learning_failure`, same idiom as the compile step above it). The `LIFEHUG_DAILY_DRY_RUN=1` preview gains exactly one new line (`--day-rollover --dry-run`, a pure read) — verified by hand against a synthetic vault; every other line is unchanged.

**`conversation-close --day-rollover`** generalizes the merged close machinery across all three layers:
- `conversation.VALID_CLOSE_REASONS` gains `"day_rollover"`; `jobs.py`'s mirrored validation set follows (documented reason it can't just import `conversation.py`).
- `conversation_delivery.py` gains pure discovery (`find_open_sessions` — every OPEN session, no idle filter) and a synchronous engine entry point (`close_all_open_sessions`, mirrors `close_expired_sessions` minus the janitor filter); its own `close` CLI gains `--day-rollover`.
- `lifehug.py`'s `conversation-close` CLI gains `--day-rollover` (+ `--dry-run`) and `_enqueue_day_rollover_conversation_closes` — the enqueue-durable-job twin of `_enqueue_expired_conversation_closes`, same per-session job, same identity (`conversation-close:<session_id>`, deliberately shared dedup key with the janitor sweep).
- The takeaway criterion is **not** re-decided: `close_session_now`'s existing `>=2`-user-turns rule governs a day-rollover close exactly as it governs any other reason — fewer turns close silently.

**`--expired` demotes to a janitor** per design §D ("The 15-min sweep demotes to janitor"): `is_janitor_expired` (mode-independent, `knob.janitor_idle_hours`, default 36) replaces `is_idle_expired` inside `find_expired_open_sessions`/`close_expired_sessions` only. The flag itself, its CLI surface, and its job-enqueue shape are unchanged — only its threshold source changes.

**`interaction.yaml`**: `chat_idle_timeout_minutes` / `conversation_idle_timeout_minutes` raised to `1440` (day-scale, for continuation checks only); new `knob.janitor_idle_hours: 36`; a doc comment recording that day rollover + user transitions are the real close lifecycle. Flat scalar keys only, per the parser's documented subset.

**Version**: v160 → v161.

## Tests

- `tests/test_conversation_delivery.py::DayRolloverTests` — rollover closes every open session regardless of idle age and is idempotent (second pass closes nothing); the >=2-user-turn takeaway rule is honored identically under `day_rollover`; below-threshold closes stay silent.
- `tests/test_conversation_delivery.py::CloseTests::test_janitor_knob_comes_from_interaction_yaml` — the new 36h knob governs `is_janitor_expired`.
- `tests/test_conversation_delivery.py::CloseTests::test_idle_timeout_files_partial_chat_silently` — updated: 5h idle no longer trips the sweep (was: the old 120-min chat knob); 37h does.
- `tests/test_conversation_delivery.py::CloseTests::test_idle_timeout_knobs_come_from_interaction_yaml` — updated to the new 1440-minute values.
- `tests/test_conversation_close.py::ConversationCloseCommandTests` — CLI-level enqueue-discovery test (mocked `_queue_and_wait`, mirrors the existing `--expired` precedent) proving `--day-rollover` sweeps every open session and skips already-closed ones; `--dry-run` proven to enqueue/close nothing and to print exactly one deterministic line regardless of vault state.
- `tests/test_lifehug_wrapper.py` — text-level "parity SPEC" pins (repo convention, see `test_arc_planner.py::CommandSurfaceTests`): the rollover step's placement (after compile, before the pass-transition check and `ask.py`'s pick) and the dry-run preview's one-new-line shape; the CLI's `--day-rollover`/`--dry-run`/`--reason` surface.

A deliberate **non**-test: an end-to-end subprocess run of `--day-rollover` with a real job worker is not exercised — `conversation-close` is a `DIRECT_MUTATION_COMMANDS` entry that takes the writer lock for the whole call before either sweep runs, and the sweep then enqueues + waits on a nested job needing the same lock, which the kicked worker can't acquire until the outer process releases it. This is pre-existing behavior inherited unchanged from `--expired` (no test in this suite exercises `--expired` end-to-end via subprocess either, for the same reason) — noted in a comment at the call site, out of scope to fix here.

## Verified locally

- `python3 -m unittest tests.test_conversation_delivery tests.test_conversation_close tests.test_lifehug_wrapper tests.test_v117_multi_writer tests.test_arc_planner -v` — 125/125 green.
- `python3 -m unittest discover -s tests -p "test_*.py"` — 1338 tests, 21 pre-existing failures in `test_v120_source_view.py` confirmed unrelated (reproduce identically on a clean `origin/main` checkout via `git stash`), zero new failures.
- `python3 scripts/ci/check_framework_files.py` — 195/195 entries exist.
- `python3 scripts/ci/check_version_bump.py --base cb4dfb2 --head HEAD` — 160 → 161, OK.
- `bash -n system/daily_question.sh` — syntax OK.
- All three `LIFEHUG_*_DRY_RUN` previews (daily/weekly/monthly) run exit-0 against a synthetic vault; the daily transcript shows the new single rollover line and, with an open session seeded first, correctly lists it without mutating anything.

## Sequencing (design §G)

PR 1 (this) → release + pin bump rides the next routine bump (the day-rollover transport in platform PR 2 is gated on the pin carrying this PR) → platform PR 2 (body reversal, transport, `focus_context`) → platform PR 3 (Chats UI).

Cites: the Chats-per-Focus design doc (§Context, §D, §G item 1) and the owner's 2026-08-12 ratified direction.

🤖 Generated with Claude Sonnet 5 via Claude Code

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0116gPPwxxMvJ1CdyqwjJQFc