### PR TITLE
docs: How-Lifehug-Works handbook scaffold — GitHub Pages + doc-parity harness (v172)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,39 @@
+title: How Lifehug Works
+description: >-
+  The handbook of Lifehug's mechanics — every feature's purpose, nouns,
+  algorithm, and place in the Loop, kept honest by parity tests against the
+  code itself.
+remote_theme: just-the-docs/just-the-docs
+plugins:
+  - jekyll-remote-theme
+
+search_enabled: true
+heading_anchors: true
+mermaid:
+  version: "10.9.0"
+
+aux_links:
+  "lifehug on GitHub":
+    - "https://github.com/lifehug/lifehug"
+
+# The handbook and landing page are the navigable site. Everything else in
+# /docs (ADRs, pr-specs, BUILDING.md) stays browsable at its URL but out of
+# the sidebar — those documents are the raw decision/contract record, linked
+# from handbook pages where relevant.
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+  - scope:
+      path: "adr"
+    values:
+      nav_exclude: true
+  - scope:
+      path: "pr-specs"
+    values:
+      nav_exclude: true
+  - scope:
+      path: "BUILDING.md"
+    values:
+      nav_exclude: true

--- a/docs/handbook/glossary.md
+++ b/docs/handbook/glossary.md
@@ -1,0 +1,37 @@
+---
+title: Glossary
+parent: Handbook
+nav_order: 99
+---
+
+# Glossary
+
+Every standard term, defined once. Feature pages link here instead of
+re-defining. Seeded verbatim from the README's Nomenclature section at
+v171; as feature pages land, terms they own move here as the single
+definition and the README slims to a pointer.
+
+The wiki is a **graph of your life**, and these are the standard terms used throughout:
+
+- **Node** — a graph vertex: a durable subject in your life that can be compiled into a wiki page. People, places, periods, objects, themes, projects, and *you* are nodes.
+- **Node Type** — graph vocabulary for the kind of node, such as person, place, period, object, theme, project, or life. Most current `Entity Type` values are node types; `relationship` is the exception because it represents an edge page.
+- **Entity** — the current product/code term for a node-worthy subject; usually one wiki page. Keep using Entity in code and product flows where the system already does.
+- **Entity Type** — the current product/code and frontmatter term for a wiki page kind: `person`, `place`, `period`, `object`, `theme`, `project`, `relationship`, and `life` (you). Most entity types are node types; `relationship` remains the compatibility page type for an edge page.
+- **Edge** — a meaningful connection between nodes/entities. An edge can carry evidence, tension, change over time, and artifact relevance.
+- **Relationship Edge** — a human bond edge, usually between you and another person. The page in `wiki/relationships/` is an edge page: it answers what the bond is, not merely who the other person is.
+- **Focus** — an entity you're deliberately building toward a deliverable (book, letter, …), with a tier and target. **You are the primary Focus** — your own life story is the biggest one and gets the largest share of questions; self-knowledge (values, fears, contradictions, growth) is a built-in dimension of it, not a separate track.
+- **Project** — a Focus whose deliverable is a composite piece built up over time. Today that's the book: your categories become chapters. A project is virtual while you're planning it — readiness is computed live from the roadmap and answered material — and becomes a concrete, versioned piece once `book-assemble` stitches the latest chapter drafts together.
+- **Piece** — a single versioned work in the Studio: a letter, tweet, essay, or chapter draft. Lives under `outputs/<slug>/` as `v1.md`, `v2.md`, ... revisions, with AI-assisted revise, mark-final, and promote-back-to-source. The code/CLI term is unchanged: **artifact** (`system/lifehug.py artifact ...`, `sources/artifacts/`).
+- **Studio** — the single workspace for making pieces and projects: grouped by Focus, project cards expand into a chapter table, piece cards keep their version/revision history, and a create form starts new pieces.
+- **Entity graduation / node graduation** — the wiki grows itself: entities mentioned across your answers are detected, **AI-curated** into a roster (`lifehug.py entity-roster --type <t>`), and graduated into node pages built from those mentions. Places and periods graduate on a low bar (a few mentions); **objects** graduate on AI-judged symbolic meaning (e.g. *The Cleats*), not frequency; people on score; **themes** via an AI-curated keyword roster (v97) — new themes like *Parenting* emerge from opinions, essays, and classifier extractions. Relationship edges use a dyadic path: Focus relationships can graduate from dedicated answers or enough cross-story mentions about the person. Rosters refresh monthly; compile graduates the current roster entries into pages — no manual work.
+- **The Loop** — the canonical continuous-learning cycle: capture source → compile wiki → lint/repair source truth → classify/score signals → promote candidates and plan the queue → ask a better question → create artifacts → feed final artifacts back as source. When we ask whether a feature "works in the Loop," we mean this path.
+- **In the Loop** — code, state, or docs reached by the daily, weekly, monthly, or artifact flows without a human manually stitching it together, and whose output can affect future questions, wiki pages, relationship understanding, or artifacts.
+- **Loop-adjacent** — useful manual, dry-run, inspection, setup, or repair surfaces. They support the Loop but do not change future behavior until their output is promoted into a Loop surface.
+- **Out of the Loop** — code or data that exists but is not called by scheduled/manual Loop entrypoints and is not read by downstream Loop state. Mission-critical work should not stay here; wire it in or document it as experimental.
+- **Interaction** — a role definition for the AI in one situation: purpose, behavior contract, context recipe, scope, and evals, packaged as files any qualified model can execute. The definition lives in the framework (`interactions/<name>/`); each runtime loads it; a model is "seated" in it only after passing its eval harness. Out-of-scope input is politely deflected. Three today: **conversation** (chats + longer sessions), **question judgment** (which follow-up candidates deserve to exist, and how urgently — ADR 0007), and **focus curation** (judging first-encounter Focus/idea duplicate name variants the deterministic layers can't resolve — ADR 0010).
+- **Chat** — the short exchange around the daily question: system-initiated, ~3 exchanges, arc-carded, graceful third-turn exit, closing takeaway.
+- **Conversation** — a long user-initiated session (a story, "something on your mind", or a thread the system offered); runs the full interviewer arc; closes with a narrative takeaway.
+- **Arc card** — the pre-planned skeleton for a chat/conversation: opening framing + 2–4 follow-up *intents* (not scripted text), planned by the loops, executed live per turn.
+- **Session** — one bounded run: open → turns → close; the durable record is the session document.
+
+---

--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -1,0 +1,30 @@
+---
+title: Handbook
+nav_order: 2
+has_children: true
+---
+
+# The Handbook
+
+One page per feature, every page in the same seven-section shape (see the
+[home page](../) for the template). Pages land here as they are written;
+each is its own reviewed PR with its numbers parity-tested.
+
+Planned pages, in build order:
+
+| Page | Covers |
+|---|---|
+| Question Candidates | the review buffer, the unified quality score, auto-promotion, parks |
+| Focuses & the Autopilot | ideas, scoring, keep-N-in-development, dedupe, merge |
+| The Mission & the Convergence Principle | the three purposes; floor and accelerator |
+| The Loop | the canonical cycle, the three clocks, In/adjacent/Out taxonomy |
+| Interactions | the pattern; Conversation, Question-Judgment, Focus-Curation |
+| Quality & Engagement Profile | answer richness, multipliers, rumination |
+| Neighborhoods | the question-supply unit and its arcs |
+| Entities & Graduation | rosters, thresholds, wiki pages |
+| Conversations & the Day Model | chats, sessions, the daily reset |
+| Decisions & Learning | the weekly rubric edit; how owner decisions teach the system |
+
+Until a page exists, its territory is covered by the
+[README](https://github.com/lifehug/lifehug#readme) and the
+[ADRs](https://github.com/lifehug/lifehug/tree/main/docs/adr).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+---
+title: Home
+nav_order: 1
+---
+
+# How Lifehug Works
+
+Lifehug is a lifelong AI oral-history system organized around **the
+Loop**: daily answers become durable sources, sources become a private
+wiki and structured signals, signals become better questions, and better
+questions deepen the life story.
+
+This site is the **handbook of its mechanics** — one page per feature,
+each answering the same questions in the same order, so that anyone
+(including a future maintainer with zero context) can read one page and
+hold that feature's complete picture:
+
+1. **What it does & what it's for** — the feature's job, and the main
+   use case told from the user's seat.
+2. **The nouns** — every term the feature owns, defined once, linked to
+   the [Glossary]({% link handbook/glossary.md %}).
+3. **How it works** — the mechanism: lifecycle, clock, files.
+4. **The algorithm** — the real formula with the real numbers, and a
+   worked example.
+5. **In the loop** — what feeds it, what it feeds, how it self-improves,
+   and its [Convergence Principle](https://github.com/lifehug/lifehug/blob/main/docs/adr/0006-convergence-principle.md)
+   classification (floor or accelerator).
+6. **Where it lives** — code map, state files, commands, guard tests.
+7. **Decisions** — the ADRs and owner rulings that bind it.
+
+## Kept honest by construction
+
+Two structural guarantees keep this site from drifting into fiction:
+
+- **Interaction pages embed their `behavior.md` files** — in the
+  Interaction pattern the documentation *is* the prompt, so those pages
+  cannot disagree with what the model is actually told.
+- **Every quoted algorithm number is parity-tested.** Handbook pages
+  annotate their numbers with an HTML comment of the shape
+  `parity: <module>.<CONSTANT> = <value>`, and
+  `tests/test_handbook_parity.py` asserts each against the live
+  constant — a code change that moves a number fails CI until the page
+  moves with it.
+
+For example, the candidate auto-promotion bar quoted across this site is
+**0.82** <!-- parity: question_candidates.AUTO_PROMOTE_THRESHOLD = 0.82 -->
+and the focus-idea ready floor is
+**8.0** <!-- parity: recommend_focuses.FOCUS_READY_SCORE_FLOOR = 8.0 --> —
+both statements are enforced, not remembered.
+
+## The raw record
+
+The [ADRs](https://github.com/lifehug/lifehug/tree/main/docs/adr) are the
+binding decision log and the [pr-specs](https://github.com/lifehug/lifehug/tree/main/docs/pr-specs)
+are the contracts features were built against. Handbook pages link into
+them; they remain the authority when prose and record disagree.

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 171,
+  "version": 172,
   "released": "2026-08-15",
-  "changelog": "v171: README accuracy pass for the v163\u2013v170 sprint \u2014 no behavior change, docs only. README.md and AGENTS.md now describe: the three shipped Interactions (conversation, question_judgment ADR 0007, focus_curation ADR 0010), the unified quality-score stamping detail (ADR 0008), weekly maintenance's judgment-update RUBRIC-EDIT step (ADR 0009) run right after quality-update and before candidate promotion, focus-autopilot's MONTHLY cadence (ADR 0011 as amended 2026-08-15, run after recommend-focuses and before the roster refresh \u2014 it is no longer a weekly step), the Review lane's fourth duplicate-focuses lane with its Combine button (ADR 0012), the new focus-autopilot/focus-dupes/focus-curate/focus-merge/judgment-update commands and their backing scripts, and the Convergence Principle (ADR 0006) as the framing for the Loop's self-improvement and for owner decisions as consumed accelerator signal.",
+  "changelog": "v172: the How-Lifehug-Works handbook site scaffold (GitHub Pages from /docs, just-the-docs): landing page with the seven-section per-feature template, handbook index with the planned page list, Glossary seeded verbatim from the README's nomenclature, ADRs/pr-specs browsable but out of the sidebar, and the doc-parity harness (tests/test_handbook_parity.py) \u2014 every algorithm number a handbook page quotes is annotated and asserted against the live module constant, so the site cannot drift from the code.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_handbook_parity.py
+++ b/tests/test_handbook_parity.py
@@ -1,0 +1,68 @@
+"""The handbook's honesty gate.
+
+Handbook pages under docs/ annotate every quoted algorithm number:
+
+    <!-- parity: module.CONSTANT = value -->
+
+This suite finds every annotation, imports the named system/ module, and
+asserts the live constant equals the quoted value — so a code change that
+moves a number fails CI until the handbook page moves with it, exactly
+like app-side parity tests keep served constants honest. A page with no
+annotations costs nothing; a page quoting an unannotated number is a
+review problem, not a test problem.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+SYSTEM = ROOT / "system"
+
+_ANNOTATION = re.compile(
+    r"<!--\s*parity:\s*([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)\s*=\s*([^\s]+)\s*-->"
+)
+
+
+def _annotations() -> list[tuple[Path, str, str, str]]:
+    found = []
+    for page in sorted(DOCS.rglob("*.md")):
+        text = page.read_text(encoding="utf-8", errors="replace")
+        for match in _ANNOTATION.finditer(text):
+            found.append((page, match.group(1), match.group(2), match.group(3)))
+    return found
+
+
+class HandbookParityTests(unittest.TestCase):
+    def test_the_harness_sees_the_seed_annotations(self):
+        # The scaffold ships with at least the two seed annotations on the
+        # landing page; an empty scan means the annotation grammar broke.
+        self.assertGreaterEqual(len(_annotations()), 2)
+
+    def test_every_quoted_number_matches_the_live_constant(self):
+        if str(SYSTEM) not in sys.path:
+            sys.path.insert(0, str(SYSTEM))
+        for page, module_name, const_name, quoted in _annotations():
+            with self.subTest(page=page.name, constant=f"{module_name}.{const_name}"):
+                module = importlib.import_module(module_name)
+                live = getattr(module, const_name)
+                try:
+                    expected: object = type(live)(quoted)
+                except (TypeError, ValueError):
+                    expected = quoted
+                self.assertEqual(
+                    live,
+                    expected,
+                    f"{page} quotes {module_name}.{const_name} = {quoted} "
+                    f"but the code says {live!r} — update the page (or the "
+                    f"annotation) alongside the code change",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Owner-directed: the navigable per-feature mechanics site. Scaffold only — Pages config (/docs, just-the-docs remote theme, GitHub-built, zero repo dependencies), landing page with the seven-section template (what it does & the user's main use case → nouns → how it works → the algorithm with worked examples → in the loop → where it lives → decisions), handbook index with the build-order page list, Glossary seeded verbatim from README nomenclature, and the honesty gate: tests/test_handbook_parity.py asserts every parity-annotated number on any docs page against the live module constant (two seed annotations prove it; the harness already caught its own docs example during development). Feature pages follow as content PRs, Question Candidates and Focuses first.

After merge: enable Pages (main /docs) — site at https://lifehug.github.io/lifehug/.

🤖 Generated with Claude Fable 5 via Claude Code