### PR TITLE
fix(tests): move temp vaults out of the workspace parent dir (v163)

### DIFF
--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 162,
-  "released": "2026-08-12",
-  "changelog": "v162: pure-chat close (issue #139, Chats-per-Focus design \u00a7K) \u2014 the exit-offer ceremony is gone: chats and conversations now close with ONE declarative statement (the statement IS the user's out; no trailing question, no meta-framing like \"leave it here\"/\"for now\"/\"a good place to rest\") instead of a separate mid-arc turn that announced stopping was okay. The exchange budget still governs how many follow-up questions the AI asks, but it now operates silently \u2014 reply-is-consent replaces the ceremony. Replying to a chat that already closed, same day or months later, resumes that same subject instead of being misread as an unrelated new story. New deterministic checks catch closing messages that slip back into the old announced-ending phrasing.",
+  "version": 163,
+  "released": "2026-08-13",
+  "changelog": "v163: test fixtures no longer create temp vaults in the workspace parent directory — a killed test run used to leak tmp* directories next to the repo (3,760 of them in one session). Temp vaults now live under the resolved system temp dir (symlink-free, so vault_paths' no-follow guard still accepts them) and are cleaned up unconditionally; a strengthened guard test bans any workspace-parent temp dir from returning. Test-only change; no user-facing behavior differs.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/tempdirs.py
+++ b/tests/tempdirs.py
@@ -1,4 +1,13 @@
-"""Temp-dir helpers for tests that must avoid macOS /var symlink paths."""
+"""Temp-dir helpers for tests that must avoid macOS /var symlink paths.
+
+vault_paths' no-follow authority rejects any path that traverses a symlink,
+and the default temp dir on macOS does (/var -> /private/var). Fixtures used
+to dodge that by creating temp dirs in the worktree's parent directory, which
+littered the user's workspace whenever a run was killed before cleanup.
+Instead, create them under the fully RESOLVED system temp dir: it has no
+symlink components (so guarded code accepts it), and anything a killed run
+leaks lands in the OS temp area, never in the workspace.
+"""
 
 from __future__ import annotations
 
@@ -7,15 +16,17 @@ import tempfile
 import unittest
 from pathlib import Path
 
+# /var/folders/... -> /private/var/folders/... on macOS; a no-op elsewhere.
+SYMLINK_FREE_TMP_BASE = Path(tempfile.gettempdir()).resolve()
 
