### PR TITLE
fix(timeline-place): a placement records the date, never the era (v251)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -994,10 +994,20 @@ contradict the curated view.
 is allowed only for dismissal (`second-voice-ack`) and rendering caches, and
 a cache must be derivable from filed sources.
 
-- Placing a timeline moment **always files the assertion** — `"<moment>"
-  happened during <Period>[, <when-hint>]` — as a `--kind date` correction
-  (no opt-in checkbox; the period is stated in the author's vocabulary, never
-  an inferred year). The pin in `state/timeline_placements.json` is a
+- Placing a timeline moment **always files the assertion** — composed by the
+  ONE definition `timeline.placement_assertion` as `"<moment>" happened
+  <date>[ (anchored on …)][, <when-hint>]` — as a `--kind date --role
+  placement` correction (no opt-in checkbox). **v251: the body states the
+  DATE DECISION and never the era.** Until v251 it opened `happened during
+  <Period>`, one sentence carrying both a date and an era: per v244/O-C2 a
+  placement is a date decision about a moment the person accepts, and per the
+  Eras design §5.1 the period is DERIVED from the date by frame arithmetic, so
+  re-asserting it as prose gave a computed name the authority of a stated date
+  inside an immutable record — and `classify_story.corrections_for` then hands
+  that prose to the next classification as authoritative. The era stays as
+  `period` on the row in `state/timeline_placements.json`, where rung 0 reads
+  it. A period-only pin (no date, no hint) says so out loud rather than
+  naming the era. The pin in `state/timeline_placements.json` is a
   display-only overlay that records the correction it filed. Unpinning keeps
   the assertion — if the *fact* was wrong, retract the correction from its
   source-actions page.

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -739,8 +739,9 @@ def cmd_timeline_place(args: argparse.Namespace) -> int:
     )
     # v195 (ADR 0024): the placement can carry a real date record. The filed
     # correction — the DURABLE half; the pin is only display — says the date in
-    # words, so the archive reads "happened around 1984 (you said you were about
-    # five)" rather than only naming an era.
+    # words, so the archive reads "happened around 1984" rather than naming an
+    # era. v251: it says ONLY that. The body is composed by the one definition
+    # `timeline.placement_assertion`, which is where the reason lives.
     record = None
     if getattr(args, "date", None):
         record = chronology.parse_edtf(args.date, basis=(args.basis or "stated"))
@@ -756,13 +757,13 @@ def cmd_timeline_place(args: argparse.Namespace) -> int:
 
         record = _replace(record, basis=basis,
                           anchors=tuple(getattr(args, "anchor", None) or ()))
-    assertion = f"“{description[:120]}” happened during {period_label}"
-    if record is not None:
-        assertion += f", {chronology.display_date(record, with_basis=False)}"
-        if record.anchors:
-            assertion += f" (anchored on {', '.join(record.anchors)})"
-    if args.when_hint:
-        assertion += f", {args.when_hint}"
+    # v251: the DATE DECISION, and never the era it lands in — `period_label`
+    # is display, and the era travels on the placement row where rung 0 reads
+    # it. Composing this sentence here is how the era got into an immutable
+    # record and, through `classify_story.corrections_for`, into the next
+    # classification prompt as an authoritative fact.
+    assertion = timeline.placement_assertion(
+        description, date=record, when_hint=args.when_hint)
     # v237 (O-C2): `--role placement`. The durable half of a placement is a
     # date DECISION about a moment the person already accepts — not a claim
     # that the source's text is wrong — so it must not mark the target's

--- a/system/timeline.py
+++ b/system/timeline.py
@@ -653,6 +653,67 @@ LANDMARKS_STORE = LANDMARKS_FILE
 #: made this a two-recipe identity in the first place.
 PLACEMENT_DESCRIPTION_MAX = 200
 
