### PR TITLE
docs(handbook): Question Candidates + Focuses & the Autopilot

### DIFF
--- a/docs/handbook/focuses.md
+++ b/docs/handbook/focuses.md
@@ -1,0 +1,380 @@
+---
+title: Focuses & the Autopilot
+parent: Handbook
+nav_order: 2
+---
+
+# Focuses & the Autopilot
+
+## 1. What it does & what it's for
+
+Say you never open the wiki viewer. You just answer the daily question,
+day after day, and across a few months you keep mentioning your Uncle
+Mike — sometimes by name, sometimes as "my uncle" — in three different
+answers, in two different categories, always with real feeling attached
+("I still miss him," "he was the one who taught me to fish"). Nothing
+about your daily experience changes: you're just answering questions.
+But underneath, `recommend_focuses.py` has been watching every answer,
+source, and classification for exactly this pattern, and it has scored
+Uncle Mike high enough to be a genuinely strong idea for a dedicated
+[Focus](glossary.md) — a person worth its own questions, its own arc,
+eventually a letter or a chapter. Because you never open the Review lane
+to approve it yourself, the monthly autopilot does it for you: it
+scaffolds a new question-bank category for Uncle Mike, registers him in
+your roadmap, and (when a model is available) generates a first batch of
+starter questions — all without you lifting a finger beyond the answers
+you were already giving. If you *do* open the Review lane, approving a
+pending idea manually works exactly the same way, any time, and a
+dismissal is a permanent veto the autopilot can never override.
+
+That's the job of this feature: turn the patterns already visible in what
+you've said into new, deliberately-pursued threads of the story — for an
+engaged user who reviews ideas by hand, and just as reliably for a
+passive one who never does.
+
+## 2. The nouns
+
+A **[Focus](glossary.md)** is the unit of intent — anything you're
+building toward, with a **tier** (`basic`/`standard`/`extreme`, setting
+its default target depth of 8/20/50 answers) and a target category (or
+categories) in the question bank. See the [Glossary](glossary.md) for the
+full definition; this page covers how new Focuses come to exist and how
+their progress is judged.
+
+A **recommendation** (an "idea" or "pending idea" in this page's prose) is
+a single scored row in `state/focus_recommendations.json` — an entity
+(`person`/`place`/`period`/`theme`) the pattern-watcher has noticed,
+carrying its `score`, `evidence_strength` band, the evidence snippets that
+justify it, and a `status` (`pending`, `approved`, or dismissed/expired,
+tracked separately). A recommendation only becomes a Focus through
+**approval** (§4) — never automatically materialized just for existing.
+
+**Evidence strength** is a three-band label on a recommendation's score:
+`weak`, `moderate`, or `strong` (§4 gives the exact cutoffs). It's
+informational — the number that actually gates approval is the floor
+(§4), not the band label.
+
+**Saturation** is how full a Focus is relative to its target depth —
+`answered ÷ target_depth`, computed live by `roadmap.focus_fill()`, never
+stored. A **verdict** (`progress.py`) turns saturation into a label:
+`EARLY` (still needs more answers), `DEVELOPING` (building material),
+`READY` (ready to draft), or `SATURATED` (at/above target — maintenance
+territory). The **developing set** is the specific subset of Focuses the
+autopilot cares about: active, non-primary, and below the `READY`
+threshold (§4) — a deliberately narrower question than the verdict alone
+answers (see §4's note on why it's not identical to the completion gate's
+own definition).
+
+**The autopilot** is `recommend_focuses.focus_autopilot()` — the
+mechanism that approves a pending idea on its own when the developing set
+is thinner than a target, described fully in §4.
+
+**Dedupe** happens in three independent layers, applied in that order,
+each catching what the layer before it structurally cannot (ADR 0010):
+**door guards** (deterministic — every Focus-creation path refuses an
+exact/case/prefix-variant name collision against an *existing* Focus),
+the **roster fold** (deterministic — settled alias knowledge from the
+monthly-curated entity rosters merges two pending ideas the roster already
+knows are one entity, before either is even scored), and **the
+Focus-Curation Interaction** ("JUDGE" — the residue neither deterministic
+layer resolves: near-name pairs like "Betty Jo" vs. "Betty Jo Taylor" that
+have no settled roster alias yet). Said honestly: the JUDGE layer is the
+only one of the three with **no deterministic fallback at all** — it
+requires an actual model call (in-process, or via the keyless
+`--emit-task`/`--from-response` loop a human or agent completes by hand).
+Absent AI, a near-name pair simply sits apart correctly rather than being
+merged on a guess; the roster fold is the floor.
+
+**`focus-merge`** (ADR 0012) is the separate, owner-initiated verb that
+heals *existing* duplicate Focuses the three dedupe layers above didn't
+prevent — never automatic, and out of scope for this page beyond the
+mention (§4 covers its shape briefly; the transaction itself is a page of
+its own territory).
+
+Shared vocabulary this page relies on without redefining:
+**[Entity](glossary.md)**, **[Interaction](glossary.md)**, and
+**[The Loop](glossary.md)** / **[In the Loop](glossary.md)** are defined
+once in the [Glossary](glossary.md); the [Question Candidates](question-candidates.md)
+page covers the candidate/promotion vocabulary this page's starter
+questions flow into.
+
+## 3. How it works
+
+Idea generation, scoring, and approval are three separate steps, on two
+different clocks.
+
+**Idea extraction and scoring** (`recommend_focuses.recommend()`) reads
+every answer, manual source, and classification record; regex-extracts
+people (after relationship words like "mom"/"dad"/"boss"), places, time
+periods, and theme-keyword hits; and folds each hit's stats — mention
+count, which answers, which categories, and a window-based emotional-word
+weight — into one score per entity (§4's formula). Before scoring, those
+raw stats are folded through the roster-fold dedupe layer, and anything
+that already has a Focus or a compiled wiki page is dropped outright — a
+recommendation only proposes genuinely new territory.
+
+**Approval** (`approve_recommendation()`) is the one path that actually
+creates a Focus: it scaffolds a new question-bank category, registers the
+Focus in the roadmap, and — when a model is available — generates and
+promotes a first batch of starter questions via `research_expand.py`
+(falling back to a keyless emit-task when no model is in-process, never a
+silent no-op). Manual approval (CLI or the viewer's Review lane) and
+autopilot approval are the *same function call* with different
+provenance — no parallel scaffold path exists for either.
+
+**The monthly cadence** (ADR 0011, amended 2026-08-15): recommendation
+refresh, autopilot approval, entity-roster refresh, and recompile all run
+in one fixed order inside `monthly_research.sh`, so each step sees the
+freshest output of the one before it:
+
+```mermaid
+flowchart LR
+    A["recommend-focuses<br/>(rescore every entity,<br/>fold through the roster,<br/>refresh state/focus_recommendations.json)"]
+    B["focus-autopilot<br/>(approve the top idea IF the<br/>developing set is thin — at most one)"]
+    C["entity-roster refresh<br/>(person / place / period / object / theme)"]
+    D["compile<br/>(newly-approved Focus's starter<br/>questions + graduated entities land in the wiki)"]
+    A --> B --> C --> D
+```
+
+This single-clock design replaced a weekly autopilot call that mostly
+re-read a static list — the ideas supply itself only refreshes monthly,
+so a faster autopilot clock bought nothing. `weekly_maintenance.sh` still
+runs `recommend_focuses`' *sibling* steps that have nothing to do with
+Focus creation (candidate auto-promotion, the question-judgment rubric
+edit) on its own weekly cadence — see the
+[Question Candidates](question-candidates.md) page for that loop.
+
+**Rot control.** A *pending* recommendation that sits below the floor
+(§4) for the expiry window (§4) auto-dismisses, tagged with a structured
+`dismissed_by: "expiry"` marker — distinct from an owner's manual
+dismissal, which is a permanent veto the same recommendation can never
+recover from even if its score later improves. An expiry-dismissed idea
+*can* be re-proposed later, but only once fresh evidence genuinely clears
+the floor again — reappearing at the same weak score doesn't reset the
+clock.
+
+## 4. The algorithm
+
+### Idea scoring
+
+```
+score = mention_count × 1.0 + unique_answers × 2.0 + cross_categories × 3.0 + emotional_weight × 1.5
+```
+
+computed by `recommend_focuses._score()`. These four weights (`1.0`,
+`2.0`, `3.0`, `1.5`) are literal values inside that one function, not
+named module constants — like this page's sibling
+[Question Candidates](question-candidates.md#4-the-algorithm) page notes
+for its own craft-penalty table, an annotation naming a constant that
+doesn't exist would fail `tests/test_handbook_parity.py` rather than
+protect it, so these four numbers are quoted here from direct code
+reading. The intent behind the weights, in order: raw repetition counts
+least; being mentioned in *multiple distinct answers* counts double;
+showing up across *multiple different question categories* — i.e. this
+entity keeps surfacing no matter what you're being asked about — counts
+most; and emotional charge (a nearby hit from a fixed emotion-word list,
+within an 80-character window of the mention) counts one and a half times
+raw mentions.
+
+**Evidence-strength bands**, also literal values inside
+`recommend_focuses._evidence_strength()`: **strong** at `15` or above,
+**moderate** from `8` up to `15`, **weak** below `8`.
+
+**The ready floor** — the number that actually matters for both manual
+"ready to start" eligibility and autopilot eligibility — is a real named
+constant:
+8.0 <!-- parity: recommend_focuses.FOCUS_READY_SCORE_FLOOR = 8.0 -->.
+It isn't a coincidence that this equals the `moderate` band's own cutoff —
+the constant's docstring is explicit that the floor is *reused* from
+`_evidence_strength()`'s cutoff rather than being a second, competing
+threshold.
+
+**Rot-control expiry**: a pending recommendation below the floor for
+6 <!-- parity: recommend_focuses.FOCUS_RECOMMENDATION_EXPIRY_WEEKS = 6 -->
+weeks auto-dismisses.
+
+### The autopilot
+
+`focus_autopilot(target=None, dry_run=False, *, catch_up=False)`:
+
+```
+while len(developing) + len(taken) < target:
+    idea = highest-scoring pending recommendation at/above the floor
+    if no such idea, or the per-run cap is spent: stop
+    approve it (via approve_recommendation(), approved_by="auto")
+```
+
+- **Target** —
+  3 <!-- parity: recommend_focuses.AUTOPILOT_TARGET_DEVELOPING = 3 -->,
+  the owner-ratified "keep this many Focuses in active development"
+  number, overridable per-vault via `config.yaml`'s
+  `focus_autopilot_target` (an explicit `--target` flag always wins over
+  both).
+- **Developing** = active (`phase` is not `"maintenance"`), non-primary,
+  and saturation strictly below
+  0.70 <!-- parity: progress.READY = 0.70 --> (the `READY` verdict cutoff,
+  §4's next subsection). This deliberately does **not** carry the
+  completion gate's own extra exemption for a Focus with zero pending
+  questions ("exhausted, not unfinished") — the developing *set* is
+  answering a different question, "how many Focuses are currently in
+  active growth," where an exhausted-but-unsaturated Focus still counts.
+- **Floor** — the same
+  8.0 <!-- parity: recommend_focuses.FOCUS_READY_SCORE_FLOOR = 8.0 -->
+  reused from idea scoring above, never a second threshold.
+- **Per-run cap** —
+  1 <!-- parity: recommend_focuses.AUTOPILOT_MAX_PER_RUN = 1 -->, gentle
+  by default: the target is reached over successive monthly runs, never
+  in one burst. `--catch-up` (manual CLI only, never wired into the
+  scheduled run) raises the effective cap to `target` for an
+  everything-answered, idle-queue catch-up in one pass.
+- **Cadence** — **monthly**, per
+  [ADR 0011's amendment](https://github.com/lifehug/lifehug/blob/main/docs/adr/0011-focus-autopilot.md#amendment-2026-08-15-owner-ratified--issue-154):
+  the algorithm shipped weekly in the original ADR, then moved to monthly
+  once the owner reasoned that Focus creation is rare and high-weight
+  while the ideas supply itself only refreshes monthly — one clock now
+  rules the whole Focus lifecycle (§3's pipeline diagram).
+- **Idempotent by construction** — no cursor file. A real approval
+  scaffolds a Focus that itself immediately counts toward `developing`
+  the moment the roadmap is re-read, so a second run the same month
+  naturally sees a thinner gap (or an empty pending list) purely from
+  durable state.
+- `dry_run=True` computes and returns the identical decision — which idea
+  it would approve and why — without writing anything.
+
+### Tiers, saturation, and verdicts
+
+| Tier | Target depth |
+|---|---|
+| `basic` | 8 answers |
+| `standard` | 20 answers |
+| `extreme` | 50 answers |
+
+(`roadmap.TIER_TARGETS` — a dict, not individually parity-annotatable
+under this site's `module.CONSTANT = scalar` grammar, but verified
+directly against the code, not remembered.)
+
+`progress.verdict(saturation)` maps a Focus's live saturation ratio to a
+label:
+
+| Verdict | Saturation |
+|---|---|
+| `EARLY` | below 0.40 <!-- parity: progress.DEVELOPING = 0.40 --> |
+| `DEVELOPING` | 0.40 up to 0.70 <!-- parity: progress.READY = 0.70 --> |
+| `READY` | 0.70 and above (and not yet saturated) |
+| `SATURATED` | saturation ≥ 1.0 |
+
+### Worked example
+
+Take a plausible pattern the extractor has been accumulating for "Uncle
+Mike" across a few months of answers:
+
+- `mention_count = 6` (six separate hits across answers, sources, and one
+  classification record)
+- `unique_answers = 3` (three distinct answer files reference him)
+- `cross_categories = 2` (he comes up under two different question-bank
+  categories — not just the one you'd expect)
+- `emotional_weight = 2.5` (a handful of nearby emotion-word hits —
+  "miss," "loved," "proud" — each contributing to the window score)
+
+```
+score = 6 × 1.0 + 3 × 2.0 + 2 × 3.0 + 2.5 × 1.5
+      = 6 + 6 + 6 + 3.75
+      = 21.75
+```
+
+**Evidence strength**: `21.75 ≥ 15` → **strong**. **Floor eligibility**:
+`21.75 ≥ 8.0` → this recommendation is eligible for `ready_to_start`
+(once the completion gate — §5 note — is open) and is a genuine autopilot
+candidate. If, that same month, your developing set has room (fewer than
+3 Focuses currently active/unsaturated/non-primary) and this is the
+highest-scoring pending idea, `focus_autopilot()` approves it on its own:
+a new "Uncle Mike" category is scaffolded, the Focus lands in your
+roadmap at `standard` tier by default (20-answer target — the size
+heuristic derives from how many questions the category already carries,
+`tier_for_size()`), and starter questions are generated and promoted
+straight into the bank, ready for next week's planner.
+
+## 5. In the loop
+
+**What feeds it:** every answer, manual source, and weekly classification
+record — the same raw material that feeds candidate generation
+([Question Candidates](question-candidates.md)) also feeds idea
+extraction here, read independently by `_build_entity_stats()`.
+
+**What it feeds:** the roadmap (a new Focus, or an existing one's category
+list), the question bank (starter questions), and downstream, the weekly
+planner's Focus-weighted queue — a Focus the autopilot just created is
+immediately eligible for next week's question selection.
+
+**How it self-improves:** the roster fold means idea extraction gets
+*more* accurate over time without any change to the extraction regexes
+themselves — as the monthly entity-roster curation resolves more aliases,
+fewer duplicate ideas are ever proposed in the first place, which is a
+form of self-improvement this page's dedupe layers (§2, §3) produce as a
+side effect of an entirely separate monthly process.
+
+**Classification (Convergence Principle):** the autopilot itself is what
+retired this feature's own **floor** gap. Before ADR 0011, Focus creation
+was approval-only — "never created without you" — which ADR 0006 named
+outright as a stage that silently required a human to make progress. The
+autopilot is now the floor: a passive user who never opens the Review
+lane still gets new Focuses, gated only by a target count and a score
+floor, at a gentle one-per-month pace. Manual approval remains the
+**accelerator** — it works identically, any time, unlimited, and a
+dismissal is a permanent veto the autopilot can never override — the
+Convergence Principle's promise that manual signal speeds up the same
+convergence without ever becoming a dependency.
+
+*Adjacent note on scope:* Focus **creation** (this page) is autonomous by
+design. A related but distinct mechanism, the **completion gate**
+(`focus_start_gate()`), separately decides whether starting something new
+is "allowed" *this week* given your existing unfinished Focuses — every
+active, non-primary Focus that still has pending questions must be
+`READY` or `SATURATED` first. It shares vocabulary with the developing-set
+definition in §4 (both lean on `roadmap.focus_fill()` and
+`progress.verdict()`) but is not the same gate: the completion gate
+additionally exempts a Focus with zero pending questions as "exhausted,
+not unfinished," which §4's developing-set definition deliberately does
+not.
+
+## 6. Where it lives
+
+| Concern | Location |
+|---|---|
+| Recommendation state | `state/focus_recommendations.json` |
+| Roadmap (Focuses, tiers, saturation is derived live) | `state/roadmap.json` |
+| Idea extraction + scoring | `recommend_focuses._build_entity_stats()`, `_score()`, `_evidence_strength()` |
+| Roster-fold dedupe | `recommend_focuses._fold_stats_through_roster()` |
+| Door-guard dedupe | `lifehug_core.normalized_focus_key()`, `roadmap.focus_new()`, `roadmap.derive_focuses()` |
+| Focus-Curation Interaction (JUDGE dedupe) | `interactions/focus_curation/`, `focus_curation.py` |
+| Duplicate detection/report (zero-write) | `focus_dupes.py` (`focus-dupes --report`) |
+| Duplicate healing (owner-initiated) | `focus_merge.py` (`focus-merge <survivor> <loser>`) |
+| Approval + scaffolding | `recommend_focuses.approve_recommendation()`, `roadmap.focus_new()` |
+| Autopilot | `recommend_focuses.focus_autopilot()`, `resolve_autopilot_target()` |
+| Saturation / verdicts | `roadmap.focus_fill()`, `progress.verdict()` |
+| CLI | `lifehug.py recommend-focuses [--recommend\|--dismiss\|--approve\|--autopilot [--dry-run\|--catch-up]\|--target N]`, `roadmap [show\|rebuild\|add\|set\|finish\|new]`, `focus-dupes --report`, `focus-merge <survivor> <loser> [--dry-run]` |
+| Monthly wiring | `monthly_research.sh` — `recommend-focuses` → `focus-autopilot` → entity-roster refresh → `compile` |
+| Interaction | [`interactions/focus_curation/`](https://github.com/lifehug/lifehug/tree/main/interactions/focus_curation) (ADR 0010) |
+| Guard tests | `tests/test_focus_autopilot.py`, `tests/test_focus_dupes.py`, `tests/test_focus_merge.py`, `tests/test_roadmap.py` (repo-verify exact names before citing in a PR) |
+
+**Change-safely notes.** `AUTOPILOT_TARGET_DEVELOPING`,
+`FOCUS_READY_SCORE_FLOOR`, and `AUTOPILOT_MAX_PER_RUN` are read live by
+every consumer (CLI display, the viewer's Review-lane policy line) — a
+restated literal anywhere else is a regression of ADR 0011, not a
+legitimate shortcut. Any future Focus-approval path must call
+`approve_recommendation()` itself rather than a parallel scaffold — that
+is what keeps zombie protection (a Focus with no question category) and
+starter-question seeding automatic for autopilot approvals too. Any
+future entity/alias-matching code must reuse
+`lifehug_core.normalized_focus_key()` / `entity_roster._entity_keys()`
+rather than re-deriving a second lowercase/slugify/"the "-strip
+definition — that collision class is exactly what ADR 0010 exists to
+foreclose.
+
+## 7. Decisions
+
+- [ADR 0006 — The Convergence Principle](https://github.com/lifehug/lifehug/blob/main/docs/adr/0006-convergence-principle.md) — names Focus creation as the original approval-only gap this page's feature closes.
+- [ADR 0010 — Focus Duplicate Curation](https://github.com/lifehug/lifehug/blob/main/docs/adr/0010-focus-duplicate-curation.md) — the three-layer dedupe in §2/§3.
+- [ADR 0011 — Focus Autopilot](https://github.com/lifehug/lifehug/blob/main/docs/adr/0011-focus-autopilot.md), including its [2026-08-15 monthly-cadence amendment](https://github.com/lifehug/lifehug/blob/main/docs/adr/0011-focus-autopilot.md#amendment-2026-08-15-owner-ratified--issue-154) — the algorithm in §4.
+- [ADR 0012 — focus-merge](https://github.com/lifehug/lifehug/blob/main/docs/adr/0012-focus-merge.md) — the owner-initiated healing verb mentioned in §2/§6, out of this page's own scope beyond the pointer.
+- The hosted platform's review-loop contracts (parallel PR review, owner closeout, executable walkthroughs) this feature's Review lane and Combine button are built against: [`lifehug-platform` docs/BUILDING.md](https://github.com/lifehug/lifehug-platform/blob/main/docs/BUILDING.md) and [docs/REVIEWING.md](https://github.com/lifehug/lifehug-platform/blob/main/docs/REVIEWING.md) (external repo — the platform orchestrates this package, never forks it).

--- a/docs/handbook/question-candidates.md
+++ b/docs/handbook/question-candidates.md
@@ -1,0 +1,390 @@
+---
+title: Question Candidates
+parent: Handbook
+nav_order: 1
+---
+
+# Question Candidates
+
+## 1. What it does & what it's for
+
+Lifehug never asks you a question the moment it's thought of. Every
+follow-up idea the system generates — from the weekly source classifier,
+the monthly research expander, the wiki's own "Open Questions" sections, a
+conversation's closing takeaways, even a hand-typed idea — lands first in a
+**review buffer**, not the daily prompt. That buffer is what this page is
+about.
+
+Here's the ordinary path one idea takes. You answer today's question about
+your first job, and in passing you mention that your first boss "was like a
+second father to me." The weekly classifier reads that answer, notices the
+relationship claim has no supporting scene behind it, and drops a candidate
+into the buffer: *"Tell me about one specific day your boss treated you like
+family instead of an employee."* You never see this happen. A few days
+later, `weekly_maintenance.sh` runs its auto-promotion pass, scores that
+candidate, finds it clears the bar, and inserts it into the question bank
+as a real, numbered question — it will reach you the next time the planner
+has room for that category. If the same candidate had scored a little
+lower — vaguer phrasing, no cited source, a near-duplicate of something you
+already answered — it would instead sit, visibly, in your wiki viewer's
+Review lane, waiting for you to promote, dismiss, or defer it yourself.
+Either way, the idea is never silently lost, and you never have to open a
+review screen for the system to keep asking you better questions.
+
+That's the job of this feature: let the system propose freely, without
+ever putting an unreviewed idea in front of you as a daily question, and
+guarantee that a genuinely good idea reaches the bank whether or not you
+personally look at it.
+
+## 2. The nouns
+
+A **candidate** is a proposed question sitting in the review buffer
+(`state/question_candidates.json`) — not yet a real, askable question. It
+becomes one only by **promotion**: either a human running
+`candidates-promote`, or the system's own **auto-promotion** during weekly
+maintenance. Every candidate carries a `kind` (what generated it — a
+classification, a research neighborhood, a wiki open question, …), a
+`source_path`, a `priority`, a `story_function`, and — once scored — a
+stamped `quality` block (score, components, timestamp; see §4).
+
+**Status.** A candidate's `status` is one of the values below (the module's
+full `VALID_STATUSES` vocabulary):
+
+| Status | Meaning |
+|---|---|
+| `candidate` | The default — proposed, unreviewed, still competing. |
+| `accepted` | A human said yes but hasn't picked a target category yet — still promotable. |
+| `deferred` | Explicitly parked with a `defer_until` date (e.g. right after a fresh loss — "not yet"); exempt from expiry until that date passes. |
+| `needs_review` | **Parked** — see below. |
+| `promoted` | Inserted into the question bank by a human. Terminal — cannot move to any other status. |
+| `auto_promoted` | Inserted into the bank by the weekly auto-promotion run. Also terminal. |
+| `rejected` | A human said no. |
+| `expired` | Aged out unpromoted (§3) — kept for audit, no longer competes. |
+| `superseded` | A template candidate whose source later earned a stronger, classifier-grade extraction of the same material — kept, never deleted, but excluded from promotion. |
+
+**Park** means a candidate is moved to `needs_review`: not rejected, not
+promoted, waiting for a human's eye. A candidate parks for one of two kinds
+of reason — a **score reason** (its unified score landed in the review
+band, §4) or a **structural reason** (an exact/near-duplicate, or no
+category could be inferred for it). This distinction matters for
+resurfacing: score-parked candidates are re-scored on every subsequent
+auto-promotion run (the quality profile shifts weekly, so a near-miss can
+clear the bar later without a human touching it — the *floor* half of the
+[Convergence Principle](https://github.com/lifehug/lifehug/blob/main/docs/adr/0006-convergence-principle.md));
+structurally-parked candidates wait for a human, because no amount of
+re-scoring resolves "this needs a category" or "this duplicates something
+else."
+
+**Promotion** is the act of turning a candidate into a real, numbered
+question-bank entry, with a provenance comment recording which candidate it
+came from and when. **Auto-promotion** is promotion the system performs
+itself, unattended, during `weekly_maintenance.sh` — the no-human path the
+Convergence Principle requires this stage to have.
+
+A **neighborhood** is the other object candidates are born from as
+often as they're born from a single answer: a cluster of 6–12 questions
+along a narrative arc, aimed at one deliverable. **Neighborhood-as-supply**
+is the idea that a neighborhood is not itself askable — it is a generator
+that deposits its slots into the candidate buffer exactly like any other
+source, and its own readiness status (`questions_generated` →
+`promoted` → `answering` → `answer_ready`) is derived by walking the same
+candidate → promoted-question → answered-source lifecycle this page
+describes, one arc slot at a time. A neighborhood can be fully
+question-ready long before it's answer-ready — `progress` only calls it
+draft-ready once enough of its slots have real answers behind them, never
+merely because its candidates were generated.
+
+Shared vocabulary this page relies on without redefining: **[Focus](glossary.md)**,
+**[Entity](glossary.md)**, **[Interaction](glossary.md)**, and
+**[The Loop](glossary.md)** are all defined once in the
+[Glossary](glossary.md).
+
+## 3. How it works: the weekly lifecycle
+
+Every eligible candidate is re-scored on every `candidates-auto-promote`
+run (the weekly maintenance job's `auto_promote` step, run after
+classification, the quality-profile update, and the question-judgment
+rubric edit — so it always sees the freshest inputs). "Eligible" means
+`status` is `candidate`, `accepted`, or `deferred` (the `PROMOTABLE_STATUSES`
+set) — or `needs_review` with a score-based parking reason, which is
+resurfaceable.
+
+```mermaid
+stateDiagram-v2
+    [*] --> candidate: source generates it\n(gap · story · classification ·\nwiki harvest · conversation)
+
+    candidate --> expired: unpromoted > max age\n(deferred candidates exempt)
+    candidate --> needs_review: exact/near-duplicate,\nor no category inferred\n(structural park)
+
+    state score_gate <<choice>>
+    candidate --> score_gate: weekly auto-promote run
+    score_gate --> auto_promoted: score at/above\nauto-promote threshold\n(and under the weekly + per-neighborhood cap)
+    score_gate --> needs_review: score in the review band\n(score park)
+    score_gate --> candidate: score below the review band\n(stays, tries again next run)
+    score_gate --> candidate: cap already spent this run\n(weekly or per-neighborhood)
+
+    needs_review --> score_gate: score-parked → re-scored\nevery subsequent run
+    needs_review --> promoted: human promotes manually
+    needs_review --> rejected: human rejects
+    needs_review --> expired: unpromoted > max age\n(structural parks age out too)
+
+    candidate --> promoted: human promotes manually\n(overrides the automated ladder)
+    candidate --> rejected: human rejects
+    candidate --> deferred: human defers\n(defer_until date)
+    deferred --> candidate: defer_until passes
+    candidate --> superseded: a stronger classifier-grade\nextraction supersedes a template
+
+    auto_promoted --> [*]
+    promoted --> [*]
+    rejected --> [*]
+    expired --> [*]
+    superseded --> [*]
+```
+
+The three numbers that drive this diagram: the auto-promote threshold is
+0.82 <!-- parity: question_candidates.AUTO_PROMOTE_THRESHOLD = 0.82 -->,
+the review band starts at
+0.70 <!-- parity: question_candidates.NEEDS_REVIEW_THRESHOLD = 0.70 -->
+(so `0.70 ≤ score < 0.82` parks, below `0.70` simply stays a candidate),
+and the max unpromoted age before expiry is
+45 <!-- parity: question_candidates.CANDIDATE_MAX_AGE_DAYS = 45 --> days
+(§4 derives the score; the numbers aren't inlined into the diagram itself
+because Mermaid's state-diagram syntax reads a bare `-->` as an arrow
+token, which an HTML comment's own `-->` would collide with).
+
+Two mechanisms keep this from ever silently jamming:
+
+- **Deferred exemption.** A candidate with `defer_until` set in the future
+  is invisible to both the promotion ladder and the 45-day expiry clock —
+  a human explicitly said "wait," and the system honors that literally
+  rather than aging the idea out from under them.
+- **Structural vs. score parks resurface differently.** Only parks whose
+  `needs_review_reason` contains `"score"` or `"quality"` are re-scored
+  automatically (`RESURFACEABLE_REVIEW_REASONS`); a `missing_category` or
+  `near_duplicate` park waits for a real decision, because re-running the
+  same score computation can't resolve either.
+
+Structural parks run first, every week, in this fixed order: exact
+duplicate (skipped outright — it's already in the bank), near-duplicate by
+token-Jaccard overlap (parked), missing category (parked). Only candidates
+that survive all three reach the score gate. Within the score gate, a
+weekly cap (`dynamic_weekly_cap`, scaling from 1 promotion when the bank
+has over 120 unanswered questions up to 4 when it has fewer than 40, with a
+backlog-drain override that can push it as high as 8) and a per-neighborhood
+cap (normally 1, doubled to 2 once the promotable backlog crosses 40 —
+`PER_NEIGHBORHOOD_CAP` <!-- parity: question_candidates.PER_NEIGHBORHOOD_CAP = 1 -->
+/ `PER_NEIGHBORHOOD_CAP_BACKLOG` <!-- parity: question_candidates.PER_NEIGHBORHOOD_CAP_BACKLOG = 2 -->,
+`BACKLOG_PRESSURE_THRESHOLD` <!-- parity: question_candidates.BACKLOG_PRESSURE_THRESHOLD = 40 -->)
+keep one prolific source or one loud topic from eating the whole week's
+promotions. The weekly-cap band cutoffs themselves (120 / 80 / 40 unanswered,
+mapping to caps of 1 / 2 / 3 / 4) are literal values inside
+`dynamic_weekly_cap()`, not named module constants — quoted here from the
+function body directly (see §4's note on why this page doesn't force a
+parity annotation onto a number with nothing to check it against).
+
+## 4. The algorithm
+
+### The unified quality score (ADR 0008)
+
+Every candidate's promotability collapses to one number:
+
+```
+score = clamp(priority × story_function_multiplier − penalty_total, 0, 1)
+```
+
+computed by `question_candidates.unified_quality_score()`. Before
+[ADR 0008](https://github.com/lifehug/lifehug/blob/main/docs/adr/0008-unified-quality-score.md),
+this was two disconnected numbers with two separate gates; now craft flaws
+drag the same score down instead of tripping a parallel check, and the
+result is stamped onto the candidate (`candidate["quality"]`) additively
+and idempotently — a run that changes nothing about a candidate's inputs
+never re-timestamps it.
+
+**`priority`** (0.0–1.0) comes from whatever generated the candidate — the
+classifier, the research expander, or (once seated) the
+[question-judgment interaction](https://github.com/lifehug/lifehug/blob/main/interactions/question_judgment/prompt/behavior.md),
+whose priority vocabulary runs 0.4 (nice-to-have) to 0.95 (critical gap).
+
+**`story_function_multiplier`** comes from `quality_profile.py`'s weekly
+aggregation: once at least
+20 <!-- parity: quality_profile.ACTIVATION_THRESHOLD = 20 --> answers have
+been scored for richness, each story function (scene, tension, foundation,
+…) gets a multiplier — how much richer answers to that *kind* of question
+have historically been versus the global average — clamped to
+[0.7 <!-- parity: quality_profile.MULTIPLIER_FLOOR = 0.7 -->,
+1.5 <!-- parity: quality_profile.MULTIPLIER_CAP = 1.5 -->]. Before
+activation (or when a candidate's story function has no bucket yet), the
+multiplier is simply 1.0.
+
+**`penalty_total`** is the sum of `check_quality()`'s tripped flags — the
+craft checker, unchanged by ADR 0008, is still the *one* place these
+weights are defined (recurring-defect doctrine: nothing else re-lists this
+table):
+
+| Flag | Trips when… | Penalty |
+|---|---|---|
+| `yes_no_wording` | Opens with did/do/have/were/was/is/are/can/could/would/should + you | −0.25 |
+| `self_directed_why` | "Why do/did/are/were/can't/… you feel/keep/always/…" — self-directed why | −0.20 |
+| `too_broad` | Matches a too-broad shape ("tell me about …", "what do you think about…") | −0.20 |
+| `no_scene_or_stakes_path` | No scene marker, no emotion marker, *and* no basic interrogative present | −0.15 |
+| `no_source_citation` | No `source_path` behind the candidate | −0.10 |
+| `too_short` | Under 5 words | −0.15 |
+| `possibly_vague` | 5–7 words (borderline length) | −0.05 |
+| `duplicate_of_<id>` | Normalized text exactly matches an existing bank question | −0.50 |
+
+These eight weights are literal values inside `check_quality()` — there is
+no `PENALTY_WEIGHTS` module constant to point `tests/test_handbook_parity.py`
+at, so this table is verified by direct code reading rather than a parity
+annotation (an annotation naming a constant that doesn't exist would fail
+the very test it's supposed to pass). They are also restated, name-for-name,
+in the [question-judgment interaction's behavior contract](https://github.com/lifehug/lifehug/blob/main/interactions/question_judgment/prompt/behavior.md#penalty-vocabulary)
+— one vocabulary, two readers (a deterministic checker and a seated model).
+
+The two bands that decide a candidate's fate: **auto-promote** at or above
+0.82 <!-- parity: question_candidates.AUTO_PROMOTE_THRESHOLD = 0.82 -->,
+**park as `needs_review`** from
+0.70 <!-- parity: question_candidates.NEEDS_REVIEW_THRESHOLD = 0.70 --> up
+to that, and simply **stay a candidate** below 0.70 — no separate craft
+gate, per ADR 0008.
+
+### Duplicate detection
+
+A near-duplicate is caught semantically, not just by exact text match:
+`near_duplicate_of()` computes token-Jaccard overlap (after stripping stop
+words) between a candidate and every bank/candidate text, and treats
+anything at or above
+0.75 <!-- parity: question_candidates.NEAR_DUPLICATE_JACCARD = 0.75 --> as
+the same question. This is what catches three differently-worded variants
+of "what did you promise yourself you'd do differently" without any AI
+call.
+
+### Expiry
+
+A candidate that sits unpromoted (status `candidate`, `accepted`, or
+`needs_review`) for more than
+45 <!-- parity: question_candidates.CANDIDATE_MAX_AGE_DAYS = 45 --> days
+expires — the record stays for audit, it simply stops competing. Deferred
+candidates are exempt for as long as their `defer_until` date is in the
+future.
+
+### Worked example
+
+Take a plausible generated candidate:
+
+> *"What was your father like?"* — story function `foundation`, priority
+> `0.80` (a `question_judgment` JUDGE verdict in the "high-value" band:
+> concrete evidence, but not the last missing key scene), source cited.
+
+Walking `unified_quality_score()` step by step:
+
+1. **Priority** — `0.80`, taken as-is from the generator.
+2. **Multiplier** — the quality profile's `foundation` bucket is running
+   above the global average this week: `×1.08`.
+   `0.80 × 1.08 = 0.864`.
+3. **Craft check** — `check_quality()` runs against the text. It isn't
+   yes/no, isn't self-directed-why, doesn't match a too-broad regex, and
+   *does* contain a bare interrogative ("what"), so it clears
+   `no_scene_or_stakes_path`. But it's exactly 5 words —
+   `word_count < 8` — so it trips `possibly_vague`: **−0.05**.
+4. **Combine** — `0.864 − 0.05 = 0.814`, rounded to `0.814`.
+5. **Clamp** — already inside `[0, 1]`, so the score is `0.814`, displayed
+   as `0.81`.
+6. **Verdict** — `0.70 ≤ 0.81 < 0.82`: this candidate **parks as
+   `needs_review`**, one hundredth short of auto-promotion, with the
+   reason string `"score 0.81 below threshold 0.82 (possibly_vague)"`.
+   Without that single five-word phrasing choice, the same evidence would
+   have cleared the bar and gone straight into the bank unattended.
+
+That's the mechanism in miniature: a single borderline craft flag is
+exactly enough to move a candidate from "the system asks this on its own"
+to "a human sees this in the Review lane" — never enough to reject a
+genuinely well-evidenced idea outright.
+
+## 5. In the loop
+
+```mermaid
+flowchart LR
+    subgraph feature["candidate feature loop"]
+        direction LR
+        AA["answers"] --> QP["quality_profile.py<br/>(richness → multipliers)"]
+        QP --> RS["unified_quality_score()<br/>re-scores every eligible<br/>candidate, every week"]
+        RS --> PR["promote / park / stay"]
+    end
+    subgraph decisions["decisions loop (ADR 0009)"]
+        direction LR
+        DD["owner promote/dismiss/defer<br/>+ decision_reason"] --> RE["question_judgment<br/>weekly RUBRIC-EDIT<br/>(≤1 bounded amendment)"]
+        RE --> LM["learned.md"]
+        LM -.->|next week's prompts, not this run's| GEN["classify_story.py /<br/>research_expand.py generation"]
+    end
+    GEN --> RS
+```
+
+**What feeds it:** the weekly source classifier, the monthly research
+expander, wiki-harvested open questions, and (via `extracted.candidate_ideas`)
+a closing Conversation. **What it feeds:** the question bank, and through it
+the weekly planner queue — a promoted candidate is invisible until the
+planner actually selects it for a Focus that needs it. **How it
+self-improves:** two independent feedback paths converge on the same score.
+`quality_profile.py`'s richness multipliers shift weekly as new answers are
+scored, which moves `unified_quality_score()`'s output for every candidate
+of that story function without anyone editing a rule. Separately, the
+owner's actual promote/dismiss/defer decisions (ADR 0009) become an "Owner
+Judgment Signals" block injected into the classifier's and research
+expander's own generation prompts — teaching the *pattern* of what gets
+rejected, not a literal blocklist — and, once a week, at most one bounded,
+evidence-cited amendment to the question-judgment rubric's learned
+amendments file. Both paths are accelerators in the Convergence Principle's
+sense: real, and multiplicative, but never a dependency — a vault where no
+human ever opens the Review lane still promotes its best candidates every
+single week.
+
+**Classification:** this feature is the **floor** of the Convergence
+Principle. Auto-promotion runs unattended, every week, with a deterministic
+no-human path all the way from "a source exists" to "a question is in the
+bank" — a candidate that would otherwise die in a park either resurfaces on
+its own (score reasons) or waits behind a real affordance (`candidates-review`
+/ the viewer's Review lane), never behind nothing at all. Manual review,
+promotion, and the decisions-feed-the-loop signal are the **accelerator**:
+they speed up which good ideas surface sooner, they never gate whether the
+system keeps improving its own questions.
+
+## 6. Where it lives
+
+| Concern | Location |
+|---|---|
+| Candidate store | `state/question_candidates.json` |
+| Quality profile (multipliers) | `state/quality_profile.json` |
+| Core scoring | `question_candidates.unified_quality_score()`, `check_quality()` |
+| Auto-promotion ladder | `question_candidates.auto_promote_candidates()` |
+| Expiry | `question_candidates.expire_stale_candidates()` |
+| Near-duplicate detection | `question_candidates.near_duplicate_of()` |
+| Wiki → candidate harvest | `question_candidates.harvest_wiki_questions()` |
+| Quality-profile aggregation | `quality_profile.compute_profile()` |
+| Question-judgment rubric (JUDGE priority/penalty vocabulary) | `interactions/question_judgment/prompt/behavior.md`, `question_judgment.py` |
+| Owner decisions → generation prompts | `question_judgment.build_decision_context()`, `owner_judgment_signals_block()` |
+| CLI | `lifehug.py candidates-list \| candidates-review \| candidates-update \| candidates-promote \| candidates-promote-neighborhood \| candidates-stats \| candidates-auto-promote [--dry-run]` |
+| Weekly wiring | `weekly_maintenance.sh` — `quality_update` → `judgment_update` → `timeline_retire` → `wiki_harvest` → `mirror_compile` → `auto_promote` → `planner_queue` → `arc_plan` |
+| Interaction | [`interactions/question_judgment/`](https://github.com/lifehug/lifehug/tree/main/interactions/question_judgment) (ADR 0007) |
+| Guard tests | `tests/test_unified_quality_score.py`, `tests/test_decisions_feed_loop.py`, `tests/test_question_candidates.py` (repo-verify exact names before citing in a PR — this table names the concern, not a promise of one file per row) |
+
+**Change-safely notes.** The two threshold constants
+(`AUTO_PROMOTE_THRESHOLD`, `NEEDS_REVIEW_THRESHOLD`) and
+`CANDIDATE_MAX_AGE_DAYS` / `NEAR_DUPLICATE_JACCARD` are read live everywhere
+they matter — moving one only requires editing `question_candidates.py`
+and this page's parity annotations together (`tests/test_handbook_parity.py`
+fails otherwise). The craft-penalty weight table lives in exactly one
+function, `check_quality()`; a change there must be mirrored by hand into
+`interactions/question_judgment/prompt/behavior.md`'s penalty vocabulary
+table (nothing enforces that mirror automatically — it's a documented,
+not a tested, invariant). Never write to `candidate["reason"]` after
+candidate creation — that field is the generator's own provenance; owner
+decisions belong in `candidate["decision_reason"]` (ADR 0009's
+field-overwrite fix).
+
+## 7. Decisions
+
+- [ADR 0006 — The Convergence Principle](https://github.com/lifehug/lifehug/blob/main/docs/adr/0006-convergence-principle.md) — the floor/accelerator classification this page's §5 applies.
+- [ADR 0007 — The Question-Judgment Interaction](https://github.com/lifehug/lifehug/blob/main/docs/adr/0007-question-judgment-interaction.md) — the priority/penalty vocabulary §4 quotes, and the JUDGE/RUBRIC-EDIT split §5 describes; see also the interaction's own [behavior contract](https://github.com/lifehug/lifehug/blob/main/interactions/question_judgment/prompt/behavior.md).
+- [ADR 0008 — One published quality score, craft penalties folded in](https://github.com/lifehug/lifehug/blob/main/docs/adr/0008-unified-quality-score.md) — the formula in §4.
+- [ADR 0009 — Decisions Feed The Loop](https://github.com/lifehug/lifehug/blob/main/docs/adr/0009-decisions-feed-the-loop.md) — the `decision_reason` field, owner judgment signals, and the weekly rubric-edit runtime.
+- The hosted platform's review-loop contracts (parallel PR review, owner closeout, executable walkthroughs) that this feature's Review lane is built against: [`lifehug-platform` docs/BUILDING.md](https://github.com/lifehug/lifehug-platform/blob/main/docs/BUILDING.md) and [docs/REVIEWING.md](https://github.com/lifehug/lifehug-platform/blob/main/docs/REVIEWING.md) (external repo — platform orchestrates this package, never forks it).

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 172,
+  "version": 173,
   "released": "2026-08-15",
-  "changelog": "v172: the How-Lifehug-Works handbook site scaffold (GitHub Pages from /docs, just-the-docs): landing page with the seven-section per-feature template, handbook index with the planned page list, Glossary seeded verbatim from the README's nomenclature, ADRs/pr-specs browsable but out of the sidebar, and the doc-parity harness (tests/test_handbook_parity.py) \u2014 every algorithm number a handbook page quotes is annotated and asserted against the live module constant, so the site cannot drift from the code.",
+  "changelog": "v173: the handbook's first two content pages \u2014 Question Candidates and Focuses & the Autopilot (docs/handbook/) \u2014 each in the seven-section template: a concrete user scenario, the nouns (candidate statuses, park, promotion, auto-promotion, neighborhood-as-supply; recommendation, evidence strength, developing set, the three dedupe layers), a mermaid lifecycle/pipeline diagram per page, the unified quality score and idea-scoring formulas with every threshold parity-annotated against question_candidates.py/quality_profile.py/recommend_focuses.py/progress.py and a worked example scored step by step, the floor/accelerator Convergence Principle classification, a code map with change-safely notes, and ADR links (0006\u20130012). 21 parity annotations total, all asserted by tests/test_handbook_parity.py.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",


### PR DESCRIPTION
## What

The first two content pages of the How-Lifehug-Works handbook
(https://lifehug.github.io/lifehug/), following `docs/index.md`'s
seven-section template exactly:

- **Question Candidates** — `docs/handbook/question-candidates.md`
  Rendered after merge: https://lifehug.github.io/lifehug/handbook/question-candidates.html
- **Focuses & the Autopilot** — `docs/handbook/focuses.md`
  Rendered after merge: https://lifehug.github.io/lifehug/handbook/focuses.html

Each page: a concrete one-paragraph user scenario (§1), the feature's
own nouns with shared glossary terms linked rather than redefined (§2),
a mermaid diagram of the mechanism (§3), the real formula with every
threshold parity-annotated and a worked example scored step by step
(§4), the feature loop plus its Convergence Principle floor/accelerator
classification (§5), a code map with change-safely notes (§6), and ADR
links (§7).

## Accuracy discipline

Every claim was verified against `system/question_candidates.py`,
`system/recommend_focuses.py`, `system/quality_profile.py`,
`system/roadmap.py`, `system/progress.py`, ADRs 0006–0012, the
question-judgment interaction's `behavior.md`, README's overlapping
sections, and `monthly_research.sh`/`weekly_maintenance.sh` for the
clocks — code wins where the README and code could be read to disagree.

**21 parity annotations** (13 on Question Candidates, 8 on Focuses),
each an HTML comment `parity: module.CONSTANT = value` asserted by
`tests/test_handbook_parity.py` against the live constant:
`question_candidates.{AUTO_PROMOTE_THRESHOLD, NEEDS_REVIEW_THRESHOLD,
CANDIDATE_MAX_AGE_DAYS, NEAR_DUPLICATE_JACCARD, PER_NEIGHBORHOOD_CAP,
PER_NEIGHBORHOOD_CAP_BACKLOG, BACKLOG_PRESSURE_THRESHOLD}`,
`quality_profile.{ACTIVATION_THRESHOLD, MULTIPLIER_FLOOR,
MULTIPLIER_CAP}`, `recommend_focuses.{FOCUS_READY_SCORE_FLOOR,
FOCUS_RECOMMENDATION_EXPIRY_WEEKS, AUTOPILOT_TARGET_DEVELOPING,
AUTOPILOT_MAX_PER_RUN}`, `progress.{READY, DEVELOPING}`.

A handful of numbers each page quotes (the craft-penalty weight table
inside `check_quality()`, the idea-scoring weights `1.0/2.0/3.0/1.5`
inside `_score()`, the evidence-strength bands `15`/`8`, and
`dynamic_weekly_cap()`'s band cutoffs) are literal in-function values
with **no live module constant** for the parity harness to check
against — each page says so explicitly, rather than fabricating a
`parity:` annotation naming a constant that doesn't exist (which would
fail `test_handbook_parity` instead of protecting it). Verified by
direct code reading instead.

Mermaid note: the state diagram in Question Candidates §3 keeps its
parity-annotated numbers in the surrounding prose, not inline in the
diagram source — an HTML comment's own `-->` collides with Mermaid's
arrow-token syntax inside a state-diagram edge label.

## Tests

- `python3 -m unittest tests.test_handbook_parity -v` — 2/2 pass, all
  21 annotations verified.
- Full suite: `21 failed, 1581 passed` — identical to the pre-existing
  baseline (`tests/test_v120_source_view.py`, environment-related),
  **zero delta**.

## Version

`system/version.json` bumped 172 → 173 (origin/main was at 172 when
this branch was cut; expect the merge train to renumber if another PR
lands first).

## Not in this PR

Everything else in the handbook's planned page list (`docs/handbook/index.md`)
— The Mission & the Convergence Principle, The Loop, Interactions,
Quality & Engagement Profile, Neighborhoods, Entities & Graduation,
Conversations & the Day Model, Decisions & Learning — stays covered by
the README/ADRs per the handbook index's own stated interim policy.

🤖 Generated with Claude Sonnet 5 via Claude Code