-def root_parent_tmp(
+
+def symlink_free_tmp(
     test_case: unittest.TestCase,
-    root: Path,
     *,
     prefix: str | None = None,
 ) -> Path:
-    """Create a ROOT.parent temp dir and register unconditional cleanup."""
-    options: dict[str, object] = {"dir": root.parent}
+    """Create a symlink-free temp dir and register unconditional cleanup."""
+    options: dict[str, object] = {"dir": SYMLINK_FREE_TMP_BASE}
     if prefix is not None:
         options["prefix"] = prefix
     tmp = Path(tempfile.mkdtemp(**options))

--- a/tests/test_answer_ack.py
+++ b/tests/test_answer_ack.py
@@ -12,7 +12,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 
 
 def load_answer_ack():
@@ -166,7 +166,7 @@ class AnswerAcknowledgmentDeliveryTests(unittest.TestCase):
         # at a synthetic vault — ROOT.parent, because vault_paths refuses to
         # traverse macOS's /var symlink — so these tests never write session
         # documents or a delivery ledger into the real vault.
-        vault = root_parent_tmp(self, ROOT, prefix="lifehug-v153-ack-") / "vault"
+        vault = symlink_free_tmp(self, prefix="lifehug-v153-ack-") / "vault"
         vault.mkdir()
         for patch in (
             mock.patch.object(conversation_delivery, "VAULT_ROOT", vault),

--- a/tests/test_arc_planner.py
+++ b/tests/test_arc_planner.py
@@ -27,7 +27,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 
 import arc_planner  # noqa: E402
 import book  # noqa: E402
@@ -153,7 +153,7 @@ class BaseVaultTest(unittest.TestCase):
     prefix = "lifehug-118-arc-"
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix=self.prefix)
+        self.tmp = symlink_free_tmp(self, prefix=self.prefix)
         self.vault = self.tmp / "vault"
         self.vault.mkdir()
         self.fixture = VaultFixture(self.vault)

--- a/tests/test_conversation_close.py
+++ b/tests/test_conversation_close.py
@@ -35,7 +35,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import conversation  # noqa: E402
 import jobs  # noqa: E402
 import lifehug  # noqa: E402
@@ -124,7 +124,7 @@ class VaultSubprocessTestCase(unittest.TestCase):
     matching the codebase's own ExternalVaultSubprocessTests precedent."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v156-close-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v156-close-")
         self.vault = make_vault(self.tmp / "vault")
         import os
         self.env = os.environ.copy()
@@ -490,7 +490,7 @@ class MirrorInboundTests(unittest.TestCase):
     """Scope §4 — surgical, mirrors tests/test_mirror.py's own fixture style."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v156-mirror-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v156-mirror-")
         self._saved = mirror.MIRROR_RESPONSES_FILE
         mirror.MIRROR_RESPONSES_FILE = self.tmp / "mirror_responses.json"
         self.addCleanup(setattr, mirror, "MIRROR_RESPONSES_FILE", self._saved)
@@ -518,7 +518,7 @@ class EngagementFieldsTests(unittest.TestCase):
     real capture path; nothing is ever fabricated for an absent signal."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v156-engagement-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v156-engagement-")
         self.scores_path = self.tmp / "answer_scores.json"
 
     def _seed(self, records: list[dict]) -> None:
@@ -586,7 +586,7 @@ class EngagementProfileTests(unittest.TestCase):
 
     def setUp(self):
         self.qprof = load("quality_profile")
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v156-profile-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v156-profile-")
         self.qprof.ANSWER_SCORES_FILE = self.tmp / "answer_scores.json"
         self.qprof.QUALITY_PROFILE_FILE = self.tmp / "quality_profile.json"
 
@@ -657,7 +657,7 @@ class PlannerEngagementTests(unittest.TestCase):
         import question_planner as qp
 
         self.qp = qp
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v156-planner-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v156-planner-")
         bank = self.tmp / "question-bank.md"
         bank.write_text(self.SELF_BANK, encoding="utf-8")
         self._saved_questions_file = qp.QUESTIONS_FILE

--- a/tests/test_conversation_delivery.py
+++ b/tests/test_conversation_delivery.py
@@ -29,7 +29,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import conversation  # noqa: E402
 import conversation_delivery as engine  # noqa: E402
 import lifehug_core as core  # noqa: E402
@@ -98,7 +98,7 @@ class EngineTestCase(unittest.TestCase):
     """Synthetic vault + injected collaborators shared by every subtest."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v153-turn-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v153-turn-")
         self.vault = self.tmp / "vault"
         self.vault.mkdir()
         self.state_path = self.tmp / "conversation_deliveries.json"

--- a/tests/test_conversation_router.py
+++ b/tests/test_conversation_router.py
@@ -31,7 +31,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import conversation  # noqa: E402
 import conversation_delivery as engine  # noqa: E402
 import lifehug_core as core  # noqa: E402
