### PR TITLE
mission: the Convergence Principle (ADR 0006) — v163

### DIFF
--- a/docs/adr/0006-convergence-principle.md
+++ b/docs/adr/0006-convergence-principle.md
@@ -1,0 +1,51 @@
+# ADR 0006: The Convergence Principle
+
+Date: 2026-08-14
+Status: Accepted (owner-ratified in design session, 2026-08-14)
+
+## Context
+
+The system's learning story had an unstated split. The README promises "the
+answer itself is the only feedback the system needs," and the Loop's
+automated stages (candidate auto-promotion, entity graduation, queue
+planning) mostly honor that. But several mission-critical stages quietly
+require a human to make progress: Focus recommendations are approval-only
+("never created without you"), structurally-parked question candidates
+wait "for a human" who has no affordance and then expire, and a saturated
+Focus's phase never advances on its own. Meanwhile the explicit decisions
+an engaged owner *does* make (promote/dismiss/defer, with reasons) are
+recorded but consumed by nothing. Neither tier of user was being served
+by a stated principle.
+
+## Decision
+
+`system/mission.md` gains **The Convergence Principle**, binding on every
+loop stage and every surface:
+
+1. **Floor** — answering alone must converge. Every autonomous stage has
+   a no-human path; a stage that silently requires manual input to make
+   progress is a defect, not a design choice.
+2. **Accelerator** — manual signals are optional and multiplicative.
+   They speed up the same convergence, never unlock different behavior;
+   no manual affordance may become a dependency, and every explicit
+   decision is signal the loop must actually consume.
+
+Corollaries: "never without you" postures are override defaults, not hard
+gates; parked-for-a-human work must either resurface autonomously or be
+reachable by a real affordance.
+
+## Consequences
+
+- Focus creation needs an autonomous path (bounded by stated policy) with
+  manual choice as the override; the current approval-only posture is
+  reclassified as a gap.
+- Structural candidate parks must gain either autonomous resolution or a
+  real owner affordance (both are in flight on the hosted surface).
+- Review decisions and their reasons become required inputs to the
+  learning loop (see the decisions-feed-the-loop and question-judgment
+  interaction work).
+- The Loop-audit acceptance criterion (lifehug-platform#410) becomes
+  concrete: for each stage, "does it close without a human?"
+- mission.md remains a draft awaiting full ratification (#126); this
+  section's substance was ratified verbally by the owner on 2026-08-14
+  and rides the same review.

--- a/system/mission.md
+++ b/system/mission.md
@@ -21,6 +21,33 @@ you realize how impactful they are in your life.
 
 One thoughtful question at a time. Voice or text, long or short. A compounding, AI-assisted memory system that gets smarter with every answer — discovering connections, deepening thin areas, and turning raw stories into a living, interlinked wiki of my life.
 
+## The Convergence Principle
+
+The loop must work without us. Two tiers, one mechanism (owner-ratified
+2026-08-14):
+
+1. **The floor: answering is sufficient.** A user who only ever answers
+   questions — who never opens a review surface, never clicks anything —
+   must still converge, over time, to the optimal system: the right
+   questions, the right Focuses, an ever-more-accurate telling of their
+   life. Every autonomous stage (candidate promotion, focus creation and
+   retirement, entity graduation, queue planning) must have a no-human
+   path. A stage that silently requires manual input to make progress is
+   a defect against this principle, not a design choice.
+
+2. **The accelerator: manual signals are optional and multiplicative.**
+   An avid user who makes explicit decisions — promoting, dismissing,
+   giving reasons, choosing focuses — does not unlock different behavior;
+   they speed up the same convergence. Every manual affordance is an
+   accelerant, never a dependency, and every explicit decision is signal
+   the loop must actually consume.
+
+Corollaries: "never created without you" postures are override defaults,
+not hard gates — the system may act autonomously within stated policy and
+the owner's explicit decision always wins. Work parked "for a human" must
+either resurface autonomously or be reachable by a real affordance; it
+never strands.
+
 ## For AI Prompts
 
 Every prompt, classification, neighborhood, and planner decision should serve at least one of these three purposes. If a question doesn't help someone understand the author, help the author tell their story, or help the author understand themselves — it's the wrong question.

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 162,
-  "released": "2026-08-12",
-  "changelog": "v162: pure-chat close (issue #139, Chats-per-Focus design \u00a7K) \u2014 the exit-offer ceremony is gone: chats and conversations now close with ONE declarative statement (the statement IS the user's out; no trailing question, no meta-framing like \"leave it here\"/\"for now\"/\"a good place to rest\") instead of a separate mid-arc turn that announced stopping was okay. The exchange budget still governs how many follow-up questions the AI asks, but it now operates silently \u2014 reply-is-consent replaces the ceremony. Replying to a chat that already closed, same day or months later, resumes that same subject instead of being misread as an unrelated new story. New deterministic checks catch closing messages that slip back into the old announced-ending phrasing.",
+  "version": 163,
+  "released": "2026-08-14",
+  "changelog": "v163: mission \u2014 the Convergence Principle (ADR 0006). The floor: answering alone must converge; every autonomous stage has a no-human path. The accelerator: manual decisions (promote/dismiss/defer + reasons) are optional, multiplicative signal the loop must actually consume \u2014 never dependencies. 'Never without you' postures become override defaults, not hard gates.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",


### PR DESCRIPTION
Adds **The Convergence Principle** to system/mission.md, with ADR 0006 recording the decision (owner-ratified verbally in the 2026-08-14 design session; the mission doc as a whole still rides #126's draft review).

**Floor** — answering alone must converge: every autonomous loop stage has a no-human path; a stage that silently requires manual input to progress is a defect. **Accelerator** — manual decisions (promote/dismiss/defer + reasons) are optional and multiplicative; the loop must actually consume them; no manual affordance may become a dependency.

Consequences (tracked work): Focus-creation autonomy, structural-park affordances (platform review-loop train), decisions-feed-the-loop, and the acceptance criterion for lifehug-platform#410's Loop audit.

Local test note: full suite shows the same 21 pre-existing environment failures as clean origin/main in this workspace (the parent-dir issue #142 fixes); delta is zero. CI is the arbiter.

🤖 Generated with Claude Fable 5 via Claude Code