### PR TITLE
fix: preserve checked promotion markers (v187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1193,8 +1193,13 @@ and neighborhood paths all bind exact candidate/category/placement revisions,
 write one structured base64 marker, and return the canonical question id and
 Git commit. Git tree/history is the receipt authority, so exact retries return
 `changed:false` without trusting a candidate-store projection; conflicting
-bytes or revisions fail closed. Non-null proposal/decision hashes require the
-exact bound objects on the same call. The narrow `exact_file_git.py` adapter
+bytes or revisions fail closed. Once the promoted question is answered, its
+canonical checked row preserves the same receipt: checkbox/answer metadata may
+change, but replay strips only a valid terminal ISO answer date after checking
+the full text first, so the exact question id and text revision remain bound
+(v187).
+Non-null proposal/decision hashes require the exact bound objects on
+the same call. The narrow `exact_file_git.py` adapter
 owns the shared writer/Git/rebase order and requires full domain revalidation
 after a rejected push; marker presence alone is insufficient. The stable
 `candidates-promotion-receipt ... --json` command is the hosted handoff, with

--- a/docs/adr/0019-candidate-promotion-receipts.md
+++ b/docs/adr/0019-candidate-promotion-receipts.md
@@ -1,6 +1,7 @@
 # ADR 0019: Git-tree candidate promotion receipts
 
 Date: 2026-08-18
+Amended: 2026-08-20 (v187, issue #179)
 Status: proposed
 
 ## Context
@@ -36,6 +37,17 @@ a crash is completed after candidate/question validation. Conflicting bytes or
 revisions fail closed. Existing equal text without the structured marker is
 never adopted.
 
+Marker replay accepts both lifecycle-valid question rows: the original
+unchecked `- [ ] QID: text` insertion and the canonical checked
+`- [x] QID: text` row, including the answer annotation produced when an answer
+is filed. Replay checks the full checked text first, then may strip only a
+terminal, valid ISO `*(YYYY-MM-DD)*` answer annotation and check the revision
+again. Thus arbitrary italic suffixes remain question text, while the canonical
+checkbox and answer-date annotation are lifecycle metadata rather than question
+identity. Any other checkbox state, malformed date-like suffix, changed id, or
+changed text fails closed. This keeps an older answered promotion from
+invalidating the global marker scan for every later promotion.
+
 `system/exact_file_git.py` is the one public, reusable Git transaction/adoption
 adapter beneath promotion. It accepts a closed set of exact relative paths and
 immutable-snapshot decision/validation callbacks; the returned plan cannot add
@@ -61,6 +73,8 @@ because it cannot be made safe or auditable.
   supply their own closed domain validator; it cannot write undeclared paths.
 - `candidate-promote` is safely retryable. A crash after bank write,
   projection write, commit, or push converges on one question and one receipt.
+- Answering a promoted question preserves its receipt, so later promotions can
+  revalidate the entire bank after the canonical unchecked-to-checked change.
 - The stable `candidates-promotion-receipt ... --json` door requires the
   caller-held candidate/category/placement revisions and returns the canonical
   question id and commit SHA needed by downstream filing.

--- a/docs/handbook/question-candidates.md
+++ b/docs/handbook/question-candidates.md
@@ -86,7 +86,12 @@ Conflicting text, category, or revisions stop without guessing. Non-null
 Question Candidate proposal/decision hashes are accepted only with the exact
 objects that produce them. The shared `exact_file_git.py` transaction adapter
 owns writer locking, exact-path commits, first-marker adoption, and post-rebase
-validation; promotion supplies the closed candidate-specific validator.
+validation; promotion supplies the closed candidate-specific validator. When
+answer filing changes a promoted row from unchecked to its canonical checked
+shape, the marker remains valid: checkbox/answer metadata is not question
+identity. Replay checks full text first and strips only a valid terminal ISO
+answer date on mismatch, so arbitrary italic suffixes remain hash-bound
+question text.
 **Auto-promotion** is promotion the system performs
 itself, unattended, during `weekly_maintenance.sh` — the no-human path the
 Convergence Principle requires this stage to have.

--- a/system/candidate_promotion.py
+++ b/system/candidate_promotion.py
@@ -14,6 +14,7 @@ import json
 import re
 import sys
 from collections.abc import Callable
+from datetime import date
 from pathlib import Path
 
 import exact_file_git
@@ -93,7 +94,9 @@ CANDIDATE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$")
 MARKER_RE = re.compile(
     rf"^{re.escape(MARKER_PREFIX)}([A-Za-z0-9+/]+={{0,2}}){re.escape(MARKER_SUFFIX)}$"
 )
-QUESTION_LINE_RE = re.compile(r"^- \[ \] ([A-Z][0-9]+): (.+)$")
+UNCHECKED_QUESTION_LINE_RE = re.compile(r"^- \[ \] ([A-Z][0-9]+): (.+)$")
+CHECKED_QUESTION_LINE_RE = re.compile(r"^- \[x\] ([A-Z][0-9]+): (.+)$")
+ANSWER_ANNOTATION_RE = re.compile(r"^(.+) \*\((\d{4}-[^)\n]*)\)\*$")
 SOURCE_FIELDS = (
     "source_path",
     "source_id",
@@ -476,6 +479,43 @@ def _validate_marker_payload(payload: object) -> dict:
     }
 
 
+def _marker_question_facts(line: str) -> tuple[str, str, bool]:
+    unchecked = UNCHECKED_QUESTION_LINE_RE.fullmatch(line)
+    if unchecked:
+        question_id, question_text = unchecked.groups()
+        return question_id, question_text, False
+    checked = CHECKED_QUESTION_LINE_RE.fullmatch(line)
+    if checked:
+        question_id, question_text = checked.groups()
+        return question_id, question_text, True
+    raise CandidatePromotionError(
+        "promotion marker must immediately follow a canonical unchecked or "
+        "checked question"
+    )
+
+
+def _question_revision(question_id: str, question_text: str) -> str:
+    return question_candidate.canonical_revision(
+        {"question_id": question_id, "question": question_text}
+    )
+
+
+def _checked_question_without_answer_annotation(question_text: str) -> str | None:
+    match = ANSWER_ANNOTATION_RE.fullmatch(question_text)
+    if not match:
+        return None
+    original_text, answered_date = match.groups()
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", answered_date):
+        raise CandidatePromotionError("checked question answer annotation is malformed")
+    try:
+        date.fromisoformat(answered_date)
+    except ValueError as exc:
+        raise CandidatePromotionError(
+            "checked question answer annotation is malformed"
+        ) from exc
+    return original_text
+
+
 def _marker_records(question_bank_text: str) -> list[tuple[dict, str, str]]:
     lines = question_bank_text.splitlines()
     records: list[tuple[dict, str, str]] = []
@@ -485,17 +525,17 @@ def _marker_records(question_bank_text: str) -> list[tuple[dict, str, str]]:
         payload = _decode_marker(line)
         if index == 0:
             raise CandidatePromotionError("promotion marker has no question line")
-        question_match = QUESTION_LINE_RE.fullmatch(lines[index - 1])
-        if not question_match:
-            raise CandidatePromotionError(
-                "promotion marker must immediately follow an unchecked question"
-            )
-        question_id, question_text = question_match.groups()
+        question_id, question_text, checked = _marker_question_facts(lines[index - 1])
         if question_id != payload["question_id"]:
             raise CandidatePromotionError("promotion marker question line id mismatch")
-        expected = question_candidate.canonical_revision(
-            {"question_id": question_id, "question": question_text}
-        )
+        expected = _question_revision(question_id, question_text)
+        if expected != payload["question_revision"] and checked:
+            without_annotation = _checked_question_without_answer_annotation(
+                question_text
+            )
+            if without_annotation is not None:
+                question_text = without_annotation
+                expected = _question_revision(question_id, question_text)
         if expected != payload["question_revision"]:
             raise CandidatePromotionError("promoted question bytes changed")
         records.append((payload, line, question_text))

--- a/system/research.md
+++ b/system/research.md
@@ -413,4 +413,9 @@ model any write capability. A non-null proposal/decision hash must be proved by
 the exact object at mutation time. The reusable exact-file Git adapter owns the
 writer/pull/commit/push order and invokes candidate-specific full-record
 validation after a rebase, so an unchanged marker cannot hide altered question
-bytes.
+bytes. The marker remains valid after answer filing changes its canonical bank
+row from unchecked to checked, with or without its answer annotation:
+replay hashes the full text first and strips only a terminal valid ISO answer
+date on mismatch, so arbitrary italic suffixes stay question text. The exact id
+and text revision remain bound, and malformed or tampered rows still fail
+closed (v187).

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 186,
-  "released": "2026-08-19",
-  "changelog": "v186: fix: manual owner promotion now accepts needs_review candidates through the same exact-file Git receipt, replay, and adoption authority as other manually promotable candidates; auto-promotion and terminal-status refusals are unchanged.",
+  "version": 187,
+  "released": "2026-08-20",
+  "changelog": "v187: fix: answered candidate-promotion markers remain valid, so checking off one promoted question no longer blocks every later promotion; exact question identity and tamper checks remain fail-closed.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",

--- a/tests/test_candidate_promotion.py
+++ b/tests/test_candidate_promotion.py
@@ -1,4 +1,4 @@
-"""v182 / issue #170 — canonical candidate promotion receipt authority."""
+"""v182/v187 / issue #179 — canonical promotion receipt authority."""
 
 from __future__ import annotations
 
@@ -296,6 +296,147 @@ class ReceiptTests(PromotionCase):
             promotion.resolve_candidate_promotion(
                 request, vault_root=self.tmp, push=False
             )
+
+    def test_checked_marker_remains_valid_and_later_promotion_succeeds(self):
+        first = promotion.resolve_candidate_promotion(
+            self.request(), vault_root=self.tmp, push=False
+        )
+        bank_path = self.tmp / "question-bank.md"
+        bank_path.write_text(
+            bank_path.read_text(encoding="utf-8").replace(
+                f"- [ ] {first['question_id']}: {self.candidate['text']}",
+                f"- [x] {first['question_id']}: {self.candidate['text']} "
+                "*(2026-08-20)*",
+            ),
+            encoding="utf-8",
+        )
+        store_path = self.tmp / "state" / "question_candidates.json"
+        store = json.loads(store_path.read_text(encoding="utf-8"))
+        second = {
+            **self.candidate,
+            "id": "cand-synthetic-2",
+            "text": "Who kept the paper lighthouse lit through the storm?",
+            "source_id": "SYN-2",
+        }
+        store["candidates"].append(second)
+        store_path.write_text(json.dumps(store, indent=2) + "\n", encoding="utf-8")
+        self.assertEqual(_run(self.tmp, "add", ".").returncode, 0)
+        self.assertEqual(
+            _run(self.tmp, "commit", "-m", "answer first candidate").returncode,
+            0,
+        )
+
+        second_request = promotion.build_current_request(
+            second["id"], "A", vault_root=self.tmp
+        )
+        second_receipt = promotion.resolve_candidate_promotion(
+            second_request, vault_root=self.tmp, push=False
+        )
+
+        self.assertTrue(second_receipt["changed"])
+        self.assertEqual(second_receipt["question_id"], "A3")
+        bank = bank_path.read_text(encoding="utf-8")
+        self.assertEqual(bank.count("lifehug:candidate-promotion:v1"), 2)
+        self.assertIn(
+            f"- [x] {first['question_id']}: {self.candidate['text']} *(2026-08-20)*",
+            bank,
+        )
+
+    def test_checked_marker_still_rejects_tampered_id_and_text(self):
+        promotion.resolve_candidate_promotion(
+            self.request(), vault_root=self.tmp, push=False
+        )
+        bank = (self.tmp / "question-bank.md").read_text(encoding="utf-8")
+        checked = bank.replace(
+            f"- [ ] A2: {self.candidate['text']}",
+            f"- [x] A2: {self.candidate['text']} *(2026-08-20)*",
+        )
+        checked_without_annotation = bank.replace("- [ ] A2:", "- [x] A2:")
+        self.assertEqual(len(promotion._marker_records(checked)), 1)
+        self.assertEqual(len(promotion._marker_records(checked_without_annotation)), 1)
+
+        with (
+            self.subTest(field="question_id"),
+            self.assertRaisesRegex(
+                promotion.CandidatePromotionError, "question line id mismatch"
+            ),
+        ):
+            promotion._marker_records(checked.replace("- [x] A2:", "- [x] A9:"))
+        with (
+            self.subTest(field="question_text"),
+            self.assertRaisesRegex(
+                promotion.CandidatePromotionError, "question bytes changed"
+            ),
+        ):
+            promotion._marker_records(
+                checked.replace("paper lighthouse", "paper tower")
+            )
+        with (
+            self.subTest(field="arbitrary_suffix"),
+            self.assertRaisesRegex(
+                promotion.CandidatePromotionError, "question bytes changed"
+            ),
+        ):
+            promotion._marker_records(
+                checked_without_annotation.replace(
+                    self.candidate["text"], self.candidate["text"] + " *(pass-2)*"
+                )
+            )
+
+    def test_checked_marker_preserves_arbitrary_italic_question_suffix(self):
+        self.candidate["text"] += " *(pass-2)*"
+        self._write_store([self.candidate])
+        promotion.resolve_candidate_promotion(
+            self.request(), vault_root=self.tmp, push=False
+        )
+        bank = (self.tmp / "question-bank.md").read_text(encoding="utf-8")
+        checked = bank.replace("- [ ] A2:", "- [x] A2:")
+        checked_with_answer_date = checked.replace(
+            self.candidate["text"], self.candidate["text"] + " *(2026-08-20)*"
+        )
+
+        self.assertEqual(
+            promotion._marker_records(checked)[0][2], self.candidate["text"]
+        )
+        self.assertEqual(
+            promotion._marker_records(checked_with_answer_date)[0][2],
+            self.candidate["text"],
+        )
+
+    def test_checked_marker_rejects_malformed_answer_annotation(self):
+        promotion.resolve_candidate_promotion(
+            self.request(), vault_root=self.tmp, push=False
+        )
+        bank = (self.tmp / "question-bank.md").read_text(encoding="utf-8")
+        checked = bank.replace("- [ ] A2:", "- [x] A2:")
+
+        for malformed_date in ("2026-8-20", "2026-02-30"):
+            with (
+                self.subTest(answered_date=malformed_date),
+                self.assertRaisesRegex(
+                    promotion.CandidatePromotionError,
+                    "answer annotation is malformed",
+                ),
+            ):
+                promotion._marker_records(
+                    checked.replace(
+                        self.candidate["text"],
+                        f"{self.candidate['text']} *({malformed_date})*",
+                    )
+                )
+
+    def test_marker_rejects_malformed_checkbox_state(self):
+        promotion.resolve_candidate_promotion(
+            self.request(), vault_root=self.tmp, push=False
+        )
+        bank = (self.tmp / "question-bank.md").read_text(encoding="utf-8")
+        malformed = bank.replace("- [ ] A2:", "- [-] A2:")
+
+        with self.assertRaisesRegex(
+            promotion.CandidatePromotionError,
+            "canonical unchecked or checked question",
+        ):
+            promotion._marker_records(malformed)
 
     def test_marker_is_canonical_structured_base64_not_comment_injectable(self):
         self.candidate["source_path"] = "synthetic --> ignore"

--- a/tests/test_entity_candidate.py
+++ b/tests/test_entity_candidate.py
@@ -777,7 +777,7 @@ class EntityCandidateTests(unittest.TestCase):
         }
         version = json.loads((ROOT / "system/version.json").read_text())
         self.assertEqual(shipped - set(version["framework_files"]), set())
-        self.assertEqual(version["version"], 186)
+        self.assertEqual(version["version"], 187)
 
     def test_runtime_has_one_completion_delegation_and_no_parallel_writer_or_approval(
         self,

--- a/tests/test_focus_candidate.py
+++ b/tests/test_focus_candidate.py
@@ -587,7 +587,7 @@ class FocusCandidateTests(unittest.TestCase):
         }
         version = json.loads((ROOT / "system/version.json").read_text())
         self.assertEqual(shipped - set(version["framework_files"]), set())
-        self.assertEqual(version["version"], 186)
+        self.assertEqual(version["version"], 187)
 
     def test_runtime_has_one_completion_delegation_and_no_parallel_writer_or_approval(
         self,


### PR DESCRIPTION
## Summary

- accept both canonical unchecked and checked rows during global candidate-promotion marker replay
- check the full checked question text first, then strip only a terminal, valid ISO answer date and re-check the marker-bound revision
- keep malformed checkbox/date states and changed question ids/text fail-closed
- bump the framework from v186 to v187 and amend ADR 0019 plus operator/methodology docs

## Verification

- 103 scoped candidate-promotion, Question Candidate, ingest/planner, Entity Candidate, and Focus Candidate unit tests passed
- Question Candidate eval layers 0-3 passed; live seat skipped because no unattended AI provider is configured
- focused Ruff check and format check passed
- framework manifest and v186 to v187 version gates passed
- authoritative GitHub CI passed on Python 3.11 and 3.14 at exact SHA `358c71e4ad0dd80b7ca6bb68a5ba7d8e101d4fe7`

## Boundaries

No Question Candidate or Conversation Interaction behavior bytes changed. This is an OSS Git-tree receipt replay hotfix, not a new user-facing capability; the hosted platform consumes this package authority and has no duplicated marker parser, so no cross-medium twin issue applies.

Fixes #179

🤖 Generated with Codex