@@ -188,7 +188,7 @@ class ThresholdAndDefaultTests(unittest.TestCase):
 
 class MutatesNothingTests(unittest.TestCase):
     def test_route_mutates_nothing(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v155-router-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-v155-router-")
         vault = tmp / "vault"
         vault.mkdir()
         state_dir = vault / "state"
@@ -266,7 +266,7 @@ class ReplyAfterCloseTests(unittest.TestCase):
         return vault, session_id
 
     def test_same_day_reply_overrides_confident_new_story_model_call(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v161-reply-after-close-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-v161-reply-after-close-")
         closed_at = datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc)
         vault, session_id = self._closed_session(tmp, last_activity=closed_at)
         same_day_later = closed_at + timedelta(hours=6)
@@ -287,7 +287,7 @@ class ReplyAfterCloseTests(unittest.TestCase):
         self.assertIsNone(result["open_session_id"])
 
     def test_later_reply_with_no_provider_resolves_to_continue_not_new_story(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v161-reply-after-close-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-v161-reply-after-close-")
         closed_at = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
         vault, session_id = self._closed_session(tmp, last_activity=closed_at)
         much_later = closed_at + timedelta(days=40)
@@ -309,7 +309,7 @@ class ReplyAfterCloseTests(unittest.TestCase):
         ai.assert_not_called()
 
     def test_recently_closed_does_not_override_out_of_scope_or_command(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v161-reply-after-close-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-v161-reply-after-close-")
         closed_at = datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc)
         vault, _session_id = self._closed_session(tmp, last_activity=closed_at)
         same_day_later = closed_at + timedelta(hours=1)
@@ -329,7 +329,7 @@ class ReplyAfterCloseTests(unittest.TestCase):
                 self.assertEqual(result["intent"], intent)
 
     def test_no_closed_session_leaves_terminal_fallback_unchanged(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v161-reply-after-close-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-v161-reply-after-close-")
         vault = tmp / "vault"
         vault.mkdir()
         ai = mock.Mock(side_effect=AssertionError("keyless must never call the model"))
@@ -347,7 +347,7 @@ class ReplyAfterCloseTests(unittest.TestCase):
         appending to the closed doc — the store forbids that by design),
         and that new session closes again with its own declarative
         takeaway. Both closes pass the closing-declarative lint."""
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v161-reopen-close-again-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-v161-reopen-close-again-")
         closed_at = datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc)
         vault, first_session_id = self._closed_session(tmp, last_activity=closed_at)
         same_day_later = closed_at + timedelta(hours=3)

--- a/tests/test_ingest_and_planner.py
+++ b/tests/test_ingest_and_planner.py
@@ -12,7 +12,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import conversation  # noqa: E402
 import conversation_delivery as engine  # noqa: E402
 import lifehug_core as core  # noqa: E402
@@ -158,7 +158,7 @@ class StoryConversationTurnCase(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v155-story-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v155-story-")
         self.vault = self.tmp / "vault"
         self.vault.mkdir()
         self.state_path = self.tmp / "conversation_deliveries.json"
@@ -421,7 +421,7 @@ class IngestCliRegressionTests(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v155-ingest-cli-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v155-ingest-cli-")
 
     def _make_vault(self) -> Path:
         vault = self.tmp / f"vault-{len(list(self.tmp.iterdir()))}"

--- a/tests/test_interaction_evals.py
+++ b/tests/test_interaction_evals.py
@@ -24,7 +24,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import conversation_lints  # noqa: E402
 import interaction_evals as ie  # noqa: E402
 from ai_provider import ProviderStatus  # noqa: E402
@@ -661,7 +661,7 @@ class RunOrchestratorTests(unittest.TestCase):
 
 class EmitTasksTests(unittest.TestCase):
     def test_emit_tasks_writes_a_prompt_per_golden_and_per_persona(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-evals-emit-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-evals-emit-")
         out_dir = tmp / "evals"
         manifest_path = ie.emit_tasks(out_dir)
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -673,7 +673,7 @@ class EmitTasksTests(unittest.TestCase):
             self.assertTrue((out_dir / item["prompt"]).exists())
 
     def test_run_with_emit_tasks_flag_writes_the_manifest(self):
-        tmp = root_parent_tmp(self, ROOT, prefix="lifehug-evals-run-emit-")
+        tmp = symlink_free_tmp(self, prefix="lifehug-evals-run-emit-")
         import unittest.mock as mock
         with mock.patch.object(ie, "AGENT_TASKS_DIR", tmp):
             code, report = ie.run(emit_tasks_flag=True)

--- a/tests/test_tempdir_cleanup.py
+++ b/tests/test_tempdir_cleanup.py
@@ -1,4 +1,12 @@
-"""Regression guard for workspace-parent temp dirs in tests."""
+"""Regression guard: test temp dirs must never land in the workspace.
+
+Tests once created temp vaults in the worktree's parent directory (to dodge
+vault_paths' symlink refusal of macOS's /var temp prefix). Runs killed before
+cleanup leaked thousands of tmp* dirs into the user's workspace. The policy
+now: every tempfile.mkdtemp/TemporaryDirectory call in tests that passes an
+explicit ``dir=`` must pass tempdirs.SYMLINK_FREE_TMP_BASE — never a path
+derived from the repo's location (ROOT.parent, Path(...).parents[n], etc.).
+"""
 
 from __future__ import annotations
 
@@ -9,47 +17,51 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 TESTS = ROOT / "tests"
 
+ALLOWED_DIR_NAME = "SYMLINK_FREE_TMP_BASE"
 
-def _is_tempfile_mkdtemp(node: ast.Call) -> bool:
+
+def _is_tempfile_tmp_call(node: ast.Call) -> bool:
     return (
         isinstance(node.func, ast.Attribute)
-        and node.func.attr == "mkdtemp"
+        and node.func.attr in {"mkdtemp", "TemporaryDirectory", "mktemp", "mkstemp"}
         and isinstance(node.func.value, ast.Name)
         and node.func.value.id == "tempfile"
     )
 
 
-def _is_root_parent(node: ast.AST) -> bool:
-    return (
-        isinstance(node, ast.Attribute)
-        and node.attr == "parent"
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "ROOT"
-    )
+def _is_allowed_dir_value(node: ast.AST) -> bool:
+    # SYMLINK_FREE_TMP_BASE or tempdirs.SYMLINK_FREE_TMP_BASE
+    if isinstance(node, ast.Name):
+        return node.id == ALLOWED_DIR_NAME
+    return isinstance(node, ast.Attribute) and node.attr == ALLOWED_DIR_NAME
 
 
-class RootParentTempDirPolicyTests(unittest.TestCase):
-    def test_root_parent_mkdtemp_uses_cleanup_helper(self):
+class WorkspaceTempDirPolicyTests(unittest.TestCase):
+    def test_no_test_creates_temp_dirs_outside_the_symlink_free_base(self):
         offenders: list[str] = []
         for path in sorted(TESTS.glob("test*.py")):
-            if path.name == Path(__file__).name:
-                continue
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Call) or not _is_tempfile_mkdtemp(node):
+                if not isinstance(node, ast.Call) or not _is_tempfile_tmp_call(node):
                     continue
-                if any(
-                    keyword.arg == "dir" and _is_root_parent(keyword.value)
-                    for keyword in node.keywords
-                ):
-                    offenders.append(f"{path.relative_to(ROOT)}:{node.lineno}")
+                for keyword in node.keywords:
+                    if keyword.arg == "dir" and not _is_allowed_dir_value(keyword.value):
+                        offenders.append(f"{path.relative_to(ROOT)}:{node.lineno}")
 
         self.assertEqual(
             offenders,
             [],
-            "Use root_parent_tmp(self, ROOT, ...) from tests/tempdirs.py so "
-            "cleanup is registered.",
+            "Explicit dir= in tempfile calls must be "
+            "tempdirs.SYMLINK_FREE_TMP_BASE (or use tempdirs.symlink_free_tmp), "
+            "so temp dirs never leak into the user's workspace.",
         )
+
+    def test_symlink_free_base_really_has_no_symlink_components(self):
+        import tempfile
+
+        base = Path(tempfile.gettempdir()).resolve()
+        chain = [base, *base.parents]
+        self.assertEqual([p for p in chain if p.is_symlink()], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -23,6 +23,9 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "system"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tempdirs import symlink_free_tmp  # noqa: E402
 import update  # noqa: E402
 import vault_paths  # noqa: E402
 
@@ -349,13 +352,7 @@ class StateDirResolutionTests(unittest.TestCase):
     never reads, silently inerting the whole feature forever."""
 
     def setUp(self):
-        import tempfile
-        # vault_paths' no-follow authority rejects the default /var/folders
-        # tmp prefix on macOS (it traverses a /var symlink) — root the
-        # fixture under the real worktree parent instead, same fix
-        # test_wiki_views.py already needed for the same reason.
-        self.tmp = Path(tempfile.mkdtemp(dir=Path(__file__).resolve().parents[2]))
-        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-update-")
         self._orig = (update.REPO_DIR, update.VERSION_FILE)
         self.addCleanup(self._restore)
         self._orig_env = os.environ.get("LIFEHUG_VAULT_ROOT")

--- a/tests/test_v101_actions.py
+++ b/tests/test_v101_actions.py
@@ -17,7 +17,9 @@ from urllib.parse import urlencode
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
+sys.path.insert(0, str(ROOT / "tests"))
 
+from tempdirs import SYMLINK_FREE_TMP_BASE  # noqa: E402
 import jobs  # noqa: E402
 import lifehug_core  # noqa: E402
 import question_planner as qp  # noqa: E402
@@ -298,7 +300,7 @@ class PostAuthTests(unittest.TestCase):
 
     def test_artifact_file_gets_private_headers(self):
         original_repo = lifehug_core.REPO_DIR
-        with tempfile.TemporaryDirectory(dir=ROOT.parent) as tmp:
+        with tempfile.TemporaryDirectory(dir=SYMLINK_FREE_TMP_BASE) as tmp:
             try:
                 lifehug_core.REPO_DIR = Path(tmp)
                 artifact = lifehug_core.REPO_DIR / "outputs" / "piece" / "v1.pdf"
@@ -343,7 +345,7 @@ class PostAuthTests(unittest.TestCase):
 
     def test_job_endpoint_converges_from_queued_to_succeeded(self):
         original = jobs.VAULT_ROOT
-        with tempfile.TemporaryDirectory(dir=ROOT.parent) as tmp:
+        with tempfile.TemporaryDirectory(dir=SYMLINK_FREE_TMP_BASE) as tmp:
             try:
                 vault_paths._reset_process_binding_for_tests()
                 vault = Path(tmp)

--- a/tests/test_v119_jobs.py
+++ b/tests/test_v119_jobs.py
@@ -21,7 +21,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import jobs  # noqa: E402
 import lifehug  # noqa: E402
 import vault_paths  # noqa: E402
@@ -117,7 +117,7 @@ def make_minimum_vault(root: Path, *, embedded: bool = False) -> None:
 class DurableJobsTests(unittest.TestCase):
     def setUp(self):
         vault_paths._reset_process_binding_for_tests()
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-jobs-test-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-jobs-test-")
         self.vault = self.tmp / "vault-only"
         make_minimum_vault(self.vault)
         self.framework = self.tmp / "framework" / "system"

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -24,7 +24,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import vault_paths  # noqa: E402
 
 
@@ -174,7 +174,7 @@ def has_direct_filesystem_call(text: str) -> bool:
 class VaultContractTests(unittest.TestCase):
     def setUp(self):
         vault_paths._reset_process_binding_for_tests()
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v120-contract-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v120-contract-")
 
     def tearDown(self):
         vault_paths._reset_process_binding_for_tests()
@@ -595,7 +595,7 @@ class VaultContractTests(unittest.TestCase):
 
 class ExternalVaultSubprocessTests(unittest.TestCase):
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v120-smoke-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v120-smoke-")
         self.framework = self.tmp / "framework"
         shutil.copytree(SYSTEM, self.framework / "system", ignore=shutil.ignore_patterns("__pycache__"))
         shutil.copytree(ROOT / "templates", self.framework / "templates")

--- a/tests/test_v121_answer_ack_delivery.py
+++ b/tests/test_v121_answer_ack_delivery.py
@@ -16,7 +16,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import answer_ack  # noqa: E402
 import conversation_delivery as turn_engine  # noqa: E402
 import answer_ack_delivery as delivery  # noqa: E402
@@ -186,7 +186,7 @@ class OrderingTests(unittest.TestCase):
     def setUp(self):
         # ROOT.parent, never tempfile's default: on macOS /var is a symlink
         # and vault_paths refuses to traverse symlinks (tests/tempdirs.py).
-        vault = root_parent_tmp(self, ROOT, prefix="lifehug-v153-ordering-") / "vault"
+        vault = symlink_free_tmp(self, prefix="lifehug-v153-ordering-") / "vault"
         vault.mkdir()
         for patch in (
             mock.patch.object(turn_engine, "VAULT_ROOT", vault),
@@ -293,7 +293,7 @@ class OrderingTests(unittest.TestCase):
 
 class ProcessAnswerIntegrationTests(unittest.TestCase):
     def setUp(self):
-        vault = root_parent_tmp(self, ROOT, prefix="lifehug-v153-integration-") / "vault"
+        vault = symlink_free_tmp(self, prefix="lifehug-v153-integration-") / "vault"
         vault.mkdir()
         for patch in (
             mock.patch.object(turn_engine, "VAULT_ROOT", vault),

--- a/tests/test_v125_frameworks.py
+++ b/tests/test_v125_frameworks.py
@@ -22,7 +22,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import book  # noqa: E402
 import compose  # noqa: E402
 import format_frameworks  # noqa: E402
@@ -140,7 +140,7 @@ class FrameworkLoaderUnitTests(unittest.TestCase):
     """Against a synthetic templates/ directory."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT)
+        self.tmp = symlink_free_tmp(self)
         self.templates_dir = self.tmp / "templates"
         self.templates_dir.mkdir(parents=True)
         self._saved = {

--- a/tests/test_v127_studio.py
+++ b/tests/test_v127_studio.py
@@ -21,7 +21,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import artifact  # noqa: E402
 import book  # noqa: E402
 import jobs  # noqa: E402
@@ -49,7 +49,7 @@ class StudioTestBase(unittest.TestCase):
     """Shared fixture plumbing: a real-path tmp dir + module attribute saves."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT)
+        self.tmp = symlink_free_tmp(self)
         self._saved = {
             (studio, "OUTPUTS_DIR"): studio.OUTPUTS_DIR,
             (studio, "QUESTIONS_FILE"): studio.QUESTIONS_FILE,

--- a/tests/test_v130_migration.py
+++ b/tests/test_v130_migration.py
@@ -34,7 +34,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import update  # noqa: E402
 import vault_paths  # noqa: E402
 
@@ -132,7 +132,7 @@ class TmpVaultCase(unittest.TestCase):
     def setUp(self):
         # dir=ROOT.parent, not the system temp dir: macOS /var is a symlink and
         # vault_paths refuses to traverse one.
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v130-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v130-")
         self._orig = (update.REPO_DIR, update.VERSION_FILE)
         self.addCleanup(self._restore)
 

--- a/tests/test_v134_focus_gate.py
+++ b/tests/test_v134_focus_gate.py
@@ -21,7 +21,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import entity_roster  # noqa: E402
 import recommend_focuses  # noqa: E402
 import roadmap  # noqa: E402
@@ -52,7 +52,7 @@ class GateTestBase(unittest.TestCase):
     real-path-tmp-dir + monkeypatched-module-attribute convention."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT)
+        self.tmp = symlink_free_tmp(self)
         self._saved = {
             (roadmap, "ROADMAP_FILE"): roadmap.ROADMAP_FILE,
             (roadmap, "QUESTIONS_FILE"): roadmap.QUESTIONS_FILE,

--- a/tests/test_v150_conversation_store.py
+++ b/tests/test_v150_conversation_store.py
@@ -25,7 +25,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import conversation  # noqa: E402
 import conversation_lints  # noqa: E402
 import vault_paths  # noqa: E402
@@ -85,7 +85,7 @@ class ConversationStoreTests(unittest.TestCase):
     """Subtest 2: session lifecycle (open/append CAS/close, cold-vault degradation)."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v150-conversation-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v150-conversation-")
         self.vault = self.tmp / "vault"
         self.vault.mkdir()
 
@@ -215,7 +215,7 @@ class ArcCardStoreTests(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-v150-arc-cards-")
+        self.tmp = symlink_free_tmp(self, prefix="lifehug-v150-arc-cards-")
         self.vault = self.tmp / "vault"
         self.vault.mkdir()
 

--- a/tests/test_wiki_views.py
+++ b/tests/test_wiki_views.py
@@ -10,7 +10,7 @@ SYSTEM = ROOT / "system"
 sys.path.insert(0, str(SYSTEM))
 sys.path.insert(0, str(ROOT / "tests"))
 
-from tempdirs import root_parent_tmp  # noqa: E402
+from tempdirs import symlink_free_tmp  # noqa: E402
 import serve_wiki  # noqa: E402
 import roadmap  # noqa: E402
 import recommend_focuses  # noqa: E402
@@ -26,7 +26,7 @@ class WikiViewsTests(unittest.TestCase):
         # Keep the fixture under the real-path worktree parent. On macOS the
         # default /var/folders prefix traverses the /var symlink, which the
         # production no-follow vault I/O authority correctly rejects.
-        self.tmp = root_parent_tmp(self, ROOT)
+        self.tmp = symlink_free_tmp(self)
         # Save originals so each test runs against an isolated fixture set.
         self._saved = {
             (serve_wiki, "QUESTIONS_FILE"): serve_wiki.QUESTIONS_FILE,
@@ -807,7 +807,7 @@ class RevisionFooterTests(unittest.TestCase):
     Thoughts group for subjectless essays."""
 
     def setUp(self):
-        self.tmp = root_parent_tmp(self, ROOT)
+        self.tmp = symlink_free_tmp(self)
         self._saved = {
             (roadmap, "ROADMAP_FILE"): roadmap.ROADMAP_FILE,
             (roadmap, "QUESTIONS_FILE"): roadmap.QUESTIONS_FILE,


### PR DESCRIPTION
## What

Test fixtures created temp vaults in the worktree's **parent directory** (`~/Workspace`) to dodge `vault_paths`' no-follow symlink guard, which rejects macOS's default temp prefix (`/var` → `/private/var`). Cleanup was `addCleanup`-based, so runs killed mid-flight leaked their dirs — **3,760 `tmp*` directories** accumulated in the user's workspace during the Aug 9 session (now deleted).

## How

- **`tests/tempdirs.py`** — the shared helper (renamed `root_parent_tmp` → `symlink_free_tmp`) now creates dirs under the fully **resolved** system temp dir (`/private/var/folders/...`), which has no symlink components, so the guard accepts it. Unconditional `addCleanup` unchanged; anything a killed run still leaks lands in the OS temp area, never the workspace.
- **`test_update.py` / `test_v101_actions.py`** — the three direct workspace-parent `tempfile` calls now route through the helper / the exported `SYMLINK_FREE_TMP_BASE`.
- **`test_tempdir_cleanup.py`** — guard strengthened: any `tempfile` call in tests passing `dir=` anything other than `SYMLINK_FREE_TMP_BASE` fails the suite. The old check only caught `tempfile.mkdtemp(dir=ROOT.parent)` and missed the `TemporaryDirectory(dir=ROOT.parent)` and `parents[2]` forms that caused the leak. Also adds a runtime assertion that the base truly has no symlink components.
- **`system/version.json`** — v163 bump (test-only change, one-paragraph changelog).

The remaining 16 files are the mechanical helper rename at call sites.

## Verification

- Directly touched modules: `test_tempdir_cleanup` + `test_update` + `test_v101_actions` — 49 tests, **OK**.
- Full suite (`python3 -m unittest discover -s tests`): 1345 tests, **no new failures** — the 21 pre-existing `test_v120_source_view` failures reproduce identically on clean `main` on this machine (local-environment issue, unrelated; CI is the arbiter).
- Zero `tmp*` dirs appeared in `~/Workspace` across two full-suite runs.
- `scripts/ci/check_framework_files.py`: all 196 entries exist.

🤖 Generated with Claude Fable 5 via Claude Code