### PR TITLE
fix(placements): a pin survives its moment's reclassification — re-keyed durably, never orphaned (v253)

### DIFF
--- a/docs/handbook/timeline.md
+++ b/docs/handbook/timeline.md
@@ -439,6 +439,26 @@ share one legacy key. Anything that still joins nothing stays in
 `stale_placements` and is counted at `counts["stale_placements"]`, with
 `counts["placements_rejoined"]` naming what the repair rescued on that read.
 
+**A pin survives its moment's reclassification (v253).** A content key is only
+as stable as the content, and rewriting a moment's description is `classify-story`'s
+ordinary weekly job — so every reclassification used to orphan the pin of every
+moment it touched: the person named a date, the date was on disk, and the moment
+rendered undated (lifehug#276). `resolve_placements` therefore has a **third
+rung**: a stored key that joins nothing, whose row's own `source` mints exactly
+one live moment, re-keys to that moment. Zero candidates or several and the rung
+does not run — the row stays orphaned under the named diagnostic
+`placement_orphaned_ambiguous` (`timeline_data()["placement_diagnostics"]`,
+counted at `counts["placements_orphaned_ambiguous"]`), because filing the
+person's date onto the wrong moment is worse than leaving it stranded. Rung 3 is
+also the only rung whose repair is **durable**: `rekey_orphaned_placements`
+rewrites the row's key with `rekeyed_from`/`rekeyed_at` provenance, seated in the
+weekly `timeline-retire` pass that runs right after `classify-story` — the read
+heals immediately, the store heals on that pass, and replaying it is a no-op.
+Rungs 1 and 2 still leave the stored key exactly as v215 pinned it. At the
+filing end, `timeline-place` refuses an explicit `--placement-key` that no live
+moment mints (`placement_key_not_live`) rather than writing a pin that is dead
+on arrival.
+
 Weekly too, `arc-plan` reads `place_no_stories` off the same assembled
 payload and plans a **place aside** onto a card whose gap slot the whisper
 left empty (v200). Nothing is written: a place stops being a gap the moment a

--- a/system/lifehug.py
+++ b/system/lifehug.py
@@ -707,10 +707,29 @@ def cmd_second_voice_ack(args: argparse.Namespace) -> int:
 
 
 def cmd_timeline_retire(args: argparse.Namespace) -> int:
+    """The weekly PIN-MAINTENANCE pass: heal first, then retire.
+
+    v253 (lifehug#276): `rekey_orphaned_placements` runs before the retirement
+    because this step is seated immediately after `classify-story` in
+    `weekly_maintenance.sh` — the very pass that rewrites descriptions and so
+    orphans pins. Healing first means a pin the classifier just orphaned AND
+    caught up with is re-keyed and retired in one pass, instead of surviving as
+    a stale notice for a week. The order is the reason both live here; neither
+    function knows about the other.
+    """
     import timeline  # noqa: PLC0415
+    rekeyed = timeline.rekey_orphaned_placements(dry_run=args.dry_run)
+    if rekeyed:
+        verb = "would re-key" if args.dry_run else "Re-keyed"
+        print(f"✓ {verb} {len(rekeyed)} orphaned pin(s) — their moment was "
+              f"reclassified, not lost:")
+        for pin in rekeyed:
+            print(f"  🔑 {pin.get('description', '?')}: "
+                  f"{pin.get('rekeyed_from', '?')} → {pin.get('key', '?')}")
     retired = timeline.retire_redundant_placements(dry_run=args.dry_run)
     if not retired:
-        print("No caught-up pins to retire.")
+        if not rekeyed:
+            print("No caught-up pins to retire.")
         return 0
     verb = "would retire" if args.dry_run else "Retired"
     print(f"✓ {verb} {len(retired)} pin(s) — the loop caught up, they place themselves:")
@@ -733,6 +752,28 @@ def cmd_timeline_place(args: argparse.Namespace) -> int:
     if not description:
         print("Error: timeline description must be provided on stdin", file=sys.stderr)
         return 1
+    # v253 (lifehug#276): a supplied identity is CHECKED before anything
+    # durable happens. `--placement-key` exists so identity travels whole from
+    # the host that knows the moment (v215); a key no live moment mints is a
+    # pin that is dead on arrival — it renders nowhere and the date the person
+    # named is gone at exit 0, which is lifehug#228's exact failure shape. The
+    # CLI can see that the key is dead, so it refuses instead of filing. The
+    # DERIVED key (no flag) is deliberately not checked here: v213-shaped
+    # records still mint one and `resolve_placements`' repair rungs are what
+    # rejoin them.
+    key = str(getattr(args, "placement_key", "") or "").strip()
+    if key:
+        if not _re.fullmatch(r"[0-9a-f]{12}", key):
+            print(f"Error: --placement-key must be 12 hex characters: {key!r}",
+                  file=sys.stderr)
+            return 1
+        live_keys = {timeline.placement_key(event) for event in timeline.load_events()}
+        if key not in live_keys:
+            print(f"Error: placement_key_not_live: --placement-key {key} matches no "
+                  f"live moment. Nothing joins it, so the pin would render nowhere. "
+                  f"Mint the key from the moment (timeline.placement_key) against a "
+                  f"compiled vault.", file=sys.stderr)
+            return 1
     period_label = next(
         (period["name"] for period in timeline.load_periods() if period["slug"] == args.period),
         args.period.replace("-", " ").title(),
@@ -790,10 +831,6 @@ def cmd_timeline_place(args: argparse.Namespace) -> int:
     # under the key `place_events` joins on. Absent the flag the key is derived
     # from source + description exactly as it always has been — the viewer's
     # placement form posts the event's real description and needs nothing else.
-    key = str(getattr(args, "placement_key", "") or "").strip()
-    if key and not _re.fullmatch(r"[0-9a-f]{12}", key):
-        print(f"Error: --placement-key must be 12 hex characters: {key!r}", file=sys.stderr)
-        return 1
     key = key or timeline.placement_key({"source": args.source, "description": description})
     timeline.save_placement(
         key,

--- a/system/timeline.py
+++ b/system/timeline.py
@@ -625,9 +625,18 @@ _PERIOD_KEYWORDS = {
 # The timeline is a validation surface; when the owner drags an unplaced
 # moment into a period (or corrects a wrong one), that decision persists here
 # and wins over every heuristic. Raw sources stay immutable — a placement is
-# an overlay keyed by CONTENT (sha of source + description), so a
-# reclassification that rewrites the description automatically orphans the
-# placement (surfaced as `stale_placements`, never silently misapplied).
+# an overlay keyed by CONTENT (sha of source + description).
+#
+# v253 (lifehug#276): that content key is not stable, and this comment used to
+# end by calling the consequence correct — "a reclassification that rewrites
+# the description automatically orphans the placement (surfaced as
+# `stale_placements`, never silently misapplied)". Rewriting descriptions is
+# the classifier's ordinary weekly job, so that sentence described a pin
+# quietly dying every time the loop did its work. `resolve_placements` now
+# carries a THIRD rung that re-keys such a pin to the one live moment its
+# source mints, and `rekey_orphaned_placements` persists that repair.
+# "Never silently misapplied" survives intact: several candidates, or none,
+# and the pin stays orphaned under a named diagnostic.
 #
 # v103: the pin is display-only; the INFORMATION lives in the date-kind
 # correction the viewer files alongside it (record's `correction` field).
@@ -751,31 +760,33 @@ def legacy_title_key(event: dict) -> str:
     return "" if legacy == placement_key(event) else legacy
 
 
-def resolve_placements(placements: dict | None,
-                       events: list[dict]) -> list[tuple[dict, str]]:
-    """Every stored placement paired with the live event key it joins, in store
-    order — `""` when it joins nothing.
+#: How a stored placement found its live moment — which rung of the join
+#: fired. `resolve_placements_with_rung` reports it and
+#: `rekey_orphaned_placements` reads it, because exactly one rung's repair is
+#: DURABLE and the other two must never touch the store.
+PLACEMENT_JOIN_EXACT = "exact"
+PLACEMENT_JOIN_LEGACY_TITLE = "legacy_title"
+PLACEMENT_JOIN_SOURCE_REKEY = "source_rekey"
 
-    ONE join, read by `place_events` (which pins the moment), `timeline_data`
-    (which counts what is still orphaned) and `retire_redundant_placements`.
+#: The one named diagnostic for a pin the source rung could not repair —
+#: either its source mints no live moment at all, or it mints SEVERAL and
+#: picking one would file the person's date onto the wrong moment. Named, and
+#: carried on `timeline_data()`, because the alternative is a silent zero.
+PLACEMENT_ORPHANED_AMBIGUOUS = "placement_orphaned_ambiguous"
 
-    Two ways a row resolves:
 
-    1. its stored key IS a live event's `placement_key` — every placement the
-       viewer and the CLI ever filed; and
-    2. its stored key is the pre-v215 `legacy_title_key` of exactly one live
-       event — the deterministic REPAIR, so a date captured in conversation
-       between v213 and v215 joins on the next compile with no migration, no
-       state file and no model call.
+def _resolve_placements(placements: dict | None, events: list[dict],
+                        ) -> tuple[list[tuple[dict, str, str]], list[dict]]:
+    """`([(row, key, rung), ...], [diagnostic, ...])` — the whole join, once.
 
-    The row keeps its stored `key`: a repaired pin renders, retires and
-    unplaces under the identity the store actually holds. Ambiguity never
-    guesses — two live events sharing one legacy key resolve neither, and a
-    second row claiming a key some earlier row already took stays orphaned.
+    Private because there is exactly ONE join and every public reader below is
+    a projection of this: `resolve_placements` drops the rung,
+    `resolve_placements_with_rung` keeps it, `placement_orphan_diagnostics`
+    takes the second half.
     """
     rows = ((placements or {}).get("placements") or [])
     if not rows:
-        return []
+        return [], []
     live: dict[str, dict] = {}
     for event in events:
         live.setdefault(placement_key(event), event)
@@ -785,17 +796,112 @@ def resolve_placements(placements: dict | None,
         if not alias or alias in live:
             continue
         legacy[alias] = None if alias in legacy and legacy[alias] != key else key
-    resolved: list[tuple[dict, str]] = []
+    # Rung 3's candidate set: the live moments each SOURCE mints. Two moments
+    # of one source is not a tie to break, it is a repair that must not run.
+    by_source: dict[str, list[str]] = {}
+    for key, event in live.items():
+        source = str(event.get("source") or "").strip()
+        if source:
+            by_source.setdefault(source, []).append(key)
+    resolved: list[tuple[dict, str, str]] = []
+    diagnostics: list[dict] = []
     taken: set[str] = set()
     for row in rows:
         key = str(row.get("key") or "")
-        target = key if key in live else (legacy.get(key) or "")
+        target, rung = "", ""
+        if key in live:
+            target, rung = key, PLACEMENT_JOIN_EXACT
+        elif legacy.get(key):
+            target, rung = str(legacy[key]), PLACEMENT_JOIN_LEGACY_TITLE
+        else:
+            source = str(row.get("source") or "").strip()
+            candidates = by_source.get(source, []) if source else []
+            if len(candidates) == 1:
+                target, rung = candidates[0], PLACEMENT_JOIN_SOURCE_REKEY
+            else:
+                diagnostics.append({
+                    "diagnostic": PLACEMENT_ORPHANED_AMBIGUOUS,
+                    "key": key, "source": source,
+                    "description": str(row.get("description") or ""),
+                    "candidates": list(candidates),
+                })
         if not target or target in taken:
-            resolved.append((row, ""))
+            resolved.append((row, "", ""))
             continue
         taken.add(target)
-        resolved.append((row, target))
-    return resolved
+        resolved.append((row, target, rung))
+    return resolved, diagnostics
+
+
+def resolve_placements_with_rung(placements: dict | None,
+                                 events: list[dict]) -> list[tuple[dict, str, str]]:
+    """`resolve_placements` plus the rung that joined each row (`""` when the
+    row joined nothing) — the only reader that needs the rung is the durable
+    re-key, which must persist rung 3's repair and NEVER rung 2's."""
+    return _resolve_placements(placements, events)[0]
+
+
+def placement_orphan_diagnostics(placements: dict | None,
+                                 events: list[dict]) -> list[dict]:
+    """One `placement_orphaned_ambiguous` record per pin the source rung
+    refused to repair. Fail LOUD: a pin that cannot be re-keyed says so with a
+    name, a source and the candidate keys it declined to choose between."""
+    return _resolve_placements(placements, events)[1]
+
+
+def resolve_placements(placements: dict | None,
+                       events: list[dict]) -> list[tuple[dict, str]]:
+    """Every stored placement paired with the live event key it joins, in store
+    order — `""` when it joins nothing.
+
+    ONE join, read by `place_events` (which pins the moment), `timeline_data`
+    (which counts what is still orphaned) and `retire_redundant_placements`.
+
+    Three ways a row resolves:
+
+    1. its stored key IS a live event's `placement_key` — every placement the
+       viewer and the CLI ever filed;
+    2. its stored key is the pre-v215 `legacy_title_key` of exactly one live
+       event — the deterministic REPAIR for the one asymmetric recipe that ever
+       shipped, so a date captured in conversation between v213 and v215 joins
+       on the next compile with no migration, no state file and no model call;
+       and
+    3. v253 (lifehug#276): its stored key joins nothing AND the row's own
+       `source` mints EXACTLY ONE live moment — the reclassification repair.
+
+    Rung 3 exists because the identity is content-addressed and the content is
+    not stable. `placement_key` hashes the moment's DESCRIPTION, and rewriting
+    descriptions is the classifier's ordinary weekly job, so every
+    reclassification orphaned the pin of every moment it touched: the person
+    named a date, the date is on disk, and the moment renders undated. The
+    comment this module has carried since v102 called that orphaning correct
+    ("never silently misapplied") — right instinct, wrong conclusion. The pin
+    carries its own `source`, and a source that mints exactly one live moment
+    is not a guess.
+
+    It IS a guess the moment the source mints two, so it does not run: rung 3
+    refuses zero candidates and refuses several, emitting
+    `PLACEMENT_ORPHANED_AMBIGUOUS` instead — filing the person's date onto the
+    wrong moment is worse than leaving it stranded, which is the rule rung 2
+    has always followed. The one trade-off it does accept, stated plainly: if a
+    source's only surviving moment is not the moment the pin was about (its own
+    moment was deleted, not rewritten), the pin lands on the survivor. That is
+    the price of a content-addressed identity, and the end of it is an opaque
+    minted placement id, not a cleverer heuristic.
+
+    Rungs 1 and 2 keep the row's stored `key` — a repaired pin renders, retires
+    and unplaces under the identity the store actually holds. Rung 3 does not:
+    its repair is persisted by `rekey_orphaned_placements` on the pin-
+    maintenance pass, with `rekeyed_from` provenance, because a repair that
+    lives only in memory proves the substrate is right and says nothing about
+    the file the product reads. The read heals immediately; the store heals on
+    the next pass.
+
+    Ambiguity never guesses at any rung — two live events sharing one legacy
+    key resolve neither, and a second row claiming a key some earlier row
+    already took stays orphaned.
+    """
+    return [(row, key) for row, key, _ in _resolve_placements(placements, events)[0]]
 
 
 def load_placements() -> dict:
@@ -1314,6 +1420,49 @@ def sort_period_events(rows: list[dict]) -> list[dict]:
                              chrono.year_of(e.get("date")) or 0,
                              not e["when_hint"], e["source_short"]))
     return rows
+
+
+def rekey_orphaned_placements(dry_run: bool = False) -> list[dict]:
+    """THE DURABLE HALF of rung 3 (v253, lifehug#276) — the store heals.
+
+    `resolve_placements` re-keys an orphaned pin IN MEMORY, so the moment the
+    classifier rewrites a description the page still renders the person's
+    date. That is the read. This is the WRITE, and it has to exist separately:
+    a repair that only recomputes proves the substrate is right and says
+    nothing about the file the product reads (the `simulate_repair.py` lesson,
+    2026-08-26). Until the store holds the live key, `remove_placement` and
+    every host that posts a key back still name an identity nothing joins.
+
+    Only rung 3 persists. Rung 2's legacy repair deliberately leaves the stored
+    key alone — that identity is what the viewer's own remove button posts, and
+    v215 pinned that behavior by test.
+
+    Each rewritten row keeps its provenance: `rekeyed_from` is the key the
+    person's pin was filed under, `rekeyed_at` is when the repair ran. Nothing
+    is deleted, and a row is never rewritten twice to the same key (the second
+    pass joins at rung 1 and this returns `[]` — the pass is idempotent, which
+    is the property a runbook step has to have).
+
+    Returns the rewritten records. `dry_run` computes them and writes nothing.
+    """
+    data = load_placements()
+    if not data["placements"]:
+        return []
+    events = load_events()
+    joined = {id(row): (key, rung)
+              for row, key, rung in resolve_placements_with_rung(data, events)}
+    rekeyed: list[dict] = []
+    for row in data["placements"]:
+        key, rung = joined.get(id(row), ("", ""))
+        if rung != PLACEMENT_JOIN_SOURCE_REKEY or not key or key == row.get("key"):
+            continue
+        row["rekeyed_from"] = str(row.get("key") or "")
+        row["key"] = key
+        row["rekeyed_at"] = now_utc()
+        rekeyed.append(dict(row))
+    if rekeyed and not dry_run:
+        write_json(PLACEMENTS_FILE, data)
+    return rekeyed
 
 
 def retire_redundant_placements(dry_run: bool = False) -> list[dict]:
@@ -3435,6 +3584,11 @@ def timeline_data(evidence: list[dict] | None = None,
                         if not key or row.get("period") not in period_slugs]
     rejoined_placements = sum(1 for row, key in resolved_placements
                               if key and key != str(row.get("key") or ""))
+    # v253: the pins rung 3 REFUSED to re-key, each naming its source and the
+    # candidates it declined to choose between. `rejoined_placements` above
+    # already counts rung 3's successes — an in-memory repair the read applies
+    # immediately and `rekey_orphaned_placements` persists on the next pass.
+    orphan_diagnostics = placement_orphan_diagnostics(placements, events)
 
     chapters = align_chapters(load_chapters(), periods)
     chapters_by_period: dict[str, list[dict]] = {}
@@ -3483,6 +3637,7 @@ def timeline_data(evidence: list[dict] | None = None,
         "unplaced_entities": unplaced_entities,
         "unplaced_events": unplaced_events,
         "stale_placements": stale_placements,
+        "placement_diagnostics": orphan_diagnostics,
         "gaps_by_period": gaps_by_period,
         "global_gaps": global_gaps,
         "corroboration": corroboration,
@@ -3509,6 +3664,7 @@ def timeline_data(evidence: list[dict] | None = None,
             # silent again.
             "stale_placements": len(stale_placements),
             "placements_rejoined": rejoined_placements,
+            "placements_orphaned_ambiguous": len(orphan_diagnostics),
             # eras O-E2 (Transitional dependencies): `O-C`'s withheld-stale
             # count, read through one shim — see `_stale_classifications_withheld`.
             "stale_classifications_withheld": _stale_classifications_withheld(),

--- a/system/version.json
+++ b/system/version.json
@@ -1,7 +1,7 @@
 {
-  "version": 252,
+  "version": 253,
   "released": "2026-08-28",
-  "changelog": "v252: model tiering \u2014 the lowest model that gets it right (owner-set 2026-08-28). Zero executable diff: AGENTS.md gains the operating rule for which model builds what.",
+  "changelog": "v253: a pin survives its moment's reclassification — re-keyed durably, never orphaned (lifehug#276, found as E7a/D16 on lifehug-platform#686). WHY: a timeline pin's identity is CONTENT — `placement_key(event) = sha1(f\"{source}\\n{description}\")[:12]` — and the description is not stable, because rewriting descriptions is exactly what `classify-story` does every week. So every reclassification minted a new key for the same moment and orphaned the pin the person had filed: `resolve_placements` returned `''`, rung 0 of `place_events` never fired, the moment rendered UNPLACED, and the pin sat forever in `state/timeline_placements.json` as a stale notice nobody could act on. Measured on the pre-fix tree: stored pin `36f7b6be7c84`, live event `794f77dcaa7a`, `unplaced_events` holding the moment the person had dated. The v102 comment called that orphaning correct — \"never silently misapplied\" — which was the right instinct and the wrong conclusion. NOW: `resolve_placements` has a THIRD rung. A stored key that joins no live event, whose row's own `source` mints EXACTLY ONE live moment, re-keys to that moment. Zero candidates or several and it does not run: the row stays orphaned under the named diagnostic `placement_orphaned_ambiguous`, carried on `timeline_data()[\"placement_diagnostics\"]` and counted at `counts[\"placements_orphaned_ambiguous\"]`, because filing the person's date onto the wrong moment is worse than leaving it stranded — the rule rung 2 has always followed. DURABLE, NOT RECOMPUTED: rung 3 is the only rung that rewrites the store. `rekey_orphaned_placements` persists the new key with `rekeyed_from`/`rekeyed_at` provenance and is idempotent on replay, seated in `timeline-retire` — the weekly step that runs immediately after `classify-story`, so a pin the classifier just orphaned is healed and, if the loop caught up with it, retired in the same pass. A repair that only recomputes proves the substrate is right and says nothing about the file the product reads. Rung 2's v215 contract is untouched: a legacy title-keyed pin still renders, retires and unplaces under the identity the store actually holds. AT THE OTHER END: `timeline-place` now REFUSES an explicit `--placement-key` that no live moment mints (`placement_key_not_live`), before it files anything durable — pre-fix that call exited 0 with \"✓ Placed … durable assertion filed\" and wrote a pin that rendered nowhere, which is lifehug#228's exact failure shape. The DERIVED key is deliberately still unchecked, because v213-shaped filings are what rung 2 exists to rejoin. TESTS: `tests/test_placement_rekey.py`, 17 cases; 12 of them were run against v252 and seen failing, and the 5 that pass there are the deliberately-invariant guards. WHAT YOU'LL NOTICE: the week after the classifier rewrites a moment's prose, the date you gave it is still on it.",
   "framework_files": [
     ".gitignore",
     "AGENTS.md",
@@ -444,6 +444,7 @@
     "tests/test_person_dates.py",
     "tests/test_place_no_stories_arcs.py",
     "tests/test_placement_body_date_only.py",
+    "tests/test_placement_rekey.py",
     "tests/test_placement_score.py",
     "tests/test_projection_publication.py",
     "tests/test_question_candidate.py",

--- a/tests/test_placement_rekey.py
+++ b/tests/test_placement_rekey.py
@@ -1,0 +1,429 @@
+"""A pin must survive its moment's reclassification (lifehug#276, v253).
+
+A placement's identity is content: ``placement_key(event) =
+sha1(f"{source}\\n{description}")[:12]``. The description is not stable —
+rewriting descriptions is what ``classify-story`` does every week — so every
+reclassification minted a NEW key for the SAME moment and orphaned the pin the
+person filed. ``resolve_placements`` had two rungs and neither of them helps:
+rung 1 is the exact key, rung 2 (v215, lifehug#229) repairs one frozen
+pre-v215 title-vs-description asymmetry. So the row resolved to ``''``, rung 0
+of ``place_events`` never fired, the moment rendered UNPLACED, and the pin sat
+forever in ``state/timeline_placements.json`` as a stale notice nobody could
+act on. The person named a date, the date was on disk, the moment showed as
+undated.
+
+E7a (D16 on lifehug/lifehug-platform#686) measured it on one real moment whose
+description a later pass rewrote and nothing else changed: the stored pin held
+``b8c4b56293ed`` while the live event minted ``86ba74d3770f``. This suite
+rebuilds that shape from scratch rather than pinning those two literals — the
+defect is the key MOVING, not the particular bytes it moved between.
+
+The fix is a third rung, and a durable one. This file was run in full against
+``origin/main`` (v252) before the fix landed: 12 of its 17 cases failed there,
+and the 5 that passed are the deliberately-invariant guards (the fixture's own
+key really moves; a row with no source is a candidate for nothing; a live key
+and a derived key still file; a malformed key is still refused). The two that
+matter, measured on the pre-fix tree with the pre-fix API:
+
+* the reclassification itself — stored pin ``36f7b6be7c84``, live event
+  ``794f77dcaa7a``, ``resolve_placements`` → ``['']``,
+  ``event_lineup[childhood]`` empty and the moment in ``unplaced_events``,
+  ``counts["stale_placements"] == 1``. The same shape E7a measured.
+* the filing refusal — ``timeline-place --placement-key <dead key>`` exited
+  **0** with ``✓ Placed 36f7b6be7c84 in Childhood; durable assertion filed``:
+  a pin dead on arrival, announced as a success.
+
+``test_two_moments_of_one_source_are_never_guessed_between`` is a negative that
+would pass on a tree with no repair at all, so it proves nothing alone —
+``test_removing_the_ambiguity_re_proves_the_repair`` drops the second moment
+and watches the SAME row re-key, which is how you know the guard refused
+rather than the rung being absent.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "system"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import timeline as tl  # noqa: E402
+from tempdirs import root_parent_tmp  # noqa: E402
+
+SOURCE = "answers/A1.md"
+PERIOD = "childhood"
+#: What the classifier said first, and what it says after the rewrite. Same
+#: moment, same source, same answer file — only the prose moved.
+FIRST = "the move to Mesa"
+RECLASSIFIED = "the family's move to Mesa in the winter"
+DATE = {"best": "1984", "earliest": "1984", "latest": "1984",
+        "granularity": "year", "confidence": "certain", "basis": "stated",
+        "anchors": []}
+
+
+def timeline_roots(root: Path) -> dict[str, Path]:
+    """Every vault root `timeline.py` reads, pointed at a fixture `root`."""
+    state = root / "state"
+    return {
+        "CLASSIFICATIONS_DIR": state / "classifications",
+        "CONNECTORS_STATE_DIR": state / "connectors",
+        "ENTITY_ROSTERS_DIR": state / "entity_rosters",
+        "MANUAL_SOURCES_DIR": root / "sources" / "manual",
+        "PLACEMENTS_FILE": state / "timeline_placements.json",
+        "STATE_DIR": state,
+        "WIKI_DIR": root / "wiki",
+    }
+
+
+def build_vault(root: Path) -> None:
+    """The minimum vault shape: one answer, one classified moment, one period.
+
+    The moment's title IS its description on purpose, so `legacy_title_key` is
+    `""` and rung 2 cannot quietly do rung 3's work — every join in this file
+    is the rung it claims to be.
+    """
+    root.mkdir(parents=True)
+    (root / "question-bank.md").write_text(
+        "# Questions\n\n## A: Origins\n\n- [ ] A1: Test question?\n",
+        encoding="utf-8")
+    state = root / "state"
+    state.mkdir()
+    (state / "rotation.json").write_text(json.dumps({
+        "version": 1, "current_pass": 1,
+        "pass_names": ["skeleton", "depth", "connections", "polish"],
+        "last_question_id": None, "last_asked_at": None,
+        "questions_asked": 0, "questions_answered": 0,
+        "next_question_id": None, "focus_frequency": 4,
+    }) + "\n", encoding="utf-8")
+    (state / "coverage.json").write_text(json.dumps({
+        "version": 1, "last_updated": None, "categories": {},
+    }) + "\n", encoding="utf-8")
+    answers = root / "answers"
+    answers.mkdir()
+    (answers / "A1.md").write_text(
+        "---\ntitle: A1\nsource_id: answer:A1\ntype: answer\n---\n\n"
+        "We moved to Mesa when I was five.\n", encoding="utf-8")
+    classifications = state / "classifications"
+    classifications.mkdir()
+    (classifications / "A1.json").write_text(json.dumps({
+        "source_path": SOURCE,
+        "time_periods": [],
+        "events": [{"description": FIRST, "title": FIRST}],
+    }), encoding="utf-8")
+    periods = root / "wiki" / "periods"
+    periods.mkdir(parents=True)
+    (periods / f"{PERIOD}.md").write_text(
+        "---\ntitle: Childhood\nchrono: 1\n---\n\n# Childhood\n",
+        encoding="utf-8")
+
+
+class VaultCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = root_parent_tmp(self, ROOT, prefix="lifehug-rekey-")
+        self.vault = self.tmp / "vault"
+        build_vault(self.vault)
+        self.store = self.vault / "state" / "timeline_placements.json"
+
+    # -- the fixture's own moving parts, stated ---------------------------
+
+    def classify(self, events: list[dict]) -> None:
+        """Rewrite what the classifier says about this source."""
+        path = self.vault / "state" / "classifications" / "A1.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["events"] = events
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def reclassify(self) -> None:
+        self.classify([{"description": RECLASSIFIED, "title": RECLASSIFIED}])
+
+    def live_keys(self) -> list[str]:
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            return [tl.placement_key(event) for event in tl.load_events()]
+
+    def pin_the_moment(self) -> str:
+        """File the pin the person made, under the key the moment mints TODAY.
+        Returns that key — the one reclassification is about to orphan."""
+        keys = self.live_keys()
+        self.assertEqual(len(keys), 1, keys)
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            tl.save_placement(keys[0], SOURCE, FIRST, PERIOD, date=dict(DATE))
+        return keys[0]
+
+    def rows(self) -> list[dict]:
+        """The store as the PRODUCT reads it — off disk, never recomputed."""
+        self.assertTrue(self.store.exists(), "no placement store on disk")
+        return json.loads(self.store.read_text(encoding="utf-8"))["placements"]
+
+    def timeline_data(self) -> dict:
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            return tl.timeline_data()
+
+    def resolve(self) -> list[tuple[dict, str, str]]:
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            return tl.resolve_placements_with_rung(tl.load_placements(),
+                                                   tl.load_events())
+
+    def rekey(self, **kwargs) -> list[dict]:
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            return tl.rekey_orphaned_placements(**kwargs)
+
+    def diagnostics(self) -> list[dict]:
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            return tl.placement_orphan_diagnostics(tl.load_placements(),
+                                                   tl.load_events())
+
+
+class ReclassificationRekeyTests(VaultCase):
+    """The defect, and the third rung that repairs it."""
+
+    def test_the_fixture_really_moves_the_key(self):
+        """Guard on the guard: if reclassification did not change the key,
+        every test below would pass for the wrong reason."""
+        before = self.pin_the_moment()
+        self.reclassify()
+        after = self.live_keys()
+        self.assertEqual(len(after), 1)
+        self.assertNotEqual(before, after[0],
+                            "the fixture must actually orphan the pin")
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            events = tl.load_events()
+        self.assertEqual(tl.legacy_title_key(events[0]), "",
+                         "rung 2 must have nothing to say here")
+
+    def test_the_pin_survives_a_reclassified_description(self):
+        """The read heals immediately: rung 3 joins the orphan to the one live
+        moment its source mints, and the moment places, dated, where the
+        person put it. Pre-fix this row resolved to `''` and the moment
+        rendered in `unplaced_events`."""
+        old = self.pin_the_moment()
+        self.reclassify()
+        new = self.live_keys()[0]
+        joined = self.resolve()
+        self.assertEqual([(key, rung) for _, key, rung in joined],
+                         [(new, tl.PLACEMENT_JOIN_SOURCE_REKEY)])
+        data = self.timeline_data()
+        moments = data["event_lineup"][PERIOD]
+        self.assertEqual([m["description"] for m in moments], [RECLASSIFIED])
+        self.assertEqual(moments[0]["placement"], "manual")
+        self.assertEqual(moments[0]["date"].best, "1984")
+        self.assertEqual(data["unplaced_events"], [])
+        self.assertEqual(data["stale_placements"], [])
+        self.assertEqual(data["counts"]["stale_placements"], 0)
+        self.assertEqual(data["counts"]["placements_rejoined"], 1)
+        self.assertEqual(data["counts"]["placements_orphaned_ambiguous"], 0)
+        # The READ does not write. The store still holds the dead key until
+        # the durable pass runs — stated, so the next test means something.
+        self.assertEqual([row["key"] for row in self.rows()], [old])
+
+    def test_the_repair_is_persisted_with_its_provenance(self):
+        """A repair that only recomputes proves the substrate is right and
+        says nothing about the file the product reads. So: read the file."""
+        old = self.pin_the_moment()
+        self.reclassify()
+        new = self.live_keys()[0]
+        rekeyed = self.rekey()
+        self.assertEqual([r["key"] for r in rekeyed], [new])
+        row = self.rows()[0]
+        self.assertEqual(row["key"], new)
+        self.assertEqual(row["rekeyed_from"], old)
+        self.assertTrue(row["rekeyed_at"], "the repair must say when it ran")
+        self.assertEqual(row["description"], FIRST,
+                         "what the person pinned is provenance, not identity")
+
+    def test_the_rekeyed_pin_is_removable_under_its_new_identity(self):
+        """The whole point of persisting: every host that posts a key back —
+        the viewer's remove button included — names an identity that joins."""
+        self.pin_the_moment()
+        self.reclassify()
+        new = self.live_keys()[0]
+        self.rekey()
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            self.assertTrue(tl.remove_placement(new))
+        data = self.timeline_data()
+        self.assertEqual(data["event_lineup"][PERIOD], [])
+        self.assertEqual([e["description"] for e in data["unplaced_events"]],
+                         [RECLASSIFIED])
+
+    def test_the_durable_pass_is_idempotent(self):
+        """Replay it and it is a no-op, byte for byte. A runbook step that
+        cannot be replayed is a step nobody can safely re-run."""
+        self.pin_the_moment()
+        self.reclassify()
+        self.assertEqual(len(self.rekey()), 1)
+        after_first = self.store.read_bytes()
+        self.assertEqual(self.rekey(), [])
+        self.assertEqual(self.store.read_bytes(), after_first)
+
+    def test_a_dry_run_writes_nothing(self):
+        self.pin_the_moment()
+        self.reclassify()
+        before = self.store.read_bytes()
+        self.assertEqual(len(self.rekey(dry_run=True)), 1)
+        self.assertEqual(self.store.read_bytes(), before)
+
+    def test_rung_2_still_keeps_its_stored_key(self):
+        """v215's contract is untouched: only rung 3 persists. A legacy
+        title-keyed orphan renders under the identity the store holds."""
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            self.classify([{"description": FIRST, "title": "Moving to Mesa"}])
+            events = tl.load_events()
+            legacy = tl.legacy_title_key(events[0])
+            self.assertTrue(legacy)
+            tl.save_placement(legacy, SOURCE, "Moving to Mesa", PERIOD)
+        joined = self.resolve()
+        self.assertEqual([rung for _, _, rung in joined],
+                         [tl.PLACEMENT_JOIN_LEGACY_TITLE])
+        self.assertEqual(self.rekey(), [])
+        self.assertEqual([row["key"] for row in self.rows()], [legacy])
+
+
+class NeverGuessTests(VaultCase):
+    """Zero candidates or several: orphaned, named, and never guessed."""
+
+    def test_two_moments_of_one_source_are_never_guessed_between(self):
+        """Filing the person's date onto the wrong moment is worse than
+        leaving it stranded — rung 2's rule, and rung 3 keeps it."""
+        old = self.pin_the_moment()
+        self.classify([{"description": RECLASSIFIED, "title": RECLASSIFIED},
+                       {"description": "a different moment entirely",
+                        "title": "a different moment entirely"}])
+        self.assertEqual([(key, rung) for _, key, rung in self.resolve()],
+                         [("", "")])
+        diagnostics = self.diagnostics()
+        self.assertEqual(len(diagnostics), 1, diagnostics)
+        self.assertEqual(diagnostics[0]["diagnostic"],
+                         tl.PLACEMENT_ORPHANED_AMBIGUOUS)
+        self.assertEqual(diagnostics[0]["key"], old)
+        self.assertEqual(diagnostics[0]["source"], SOURCE)
+        self.assertEqual(sorted(diagnostics[0]["candidates"]),
+                         sorted(self.live_keys()))
+        data = self.timeline_data()
+        self.assertEqual([row["key"] for row in data["stale_placements"]], [old])
+        self.assertEqual(data["counts"]["stale_placements"], 1)
+        self.assertEqual(data["counts"]["placements_rejoined"], 0)
+        self.assertEqual(data["counts"]["placements_orphaned_ambiguous"], 1)
+        # And nothing durable happened: an ambiguous pin is left exactly as
+        # the person filed it.
+        self.assertEqual(self.rekey(), [])
+        self.assertEqual([row["key"] for row in self.rows()], [old])
+
+    def test_removing_the_ambiguity_re_proves_the_repair(self):
+        """The negative above passes on a tree with no repair at all, so it
+        would prove nothing on its own. Drop the second moment and the SAME
+        row re-keys — the guard is what refused, not the absence of a rung."""
+        old = self.pin_the_moment()
+        self.classify([{"description": RECLASSIFIED, "title": RECLASSIFIED},
+                       {"description": "a different moment entirely",
+                        "title": "a different moment entirely"}])
+        self.assertEqual(self.rekey(), [])
+        self.reclassify()
+        self.assertEqual([r["rekeyed_from"] for r in self.rekey()], [old])
+
+    def test_a_source_that_mints_no_live_moment_stays_orphaned(self):
+        """The v215 shape, unchanged: a pin whose source is gone entirely has
+        no candidate to re-key to, and says so by name."""
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            tl.save_placement("deadbeef0000", "answers/GONE.md",
+                              "a moment no classification mentions", PERIOD)
+        self.assertEqual([key for _, key, _ in self.resolve()], [""])
+        diagnostics = self.diagnostics()
+        self.assertEqual([d["diagnostic"] for d in diagnostics],
+                         [tl.PLACEMENT_ORPHANED_AMBIGUOUS])
+        self.assertEqual(diagnostics[0]["candidates"], [])
+        self.assertEqual(self.rekey(), [])
+        data = self.timeline_data()
+        self.assertEqual(data["counts"]["stale_placements"], 1)
+        self.assertEqual(data["counts"]["placements_rejoined"], 0)
+
+    def test_a_row_with_no_source_is_not_a_candidate_for_anything(self):
+        """Rung 3 joins on the row's OWN source. A row that carries none —
+        a hand-written store, a host that posted only a key — must not fall
+        into some other source's single live moment."""
+        with tl.vault_roots(**timeline_roots(self.vault)):
+            events = tl.load_events()
+            self.assertEqual(
+                [key for _, key in tl.resolve_placements(
+                    {"placements": [{"key": "ffffffffffff", "period": PERIOD}]},
+                    events)],
+                [""])
+
+
+class PlacementKeyLivenessTests(VaultCase):
+    """`timeline-place` refuses an identity nothing can join. Fail LOUD."""
+
+    def place(self, *extra: str, stdin: str = FIRST) -> subprocess.CompletedProcess:
+        return subprocess.run(  # noqa: S603
+            [sys.executable, str(ROOT / "system" / "lifehug.py"),
+             "--vault-root", str(self.vault), "timeline-place", SOURCE,
+             "--period", PERIOD, *extra],
+            input=stdin, text=True, capture_output=True, timeout=180)
+
+    def test_a_live_placement_key_still_files(self):
+        key = self.live_keys()[0]
+        result = self.place("--placement-key", key)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([row["key"] for row in self.rows()], [key])
+
+    def test_a_dead_placement_key_is_refused_at_filing(self):
+        """The key of a moment that no longer mints it — exactly what a host
+        holding a stale timeline row would post. Pre-fix: exit 0, a correction
+        filed, and a pin written that renders nowhere (lifehug#228's shape)."""
+        stale = self.live_keys()[0]
+        self.reclassify()
+        result = self.place("--placement-key", stale)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("placement_key_not_live", result.stderr)
+        self.assertIn(stale, result.stderr)
+        self.assertFalse(self.store.exists(), "a refused filing wrote a pin")
+
+    def test_the_refusal_happens_before_anything_durable(self):
+        """No correction source, no pin: a refused call leaves the vault the
+        way it found it."""
+        stale = self.live_keys()[0]
+        self.reclassify()
+        answer = (self.vault / "answers" / "A1.md").read_bytes()
+        self.assertEqual(self.place("--placement-key", stale).returncode, 1)
+        self.assertFalse(self.store.exists(), "a refused filing wrote a pin")
+        self.assertEqual(sorted(p.name for p in (self.vault / "sources").rglob("*")
+                                if p.is_file()), [],
+                         "a refused filing filed a durable correction source")
+        self.assertEqual((self.vault / "answers" / "A1.md").read_bytes(), answer)
+
+    def test_a_malformed_key_is_still_refused_loudly(self):
+        result = self.place("--placement-key", "not-a-key")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("--placement-key must be 12 hex", result.stderr)
+        self.assertFalse(self.store.exists())
+
+    def test_a_derived_key_is_deliberately_not_checked(self):
+        """v213-shaped filings (no flag) still mint from source+description
+        and still file — the repair rungs are what rejoin them. Narrowing the
+        refusal to the explicit flag is the deliberate scope."""
+        result = self.place(stdin="Moving to Mesa")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(self.rows()), 1)
+
+
+class WeeklyPinMaintenanceTests(VaultCase):
+    """`timeline-retire` is the seat: it runs right after `classify-story`."""
+
+    def test_the_weekly_pass_heals_the_store(self):
+        old = self.pin_the_moment()
+        self.reclassify()
+        new = self.live_keys()[0]
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, str(ROOT / "system" / "lifehug.py"),
+             "--vault-root", str(self.vault), "timeline-retire"],
+            text=True, capture_output=True, timeout=180)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"{old} → {new}", result.stdout)
+        self.assertEqual([row["key"] for row in self.rows()], [new])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v105_pin_retire.py
+++ b/tests/test_v105_pin_retire.py
@@ -3,9 +3,18 @@
 Once the re-derived classification places a pinned moment in its period by
 itself, the weekly `timeline-retire` step removes the pin (moving it to the
 placements file's `retired` list, correction link intact). The filed date
-assertion is the durable information; nothing is lost. Orphaned pins (event
-rewritten, period gone) never auto-retire — they stay surfaced as stale
-notices for the owner.
+assertion is the durable information; nothing is lost. Orphaned pins never
+auto-retire — they stay surfaced as stale notices for the owner.
+
+v253 (lifehug#276) narrowed what "orphaned" means, and this file records the
+change. Until v253 a pin whose moment had merely been RECLASSIFIED counted as
+orphaned forever, because the identity is content-addressed and the classifier
+rewrites descriptions every week. `resolve_placements`' third rung re-keys such
+a pin to the one live moment its source mints, so the pin is now judged like
+any other: it retires when the loop has caught up with it and stays when the
+owner is still overriding the heuristic. Genuinely orphaned pins — the source
+mints no live moment, or it mints several and the repair refuses to guess, or
+the period page is gone — still never retire.
 """
 
 import sys
@@ -75,11 +84,49 @@ class RetireRedundantPlacementsTests(unittest.TestCase):
         self.assertEqual(self._retire([e]), [])
         self.assertEqual(len(tl.load_placements()["placements"]), 1)
 
-    def test_orphaned_pin_never_retires(self):
+    def test_a_reclassified_moment_is_re_keyed_and_then_judged_normally(self):
+        """v253: a rewritten description is not an orphan. The pin re-keys to
+        the one live moment its source mints, and then the ordinary rule
+        applies — here the heuristic agrees with the pin, so the loop has
+        caught up and the pin retires with its correction intact. Before v253
+        this pin survived every weekly pass forever, pinning nothing."""
+        e = event("The old description", when_hint="in college")
+        key = self._pin(e, "college")
+        rewritten = event("A rewritten description", when_hint="in college")
+        self.assertNotEqual(tl.placement_key(rewritten), key,
+                            "the fixture must actually move the key")
+        retired = self._retire([rewritten])
+        self.assertEqual([r["description"] for r in retired],
+                         ["The old description"])
+        self.assertEqual(retired[0]["correction"], "sources/corrections/c1.md")
+        self.assertEqual(tl.load_placements()["placements"], [])
+
+    def test_a_reclassified_pin_the_owner_still_overrides_stays(self):
+        """Re-keying is not retirement. A pin whose period still disagrees with
+        the heuristic keeps doing its job under its moment's new identity."""
+        e = event("The old description", when_hint="in college")
+        self._pin(e, "childhood")
+        rewritten = event("A rewritten description", when_hint="in college")
+        self.assertEqual(self._retire([rewritten]), [])
+        self.assertEqual(len(tl.load_placements()["placements"]), 1)
+
+    def test_an_ambiguous_orphan_never_retires(self):
+        """Two live moments of one source: the repair refuses to guess, so the
+        pin is still orphaned and still never auto-retires."""
         e = event("The old description", when_hint="in college")
         self._pin(e, "college")
         rewritten = event("A rewritten description", when_hint="in college")
-        self.assertEqual(self._retire([rewritten]), [])
+        other = event("Something else entirely", when_hint="in college")
+        self.assertEqual(self._retire([rewritten, other]), [])
+        self.assertEqual(len(tl.load_placements()["placements"]), 1)
+
+    def test_a_pin_whose_source_is_gone_never_retires(self):
+        """Nothing to re-key to at all — the v105 shape, unchanged."""
+        e = event("The old description", when_hint="in college")
+        self._pin(e, "college")
+        survivor = event("A moment from another answer", source="answers/Q9.md",
+                         when_hint="in college")
+        self.assertEqual(self._retire([survivor]), [])
         self.assertEqual(len(tl.load_placements()["placements"]), 1)
 
     def test_pin_on_vanished_period_never_retires(self):


### PR DESCRIPTION
Closes lifehug/lifehug#276. Found by E7a (D16 on lifehug/lifehug-platform#686).

## The defect

A timeline pin's identity is **content**:

```python
placement_key(event) = sha1(f"{source}\n{description}")[:12]
```

The description is not stable. Rewriting descriptions is exactly what `classify-story` does every week, so every reclassification minted a new key for the same moment and orphaned the pin the person had filed: `resolve_placements` returned `''`, rung 0 of `place_events` never fired, the moment rendered **unplaced**, and the pin sat forever in `state/timeline_placements.json` as a stale notice nobody could act on.

The person named a date. The date was on disk. The moment showed as undated.

`resolve_placements` had two rungs and neither helps — rung 1 is the exact key, rung 2 (v215, lifehug#229) repairs one frozen pre-v215 title-vs-description asymmetry. The module comment had called the orphaning correct since v102 ("never silently misapplied"): right instinct, wrong conclusion. The pin carries its own `source`, and a source that mints exactly one live moment is not a guess.

## Measured, not asserted

Run against `origin/main` (v252) before the fix, one moment whose description a later pass rewrote and nothing else changed:

```
PRE-FIX (origin/main, v252)
  stored pin key      : 36f7b6be7c84
  live event key      : 794f77dcaa7a
  resolve_placements  : ['']
  event_lineup[period]: []
  unplaced_events     : ["the family's move to Mesa in the winter"]
  counts.stale        : 1
  counts.rejoined     : 0
```

The same shape E7a measured on a real vault: `b8c4b56293ed` → `86ba74d3770f`.

And the other end, pre-fix — `timeline-place --placement-key <a key nothing mints>`:

```
exit 0
✓ Placed 36f7b6be7c84 in Childhood; durable assertion filed
```

A pin dead on arrival, announced as a success. That is lifehug#228's exact failure shape.

## The fix

**A third repair rung** in `resolve_placements`. A stored key that joins no live event, whose row's own `source` mints **exactly one** live moment, re-keys to that moment. Zero candidates or several and the rung does not run: the row stays orphaned under the named diagnostic **`placement_orphaned_ambiguous`**, carried on `timeline_data()["placement_diagnostics"]` and counted at `counts["placements_orphaned_ambiguous"]`. Filing the person's date onto the wrong moment is worse than leaving it stranded — the rule rung 2 has always followed.

The one trade-off is stated in the docstring rather than hidden: if a source's only surviving moment is not the moment the pin was about (its own moment was *deleted*, not rewritten), the pin lands on the survivor. That is the price of a content-addressed identity; the end of it is an opaque minted placement id, not a cleverer heuristic, and that is deliberately out of scope here.

**The repair is durable, not recomputed.** `rekey_orphaned_placements` rewrites the row's `key` in the store with `rekeyed_from` / `rekeyed_at` provenance and replays as a no-op. It is seated in `timeline-retire` — the weekly step that runs immediately *after* `classify-story`, i.e. the very pass that orphans pins — so a pin the classifier just orphaned is healed and, if the loop has caught up with it, retired in the same pass. The read heals immediately; the store heals on that pass. *A repair that only recomputes proves the substrate is right and says nothing about the file the product reads.*

Rung 2's v215 contract is untouched: only rung 3 rewrites the store, so a legacy title-keyed pin still renders, retires and unplaces under the identity the store actually holds (pinned by a test).

**Fail loud at filing.** `timeline-place` now refuses an explicit `--placement-key` that no live moment mints (`placement_key_not_live`), before it files the correction source or writes the pin. The **derived** key (no flag) is deliberately still unchecked — v213-shaped filings are precisely what rung 2 exists to rejoin.

## Tests

New `tests/test_placement_rekey.py`, 17 cases. The whole file was run against `origin/main` (v252) first: **12 failed there**, and the 5 that pass are the deliberately-invariant guards (the fixture's key really moves; a row with no source is a candidate for nothing; a live key and a derived key still file; a malformed key is still refused).

`test_two_moments_of_one_source_are_never_guessed_between` is a negative that would pass on a tree with no repair at all, so it proves nothing alone — `test_removing_the_ambiguity_re_proves_the_repair` drops the second moment and watches the **same row** re-key, which is how you know the guard refused rather than the rung being absent.

`tests/test_v105_pin_retire.py::test_orphaned_pin_never_retires` encoded the behavior this PR repeals (a rewritten description = orphaned forever). It is replaced by four cases that say what "orphaned" now means: a reclassified pin is re-keyed and then judged normally (retires when the loop caught up, stays when the owner is still overriding), while an *ambiguous* orphan and a pin whose source is gone entirely still never retire.

The #229 orphan-repair tests are untouched and green.

## Gates

| gate | result |
|---|---|
| `pytest tests/test_timeline*.py tests/test_cross_dating*.py tests/test_v103_placement_loop.py tests/test_placement_rekey.py tests/test_handbook_parity.py -q` | 354 passed, 247 subtests |
| full suite, `pytest tests/ -q` | 4141 passed, 4 skipped, 2118 subtests |
| `python3 -m unittest` (the CI runner's form) on the touched modules | 46 tests, OK |
| `scripts/ci/check_framework_files.py` | all 505 entries exist |
| `scripts/ci/check_version_bump.py --base origin/main --head HEAD` | 252 → 253, OK |
| conflict-marker scan | clean |
| checkout after the suite | clean (lifehug#225 holds) |

**v253** in `system/version.json`; `framework_files` gains `tests/test_placement_rekey.py`. `docs/handbook/timeline.md` gains the third rung.

🤖 Generated with Claude Opus 5 via Claude Code
