### PR TITLE
fix: allow manual promotion of needs_review candidates (v186)

### DIFF
--- a/system/candidate_promotion.py
+++ b/system/candidate_promotion.py
@@ -30,8 +30,16 @@ SCHEMA_VERSION = 1
 MARKER_PREFIX = "  <!-- lifehug:candidate-promotion:v1 "
 MARKER_SUFFIX = " -->"
 PROMOTION_MODES = frozenset({"manual", "auto", "neighborhood"})
-MANUAL_PROMOTABLE_STATUSES = frozenset({"candidate", "accepted", "deferred"})
-AUTO_PROMOTABLE_STATUSES = MANUAL_PROMOTABLE_STATUSES | {"needs_review"}
+MANUAL_PROMOTABLE_STATUSES = frozenset(
+    {"candidate", "accepted", "deferred", "needs_review"}
+)
+NEIGHBORHOOD_PROMOTABLE_STATUSES = frozenset({"candidate", "accepted", "deferred"})
+AUTO_PROMOTABLE_STATUSES = MANUAL_PROMOTABLE_STATUSES
+PROMOTABLE_STATUSES_BY_MODE = {
+    "manual": MANUAL_PROMOTABLE_STATUSES,
+    "auto": AUTO_PROMOTABLE_STATUSES,
+    "neighborhood": NEIGHBORHOOD_PROMOTABLE_STATUSES,
+}
 REQUEST_KEYS = frozenset(
     {
         "schema_version",
@@ -624,11 +632,7 @@ def apply_candidate_promotion(
         decision=decision,
     )
     status = candidate.get("status", "candidate")
-    promotable_statuses = (
-        AUTO_PROMOTABLE_STATUSES
-        if promotion_mode == "auto"
-        else MANUAL_PROMOTABLE_STATUSES
-    )
+    promotable_statuses = PROMOTABLE_STATUSES_BY_MODE[promotion_mode]
     if status not in promotable_statuses:
         raise CandidatePromotionError(
             f"candidate {request['candidate_id']} cannot be promoted from status {status!r}"
@@ -800,7 +804,10 @@ def _resolve_locked(
                     "uncommitted promotion marker question differs from candidate"
                 )
             status = candidate.get("status")
-            if status not in AUTO_PROMOTABLE_STATUSES | {"promoted", "auto_promoted"}:
+            if status not in PROMOTABLE_STATUSES_BY_MODE[promotion_mode] | {
+                "promoted",
+                "auto_promoted",
+            }:
                 raise CandidatePromotionError(
                     f"candidate projection has conflicting status {status!r}"
                 )

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 185,
-  "released": "2026-08-18",
-  "changelog": "v185: feat(172): add Entity Candidate research for people, places, periods, objects, and themes. It starts read-only, keeps useful material as exact user excerpts, evaluates each type's actual meaning instead of reference counts, and requires a distinct current explicit confirmation before preserving candidate research. Every completion path rechecks lifecycle and revisions, never approves, graduates, or creates a page, and leaves a later independent roster decision required.",
+  "version": 186,
+  "released": "2026-08-19",
+  "changelog": "v186: fix: manual owner promotion now accepts needs_review candidates through the same exact-file Git receipt, replay, and adoption authority as other manually promotable candidates; auto-promotion and terminal-status refusals are unchanged.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_candidate_promotion.py
+++ b/tests/test_candidate_promotion.py
@@ -113,6 +113,140 @@ class PromotionCase(unittest.TestCase):
 
 
 class ReceiptTests(PromotionCase):
+    def _set_candidate_status(self, status: str) -> None:
+        self.candidate["status"] = status
+        self._write_store([self.candidate])
+
+    def test_manual_needs_review_first_promotion_and_exact_replay_receipt(self):
+        self._set_candidate_status("needs_review")
+        request = self.request()
+
+        first = promotion.resolve_candidate_promotion(
+            request, vault_root=self.tmp, push=False
+        )
+        replay = promotion.resolve_candidate_promotion(
+            request, vault_root=self.tmp, push=False
+        )
+
+        self.assertTrue(first["changed"])
+        self.assertFalse(replay["changed"])
+        self.assertEqual(
+            {key: value for key, value in first.items() if key != "changed"},
+            {key: value for key, value in replay.items() if key != "changed"},
+        )
+        self.assertEqual(first["question_id"], "A2")
+        self.assertEqual(
+            json.loads(
+                (self.tmp / "state" / "question_candidates.json").read_text(
+                    encoding="utf-8"
+                )
+            )["candidates"][0]["status"],
+            "promoted",
+        )
+
+    def test_manual_needs_review_adopts_exact_commit_after_resolver_crash(self):
+        self._set_candidate_status("needs_review")
+        request = self.request()
+
+        def failpoint(stage: str) -> None:
+            if stage == "after_commit":
+                raise RuntimeError(stage)
+
+        with self.assertRaisesRegex(RuntimeError, "after_commit"):
+            promotion.resolve_candidate_promotion(
+                request,
+                vault_root=self.tmp,
+                push=False,
+                failpoint=failpoint,
+            )
+
+        adopted = promotion.resolve_candidate_promotion(
+            request, vault_root=self.tmp, push=False
+        )
+
+        self.assertFalse(adopted["changed"])
+        self.assertEqual(
+            adopted["commit_sha"],
+            _run(self.tmp, "rev-parse", "HEAD").stdout.strip(),
+        )
+        self.assertEqual(adopted["question_id"], "A2")
+
+    def test_manual_needs_review_still_requires_current_candidate_and_category(self):
+        self._set_candidate_status("needs_review")
+        request = self.request()
+
+        stale_candidate = dict(request)
+        stale_candidate["candidate_revision"] = "sha256:" + "0" * 64
+        with self.assertRaisesRegex(promotion.CandidatePromotionError, "stale"):
+            promotion.resolve_candidate_promotion(
+                stale_candidate, vault_root=self.tmp, push=False
+            )
+
+        self.candidate["source_id"] = "SYN-1-current"
+        self._write_store([self.candidate])
+        with self.assertRaisesRegex(promotion.CandidatePromotionError, "stale"):
+            promotion.resolve_candidate_promotion(
+                request, vault_root=self.tmp, push=False
+            )
+
+        self._write_store([self.candidate])
+        current = self.request()
+        bank_path = self.tmp / "question-bank.md"
+        bank_path.write_text(
+            bank_path.read_text(encoding="utf-8").replace(
+                "Origins (Childhood)", "Origins (Current)"
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(promotion.CandidatePromotionError, "stale"):
+            promotion.resolve_candidate_promotion(
+                current, vault_root=self.tmp, push=False
+            )
+
+    def test_manual_terminal_statuses_remain_refused(self):
+        for status in (
+            "promoted",
+            "auto_promoted",
+            "rejected",
+            "expired",
+            "superseded",
+        ):
+            with self.subTest(status=status):
+                self._set_candidate_status(status)
+                request = self.request()
+                with self.assertRaisesRegex(
+                    promotion.CandidatePromotionError,
+                    rf"cannot be promoted from status '{status}'",
+                ):
+                    promotion.resolve_candidate_promotion(
+                        request, vault_root=self.tmp, push=False
+                    )
+
+    def test_neighborhood_needs_review_remains_refused_but_candidate_works(self):
+        self._set_candidate_status("needs_review")
+        request = self.request()
+        with self.assertRaisesRegex(
+            promotion.CandidatePromotionError,
+            "cannot be promoted from status 'needs_review'",
+        ):
+            promotion.resolve_candidate_promotion(
+                request,
+                vault_root=self.tmp,
+                promotion_mode="neighborhood",
+                push=False,
+            )
+
+        self._set_candidate_status("candidate")
+        request = self.request()
+        receipt = promotion.resolve_candidate_promotion(
+            request,
+            vault_root=self.tmp,
+            promotion_mode="neighborhood",
+            push=False,
+        )
+        self.assertTrue(receipt["changed"])
+        self.assertEqual(receipt["question_id"], "A2")
+
     def test_first_promotion_and_replay_have_one_question_and_stable_receipt(self):
         request = self.request()
         first = promotion.resolve_candidate_promotion(

--- a/tests/test_entity_candidate.py
+++ b/tests/test_entity_candidate.py
@@ -777,7 +777,7 @@ class EntityCandidateTests(unittest.TestCase):
         }
         version = json.loads((ROOT / "system/version.json").read_text())
         self.assertEqual(shipped - set(version["framework_files"]), set())
-        self.assertEqual(version["version"], 185)
+        self.assertEqual(version["version"], 186)
 
     def test_runtime_has_one_completion_delegation_and_no_parallel_writer_or_approval(
         self,

--- a/tests/test_focus_candidate.py
+++ b/tests/test_focus_candidate.py
@@ -587,7 +587,7 @@ class FocusCandidateTests(unittest.TestCase):
         }
         version = json.loads((ROOT / "system/version.json").read_text())
         self.assertEqual(shipped - set(version["framework_files"]), set())
-        self.assertEqual(version["version"], 185)
+        self.assertEqual(version["version"], 186)
 
     def test_runtime_has_one_completion_delegation_and_no_parallel_writer_or_approval(
         self,


### PR DESCRIPTION
## Summary

Manual owner promotion now accepts `needs_review` candidates through the existing canonical `candidate_promotion.py` exact-file Git receipt transaction. Auto-promotion remains unchanged, neighborhood promotion remains unchanged, and terminal statuses remain refused.

The focused regression coverage proves:

- first manual promotion and exact receipt replay for `needs_review`;
- post-commit crash adoption without duplicate questions or a new commit;
- stale candidate/category revisions still fail closed;
- `promoted`, `auto_promoted`, `rejected`, `expired`, and `superseded` remain refused;
- neighborhood `needs_review` remains refused while ordinary neighborhood candidates still promote.

Closes #178.

This is a narrow bug fix with regression coverage, explicitly exempt from a separate contract by `docs/BUILDING.md` §1 ("A bug fix with a regression test does not need a contract — go straight to the PR").

## Authority and compatibility

- Base: annotated `v185` / `0cdd8bec10a29463790694ebe1cd2b55845afa05`.
- Current implementation SHA: `7f3db1f08f66553136e1d82ca0d574c2a7f363b1`.
- New package version: v186.
- The existing handbook state machine already documents `needs_review -> promoted` for human promotion, so no handbook or ADR correction is needed.
- Hosted review-loop #516 and #520 should pin the v186 release after merge; no platform workaround or behavior fork is required.

## Verification

- `python3 -m unittest tests.test_candidate_promotion tests.test_exact_file_git tests.test_ingest_and_planner tests.test_unified_quality_score tests.test_lifehug_wrapper tests.test_question_candidate tests.test_question_candidate_evals tests.test_interaction_registry -v` — 130 passed
- `python3 system/lifehug.py question-candidate-evals` — deterministic layers passed; live AI layer skipped without provider
- `python3 system/lifehug.py conversation-evals` — deterministic layers passed; model-backed layers skipped without provider
- `python3 scripts/ci/check_framework_files.py` — 326 entries present
- `python3 scripts/ci/check_version_bump.py --base 0cdd8bec10a29463790694ebe1cd2b55845afa05 --head 7f3db1f08f66553136e1d82ca0d574c2a7f363b1` — v185 -> v186
- `python3 -m compileall -q system tests`
- Ruff lint and format checks; `git diff --check`

## Owner closeout

### Look

No new visible surface. Review the mode mapping and exact-file resolver guard in [`system/candidate_promotion.py`](https://github.com/lifehug/lifehug/blob/7f3db1f08f66553136e1d82ca0d574c2a7f363b1/system/candidate_promotion.py), with focused state-machine coverage in [`tests/test_candidate_promotion.py`](https://github.com/lifehug/lifehug/blob/7f3db1f08f66553136e1d82ca0d574c2a7f363b1/tests/test_candidate_promotion.py).

### Judge

- Should manual owner promotion of a candidate parked in `needs_review` follow the already-documented `needs_review -> promoted` transition? Yes means merge v186 and update hosted pins for #516/#520; no means keep the current contradiction.
- Should auto-promotion and neighborhood promotion remain unchanged, with terminal statuses still refused? Yes means merge as scoped; no means request a separate contract.

### Done when

Approve and merge this draft PR. The v186 tag/release automation will publish the package version, after which hosted #516/#520 can advance their exact package pin. Issue #178 closes on merge. No owner-run live check remains.

🤖 Generated with Codex