+#: The longest description the placement's DURABLE BODY quotes back. Prose,
+#: not identity — `PLACEMENT_DESCRIPTION_MAX` above is the identity clamp and
+#: the two must never be conflated: shortening this one changes a sentence,
+#: shortening that one changes a key.
+PLACEMENT_ASSERTION_DESCRIPTION_MAX = 120
+
+
+def placement_assertion(description: str, *, date: object = None,
+                        when_hint: str = "") -> str:
+    """The durable body of a placement correction: the DATE DECISION, only.
+
+    ONE definition, because this text is durable twice over. It is the
+    immutable payload of a vault source record (`--role placement`, v237/O-C2),
+    and `classify_story.corrections_for` hands it back to the next
+    classification prompt under the heading *"LATER CORRECTIONS
+    (authoritative — these OVERRIDE the story text above)"*. Whatever this
+    sentence says, the vault keeps forever and the model is told to obey.
+
+    So it says the date and nothing else. Until v251 it opened
+    ``"“…” happened during My 40s, May 2022"`` — one sentence carrying both a
+    date and an ERA, which is the sentence shape of the 2026-08-25 defect one
+    era to the right. Two authorities forbid it:
+
+    * **v244 / O-C2** — a placement is a date DECISION about a moment the
+      person accepts, not an assertion about the era it lands in.
+    * **the Eras design §5.1** — the period is DERIVED from the date by frame
+      arithmetic. ``My 40s`` is not something anybody said; it is what the
+      arithmetic computed from ``May 2022``. Asserting the derived half back
+      as fact gives it the date's own authority, and a later correction to the
+      arithmetic cannot reach it: prose inside an immutable source is not a
+      claim anything can supersede.
+
+    The era is not lost, because it was never information this record held:
+    it lives as ``period`` on the row in ``state/timeline_placements.json``,
+    which is where rung 0 reads it (see `save_placement`).
+
+    `date` is a `chronology.DateRecord` or its serialized form; `when_hint` is
+    the person's own words for when, which stand on their own when no date
+    parsed. With neither, the body states the placement and claims no time at
+    all — the honest reading of a period-only pin from the viewer's form.
+    """
+    quoted = f"“{str(description)[:PLACEMENT_ASSERTION_DESCRIPTION_MAX]}”"
+    record = date if isinstance(date, chrono.DateRecord) else (
+        chrono.from_dict(date) if date is not None else None)
+    clauses: list[str] = []
+    stated = chrono.display_date(record, with_basis=False) if record is not None else ""
+    if stated:
+        anchors = tuple(getattr(record, "anchors", ()) or ())
+        clauses.append(f"{stated} (anchored on {', '.join(anchors)})"
+                       if anchors else stated)
+    hint = str(when_hint or "").strip()
+    # A host that derives its `--when-hint` FROM the date says the date twice:
+    # `timeline_interaction.place_invocation` sets the hint to this very
+    # `display_date`. The era used to stand between the two copies; without it
+    # the duplication is the whole sentence.
+    if hint and hint != stated:
+        clauses.append(hint)
+    if not clauses:
+        return f"{quoted} — I placed this moment on my timeline; I stated no date."
+    return f"{quoted} happened {', '.join(clauses)}"
+
 
 def placement_key(event: dict) -> str:
     """The identity of one placement: the event's SOURCE and its DESCRIPTION.

--- a/system/vault_contract.json
+++ b/system/vault_contract.json
@@ -2,9 +2,9 @@
   "contract_version": 1,
   "identity": {
     "framework": "lifehug/lifehug",
-    "framework_version": 250,
+    "framework_version": 251,
     "revision": "vault-contract-v12",
-    "content_digest": "sha256:9230ce954dabc5880d88f4770db86dface45fc88eb382cc674c35e89472e4bd7"
+    "content_digest": "sha256:111d8188480c571a6d98bf29c2cc751757ff0c5c389a8f742760c1f5cef73e16"
   },
   "special_file_policy": {
     "regular_files": "allow",

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 250,
+  "version": 251,
   "released": "2026-08-28",
-  "changelog": "v250: a provisional frame says how it was calculated, never that you said it (lifehug#266, lifehug-platform#686). WHY: O-E1 files ONE provenance entry on every age frame's own record, and it was always the stated birthday's — cross_dating.AGE_FRAME_PROVENANCE, which chronology.display_date renders as “— you said from your birthday”. v241's birth_origin.provisional_origin then started drawing frames on a CALCULATED origin (origin_basis: calculated), seeded from age statements on a vault whose whole point is that it has no birthday on file — so every frame of a provisional scaffold rendered a sentence the person never said. The node's own provenance_summary was already correct; the record the host renders was not. NOW: cross_dating.frame_origin_provenance is the ONE place the entry is chosen, and it reads the ORIGIN's basis — explicit keeps “from your birthday” verbatim; calculated quotes the origin's own words back from the birth-origin:1 provenance row (“calculated from ‘I was 30 when I started there’”), or the bare AGE_FRAME_CALCULATED_PROVENANCE sentence when the origin kept none. Never omitted: an absent entry would promote the age-frame:1 clamp row into the clause and tell the same lie in different words. age_frames gains origin_basis (default explicit — timeline.py's three callers hold a stated vault birthday; the fold passes what _origin_basis_of already answered, so the substrate table CLAIM_BASIS_BY_DATE_BASIS is still read in exactly one place). chronology.CALCULATED_PROVENANCE_BASIS is a new provenance-entry basis — not a member of BASES — whose claim display_date prints VERBATIM after the dash, because a clause that names arithmetic has nobody to attribute it to. cross_dating.origin_is_explicit is the one predicate, shared with birth_origin.origin_provenance_summary, so the frame's rendered clause and the node's summary cannot drift; birth_origin.CALCULATED_ORIGIN_PROVENANCE is now a re-export of the cross_dating constant rather than a second copy of the sentence. TESTS: tests/test_eras_e_bo.py ProvisionalFrameProvenanceTests (five cases: the defect, the quoted clause, the no-quote fallback, the frame/node non-drift, the explicit origin untouched) and tests/test_eras_e1.py StatedOriginProvenanceTests (three cases pinning the stated rendering and the predicate); every one was run against unmodified main (90bdc57) first and SEEN failing — the prime case failed with “16 June 1980–15 June 1994 — you said from your birthday” on all seven reached frames. WHAT YOU'LL NOTICE: on a vault with no birthday, the age frames now read “16 June 1980–15 June 1994 — calculated from ‘I was 30’” instead of claiming you gave a birthday you never gave. A stated birthday's frames are byte-identical to v249.",
+  "changelog": "v251: a placement records the DATE, never the era (lifehug#274, found by the E7a rehearsal; authorities v244/O-C2 `docs/pr-specs/eras-o-c2-placement-keeps-its-moment.md` and the Eras controlling design §5.1). WHY: `timeline-place` files the durable half of every placement as a `--role placement` correction, and the body it composed read ““Charlee writes … Father's Day letter to Dave” happened during My 40s, May 2022” — ONE SENTENCE CARRYING BOTH A DATE AND AN ERA, which is the sentence shape of the 2026-08-25 defect one era to the right. O-C2 already ruled that a placement is a date DECISION about a moment the person accepts, not an assertion about the era it lands in; §5.1 says the period is DERIVED from the date by frame arithmetic. `My 40s` is not something anybody said — it is what the arithmetic computed from `May 2022`. THE BODY IS DURABLE TWICE, which is what made this worse than untidy prose: it is the immutable payload of a vault source record, AND `classify_story.corrections_for` hands it straight back to the next classification prompt under “LATER CORRECTIONS (authoritative — these OVERRIDE the story text above)”. So the derived era steered the next reclassification with the date's own authority, and a later correction to the arithmetic could never reach it: prose inside an immutable source is not a claim anything can supersede. NOW: ONE DEFINITION — `timeline.placement_assertion` — composes the body, and it states the date decision only: ““…” happened May 2022” at the grain the person gave it (`around 1984`, `sometime in the 1980s`, `spring 2001`, `21 December 2010`), the anchor clause kept because anchors are evidence FOR the date, and the when-hint kept unless a host derived it from the date itself (`timeline_interaction.place_invocation` sets `--when-hint` to the very same `display_date`, so without the era standing between them the duplication was the whole sentence). A period-only pin — no date, no hint — now says so out loud rather than naming the era as the only temporal thing it asserts. THE ERA IS NOT LOST: it was never information this record held. It travels as `period` on the row in `state/timeline_placements.json`, which is where rung 0 reads it (`timeline.save_placement`). `cmd_timeline_place` no longer composes a sentence of its own — composing it there is how the era got in — and `period_label` stays what it always was: display, in the success line. CONTENT-ROLE CORRECTIONS ARE UNTOUCHED: a person saying the text got a fact wrong still files their own words verbatim and still marks the reading stale. TESTS: `tests/test_placement_body_date_only.py`, 16 cases / 5 subtests, every one seen failing first — the one definition read directly, the command's filed body pinned to be that definition's output, the bytes on disk in a real temp vault whose era is named `My 40s`, and the classification-prompt injection proved era-free at the point the model actually reads it. WHAT YOU'LL NOTICE: dating a moment writes down the date you gave and nothing the machine inferred.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -421,6 +421,7 @@
     "tests/test_eras_e1b.py",
     "tests/test_eras_e2.py",
     "tests/test_eras_e3.py",
+    "tests/test_eras_e3b.py",
     "tests/test_eras_e_bo.py",
     "tests/test_exact_file_git.py",
     "tests/test_extraction_claims.py",
@@ -442,6 +443,7 @@
     "tests/test_people_roster.py",
     "tests/test_person_dates.py",
     "tests/test_place_no_stories_arcs.py",
+    "tests/test_placement_body_date_only.py",
     "tests/test_placement_score.py",
     "tests/test_projection_publication.py",
     "tests/test_question_candidate.py",
@@ -504,7 +506,6 @@
     "tests/walkthrough_entity_candidate.py",
     "tests/walkthrough_focus_candidate.py",
     "tests/walkthrough_lib.py",
-    "wiki/SCHEMA.md",
-    "tests/test_eras_e3b.py"
+    "wiki/SCHEMA.md"
   ]
 }

--- a/tests/test_classify_story_current.py
+++ b/tests/test_classify_story_current.py
@@ -489,7 +489,9 @@ class PlacementKeepsItsOwnMomentTests(unittest.TestCase):
         with redirect_stdout(buffer):
             path = si.create_linked_source(
                 "answers/A1.md",
-                "“the move to Mesa” happened during Childhood, 1984",
+                # v251: the shape `timeline.placement_assertion` actually
+                # files — the date decision, never the era it lands in.
+                "“the move to Mesa” happened 1984",
                 source_type="source_correction", title=None,
                 source_medium="fix", correction_kind=kind,
                 correction_role=role)

--- a/tests/test_placement_body_date_only.py
+++ b/tests/test_placement_body_date_only.py
@@ -1,0 +1,306 @@
+"""A placement records the DATE, never the era (v251).
+
+Found by the E7a rehearsal. `timeline-place` files the durable half of a
+placement as a `--role placement` correction (v103, narrowed by v237/O-C2),
+and the body it filed read:
+
+    “Charlee writes … Father's Day letter to Dave” happened during My 40s,
+    May 2022
+
+One sentence carrying both a date and an ERA — the sentence shape of the
+2026-08-25 defect, one era to the right. Two authorities say it must not:
+
+* **v244 / O-C2** (`docs/pr-specs/eras-o-c2-placement-keeps-its-moment.md`):
+  a placement is *"a date DECISION about a moment the person accepts"*, not an
+  assertion about the era it lands in.
+* **The Eras design §5.1**: the period is DERIVED from the date by frame
+  arithmetic. `My 40s` is not something the person said; it is what the
+  arithmetic computed from `May 2022`.
+
+The body is durable TWICE. It is the immutable payload of a vault source
+record, and `classify_story.corrections_for` re-injects it into the next
+classification prompt under the heading *"LATER CORRECTIONS (authoritative —
+these OVERRIDE the story text above)"*. So the era prose does not merely sit
+in the archive: it steers the next reclassification, with the same authority
+as the date, and a later correction to the frame arithmetic cannot reach it —
+prose in an immutable record is not a claim anything can supersede.
+
+The fix is one definition — `timeline.placement_assertion` — and these tests
+are its negative half: the era label appears in `state/timeline_placements.json`
+(where rung 0 reads it) and NOWHERE in the prose.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "system"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import chronology as chrono  # noqa: E402
+import classify_story as cs  # noqa: E402
+import lifehug  # noqa: E402
+import timeline as tl  # noqa: E402
+from tempdirs import root_parent_tmp  # noqa: E402
+
+#: The era the E7a rehearsal actually filed: an AGE FRAME, whose name is pure
+#: arithmetic over the date beside it. `40s` is asserted separately because
+#: "My 40s" surviving as "40s" would be the same defect wearing a shorter coat.
+ERA_SLUG = "my-40s"
+ERA_LABEL = "My 40s"
+ERA_FRAGMENTS = (ERA_LABEL, "40s", "during")
+
+DESCRIPTION = "Charlee writes her Father's Day letter to Dave"
+SOURCE = "answers/A1.md"
+DATE = "2022-05"
+DATE_PROSE = "May 2022"
+
+
+def build_vault(root: Path) -> None:
+    """The minimum vault `timeline-place` needs, with the era named as the
+    rehearsal named it."""
+    root.mkdir(parents=True)
+    (root / "question-bank.md").write_text(
+        "# Questions\n\n## A: Origins\n\n- [ ] A1: Test question?\n",
+        encoding="utf-8")
+    state = root / "state"
+    state.mkdir()
+    (state / "rotation.json").write_text(json.dumps({
+        "version": 1, "current_pass": 1,
+        "pass_names": ["skeleton", "depth", "connections", "polish"],
+        "last_question_id": None, "last_asked_at": None,
+        "questions_asked": 0, "questions_answered": 0,
+        "next_question_id": None, "focus_frequency": 4,
+    }) + "\n", encoding="utf-8")
+    (state / "coverage.json").write_text(json.dumps({
+        "version": 1, "last_updated": None, "categories": {},
+    }) + "\n", encoding="utf-8")
+    answers = root / "answers"
+    answers.mkdir()
+    (answers / "A1.md").write_text(
+        "---\ntitle: A1\nsource_id: answer:A1\ntype: answer\n---\n\n"
+        "Charlee wrote me a letter that Father's Day.\n", encoding="utf-8")
+    classifications = state / "classifications"
+    classifications.mkdir()
+    (classifications / "A1.json").write_text(json.dumps({
+        "source_path": SOURCE,
+        "time_periods": [],
+        "events": [{"description": DESCRIPTION, "title": DESCRIPTION}],
+    }), encoding="utf-8")
+    periods = root / "wiki" / "periods"
+    periods.mkdir(parents=True)
+    (periods / f"{ERA_SLUG}.md").write_text(
+        f"---\ntitle: {ERA_LABEL}\nchrono: 5\n---\n\n# {ERA_LABEL}\n",
+        encoding="utf-8")
+
+
+class PlacementAssertionTests(unittest.TestCase):
+    """`timeline.placement_assertion` — the ONE definition, read directly."""
+
+    def record(self, edtf: str = DATE, **kwargs):
+        record = chrono.parse_edtf(edtf, basis="stated")
+        self.assertIsNotNone(record, edtf)
+        if kwargs:
+            from dataclasses import replace
+
+            record = replace(record, **kwargs)
+        return record
+
+    def test_the_body_states_the_date(self):
+        body = tl.placement_assertion(DESCRIPTION, date=self.record())
+        self.assertIn(DESCRIPTION, body)
+        self.assertIn(DATE_PROSE, body)
+        self.assertIn("happened", body)
+
+    def test_the_body_names_no_era(self):
+        """The defect, stated as a property: the era label cannot be in the
+        prose, because the prose has no argument that could put it there."""
+        body = tl.placement_assertion(DESCRIPTION, date=self.record())
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, body, f"the body still says {fragment!r}")
+
+    def test_the_date_keeps_its_own_granularity(self):
+        """"the date at its granularity" — a hedged date stays hedged, and a
+        day-precise one keeps its day. The body never sharpens or blurs."""
+        for edtf, prose in (("1984", "1984"), ("1984~", "around 1984"),
+                            ("198X", "sometime in the 1980s"),
+                            ("2001-21", "spring 2001"),
+                            ("2010-12-21", "21 December 2010")):
+            with self.subTest(edtf=edtf):
+                body = tl.placement_assertion(DESCRIPTION, date=self.record(edtf))
+                self.assertIn(prose, body)
+
+    def test_anchors_still_say_what_the_date_leans_on(self):
+        """The anchor clause is evidence for the DATE — it survives."""
+        body = tl.placement_assertion(
+            DESCRIPTION, date=self.record(anchors=("the move to Mesa",)))
+        self.assertIn("anchored on the move to Mesa", body)
+
+    def test_a_when_hint_that_is_the_date_is_not_said_twice(self):
+        """`timeline_interaction.place_invocation` derives `--when-hint` FROM
+        the record (`display_date`), so the conversational lane hands the same
+        prose in twice. Without the era in front of it, that duplication is
+        the whole sentence."""
+        body = tl.placement_assertion(DESCRIPTION, date=self.record(),
+                                      when_hint=DATE_PROSE)
+        self.assertEqual(body.count(DATE_PROSE), 1, body)
+
+    def test_a_when_hint_that_adds_something_is_kept(self):
+        body = tl.placement_assertion(DESCRIPTION, date=self.record(),
+                                      when_hint="the summer after we moved")
+        self.assertIn(DATE_PROSE, body)
+        self.assertIn("the summer after we moved", body)
+
+    def test_a_hint_only_placement_states_the_hint(self):
+        body = tl.placement_assertion(DESCRIPTION, when_hint="summer of first grade")
+        self.assertIn("happened summer of first grade", body)
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, body, f"the body still says {fragment!r}")
+
+    def test_a_placement_with_no_date_at_all_asserts_no_date(self):
+        """A period-only pin from the viewer's form states no time. It used to
+        state the era as fact, which was the only temporal thing it said —
+        and it was derived, not said."""
+        body = tl.placement_assertion(DESCRIPTION)
+        self.assertIn(DESCRIPTION, body)
+        self.assertNotIn("happened", body)
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, body, f"the body still says {fragment!r}")
+
+    def test_the_description_is_clamped_for_prose(self):
+        body = tl.placement_assertion("x" * 400, date=self.record())
+        self.assertIn("x" * tl.PLACEMENT_ASSERTION_DESCRIPTION_MAX, body)
+        self.assertNotIn("x" * (tl.PLACEMENT_ASSERTION_DESCRIPTION_MAX + 1), body)
+
+
+class CmdTimelinePlaceBodyTests(unittest.TestCase):
+    """The command files exactly what the one definition returns — no host
+    re-adds the era on the way out."""
+
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-place-body-")
+        self._orig = tl.PLACEMENTS_FILE
+        tl.PLACEMENTS_FILE = self.tmp / "placements.json"
+        self.addCleanup(lambda: setattr(tl, "PLACEMENTS_FILE", self._orig))
+
+    def place(self, *, date=DATE, when_hint=""):
+        calls: list[tuple] = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(
+                args, 0, "✓ Created correction source: sources/corrections/c1.md", "")
+
+        args = type("Args", (), {
+            "source": SOURCE, "period": ERA_SLUG, "when_hint": when_hint,
+            "note": "", "date": date, "basis": "stated", "anchor": [],
+            "placement_key": "",
+        })()
+        with mock.patch.object(lifehug.subprocess, "run", fake_run), \
+                mock.patch.object(tl, "load_periods",
+                                  lambda: [{"slug": ERA_SLUG, "name": ERA_LABEL}]), \
+                mock.patch("sys.stdin", io.StringIO(DESCRIPTION)), \
+                mock.patch("sys.stdout", new_callable=io.StringIO):
+            rc = lifehug.cmd_timeline_place(args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(calls), 1)
+        return calls[0]
+
+    def test_the_filed_body_is_the_one_definitions_output(self):
+        _args, kwargs = self.place()
+        self.assertEqual(
+            kwargs["input"],
+            tl.placement_assertion(DESCRIPTION,
+                                   date=chrono.parse_edtf(DATE, basis="stated")),
+            "the command composed its own body instead of using the one "
+            "definition — that is how the era got back in")
+
+    def test_the_filed_body_names_no_era(self):
+        _args, kwargs = self.place()
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, kwargs["input"],
+                             f"the filed body still says {fragment!r}")
+        self.assertIn(DATE_PROSE, kwargs["input"])
+
+    def test_it_still_files_as_a_placement_role_date_correction(self):
+        args, _kwargs = self.place()
+        self.assertEqual(args[2:4], ["correct", SOURCE])
+        self.assertEqual(args[args.index("--kind") + 1], "date")
+        self.assertEqual(args[args.index("--role") + 1], "placement")
+
+    def test_the_era_stays_on_the_placement_row(self):
+        """Where rung 0 reads it (`timeline.save_placement`'s own contract).
+        Removing the prose must not remove the information."""
+        self.place()
+        row = tl.load_placements()["placements"][0]
+        self.assertEqual(row["period"], ERA_SLUG)
+        self.assertEqual(row["date"]["best"], "2022-05")
+        self.assertEqual(row["correction"], "sources/corrections/c1.md")
+
+    def test_a_dateless_placement_files_a_body_with_no_era(self):
+        _args, kwargs = self.place(date=None)
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, kwargs["input"],
+                             f"the filed body still says {fragment!r}")
+
+
+class FiledBytesTests(unittest.TestCase):
+    """The real CLI, a real temp vault, and the bytes on disk."""
+
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-place-bytes-")
+        self.vault = self.tmp / "vault"
+        build_vault(self.vault)
+
+    def run_place(self, *extra: str) -> subprocess.CompletedProcess:
+        return subprocess.run(  # noqa: S603
+            [sys.executable, str(ROOT / "system" / "lifehug.py"),
+             "--vault-root", str(self.vault), "timeline-place", SOURCE,
+             "--period", ERA_SLUG, "--date", DATE, "--basis", "stated", *extra],
+            input=DESCRIPTION, text=True, capture_output=True, timeout=180)
+
+    def test_the_correction_on_disk_states_the_date_and_no_era(self):
+        result = self.run_place()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        row = json.loads(
+            (self.vault / "state" / "timeline_placements.json").read_text(
+                encoding="utf-8"))["placements"][0]
+        self.assertEqual(row["period"], ERA_SLUG)
+        correction = self.vault / row["correction"]
+        self.assertTrue(correction.exists(), row["correction"])
+        text = correction.read_text(encoding="utf-8")
+        self.assertIn(DATE_PROSE, text)
+        self.assertIn(DESCRIPTION, text)
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, text,
+                             f"the durable record still says {fragment!r}")
+
+    def test_the_classification_prompt_injection_carries_no_era(self):
+        """The second durability: this body comes BACK, as an authoritative
+        correction the next classification is told to obey."""
+        result = self.run_place()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        target = self.vault / "answers" / "A1.md"
+        with mock.patch.object(cs, "SOURCES_DIR", self.vault / "sources"), \
+                mock.patch.object(cs, "REPO_DIR", self.vault):
+            bodies = cs.corrections_for(target)
+            block = cs._corrections_block(target)  # noqa: SLF001
+        self.assertEqual(len(bodies), 1, bodies)
+        self.assertIn(DATE_PROSE, bodies[0])
+        self.assertIn("authoritative", block)
+        for fragment in ERA_FRAGMENTS:
+            self.assertNotIn(fragment, bodies[0],
+                             f"the prompt is still told {fragment!r}")
+            self.assertNotIn(fragment, block,
+                             f"the prompt is still told {fragment!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v103_placement_loop.py
+++ b/tests/test_v103_placement_loop.py
@@ -74,17 +74,28 @@ class PlaceFilesAssertionTests(unittest.TestCase):
         self.assertTrue(str(args[1]).endswith("source_integrity.py"))
         self.assertEqual(args[2:4], ["correct", "answers/Z1.md"])
         right = kwargs["input"]
-        self.assertIn("happened during Childhood", right)
+        # v251: the body is the DATE DECISION and nothing else — the person's
+        # own words for when, never the era the pin lands in. The era is
+        # information the ROW carries (`period`, read by rung 0); asserting it
+        # in an immutable source record made a derived name as authoritative as
+        # a stated date. See `timeline.placement_assertion`.
         self.assertIn("summer of first grade", right)
+        self.assertNotIn("Childhood", right)
+        self.assertNotIn("during", right)
         self.assertEqual(args[args.index("--kind") + 1], "date")
         rec = tl.load_placements()["placements"][0]
         self.assertEqual(rec["correction"], "sources/corrections/c1.md")
 
     def test_place_without_when_hint_still_files(self):
+        """A period-only pin still files its durable half — and now says the
+        honest thing, which is that no date was stated. It used to state the
+        era as fact, and that was the ONLY temporal thing it said."""
         result, calls = self._place(when_hint="")
         self.assertEqual(result, 0)
         right = calls[0][1]["input"]
-        self.assertTrue(right.endswith("happened during Childhood"))
+        self.assertIn("The porch dog summer", right)
+        self.assertIn("I stated no date", right)
+        self.assertNotIn("Childhood", right)
 
     def test_cli_failure_does_not_create_pin(self):
         result, _ = self._place(cli_rc=1, cli_out="boom")

--- a/tests/test_v120_vault_only.py
+++ b/tests/test_v120_vault_only.py
@@ -216,7 +216,7 @@ class VaultContractTests(unittest.TestCase):
         # (stale-first classification) added `state/classify_cursor.json`.
         # The release commit that takes this branch's version slot moves
         # both this number and `vault_contract.json`'s together.
-        self.assertEqual(exported["identity"]["framework_version"], 250)
+        self.assertEqual(exported["identity"]["framework_version"], 251)
         self.assertEqual(
             exported["identity"]["content_digest"],
             vault_paths._contract_digest(exported),


### PR DESCRIPTION
Found by the **E7a rehearsal** (lifehug-platform#692, program lifehug-platform#686). `timeline-place --role placement` filed a durable correction whose body read:

> “Charlee writes … Father's Day letter to Dave” happened **during My 40s**, May 2022

One sentence carrying both a date and an ERA — the sentence shape of the 2026-08-25 defect, one era to the right.

## Why it is a defect, not a wording nit

Two authorities already forbade it:

- **v244 / O-C2** (`docs/pr-specs/eras-o-c2-placement-keeps-its-moment.md`): a placement is *"a date DECISION about a moment the person accepts"*, not an assertion about the era it lands in.
- **Eras design §5.1**: the period is DERIVED from the date by frame arithmetic. `My 40s` is not something anybody said; it is what the arithmetic computed from `May 2022`.

And the body is **durable twice**. It is the immutable payload of a vault source record, *and* `classify_story.corrections_for` hands it straight back to the next classification prompt under the heading *"LATER CORRECTIONS (authoritative — these OVERRIDE the story text above)"*. So the derived era did not merely sit in the archive: it steered the next reclassification with the date's own authority, and a later correction to the frame arithmetic could never reach it — prose inside an immutable source is not a claim anything can supersede.

## The fix — one definition

`timeline.placement_assertion` (new, `system/timeline.py`) composes the body, and it states the **date decision only**:

| input | body |
|---|---|
| `--date 2022-05` | `“…” happened May 2022` |
| `--date 1984 --anchor "the move to Mesa"` | `“…” happened 1984 (anchored on the move to Mesa)` |
| `--when-hint "summer of first grade"`, no date | `“…” happened summer of first grade` |
| period only | `“…” — I placed this moment on my timeline; I stated no date.` |

- The date keeps **its own granularity** (`around 1984`, `sometime in the 1980s`, `spring 2001`, `21 December 2010`) — never sharpened, never blurred.
- The **anchor clause survives**: anchors are evidence *for the date*.
- A `--when-hint` a host derived FROM the date is not said twice. `timeline_interaction.place_invocation` sets `--when-hint` to the very same `chronology.display_date`, so with the era gone from between them the duplication would have been the whole sentence.
- A **period-only pin** says so out loud rather than naming the era as the only temporal thing it asserts.
- `cmd_timeline_place` no longer composes a sentence of its own — composing it there is how the era got in. `period_label` stays what it always was: display, in the success line.

**The era is not lost**, because it was never information this record held: it travels as `period` on the row in `state/timeline_placements.json`, which is where rung 0 reads it (`timeline.save_placement`'s own contract). **Content-role corrections are untouched** — a person saying the text got a fact wrong still files their own words verbatim and still marks the reading stale.

## Tests

`tests/test_placement_body_date_only.py` — **16 cases / 5 subtests, every one seen failing first** (18 failures against the pre-fix tree):

- the one definition read directly: the date is stated, no era fragment (`My 40s`, `40s`, `during`) can appear, granularity preserved, anchors preserved, hint de-duplicated;
- `cmd_timeline_place`'s filed body **pinned to be that definition's output**, so no host can re-compose it — plus the role/kind argv and the era still on the placement row;
- the **bytes on disk**, real CLI against a real temp vault whose era is named `My 40s`;
- the **classification-prompt injection** (`corrections_for` / `_corrections_block`) proved era-free at the point the model actually reads it.

Updated honestly: `tests/test_v103_placement_loop.py` (two assertions pinned the old sentence) and `tests/test_classify_story_current.py` (its O-C2 fixture body). `CLAUDE.md`'s v103 "Placement feeds the Loop" section now documents the shape that is filed.

## Gates

- `tests/test_timeline_place_filing.py tests/test_v103_placement_loop.py tests/test_classify_story_current.py tests/test_eras_e0a.py tests/test_handbook_parity.py tests/test_placement_body_date_only.py` — **106 passed, 97 subtests**
- full suite: **4121 passed, 4 skipped, 2118 subtests** — and it leaves the checkout clean
- `scripts/ci/check_framework_files.py` — 504 entries OK · `scripts/ci/check_version_bump.py --base origin/main --head HEAD` — 250 → 251 OK · repo-wide conflict-marker scan clean

**v251.** `system/vault_contract.json`'s `framework_version` + `content_digest` and `tests/test_v120_vault_only.py`'s pin move with the slot, per the v250 release convention.

🤖 Generated with Claude Opus 5 via Claude Code
